### PR TITLE
Add support for Poolex Vertigo FI heatpump

### DIFF
--- a/custom_components/tuya_local/devices/poolex_vertigo_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolex_vertigo_heatpump.yaml
@@ -1,0 +1,45 @@
+name: Poolex Vertigo FI Heatpump
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+          icon: "mdi:hvac-off"
+          icon_priority: 1
+        - dps_val: true
+          value: "heat"
+          icon: "mdi:hot-tub"
+          icon_priority: 3
+    - id: 2
+      name: temperature
+      type: integer
+      range:
+        min: 8
+        max: 40
+    - id: 3
+      name: current_temperature
+      type: integer
+    - id: 4
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: "cool"
+          value: "Cool"
+        - dps_val: "heat"
+          value: "Heat"
+        - dps_val: "silent"
+          value: "Silent"
+    - id: 9
+      type: integer
+      name: error
+      mapping:
+        - dps_val: 0
+          value: "OK"
+        - dps_val: 4
+          value: "Water Flow Protection"
+          icon: "mdi:water-pump-off"
+          icon_priority: 2


### PR DESCRIPTION
Inspired from previous commit for Poolex Silverline FI heatpump.
The preset names and error code of Poolex Vertigo FI are different from those of the Poolex Silverline FI.