### PR TITLE
Add support for Aspen smart fan

### DIFF
--- a/custom_components/tuya_local/devices/aspen_fan.yaml
+++ b/custom_components/tuya_local/devices/aspen_fan.yaml
@@ -1,0 +1,95 @@
+name: Aspen Fan
+primary_entity:
+  entity: fan
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: in
+          value: cool
+        - dps_val: out
+          value: exhaust
+        - dps_val: exch
+          value: exchange
+    - id: 3
+      type: integer
+      name: speed
+      mapping:
+        - dps_val: 1
+          value: low
+        - dps_val: 2
+          value: medium
+        - dps_val: 3
+          value: high
+secondary_entities:
+  - entity: climate
+    name: Bedroom Fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: in
+            value: intake
+          - dps_val: out
+            value: exhaust
+          - dps_val: exch
+            value: exchange
+      - id: 101
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "fan_only"
+            icon: "mdi:fan-off"
+          - dps_val: true
+            value: "cool"
+            icon: "mdi:fan"
+        name: hvac_mode
+      - id: 3
+        type: integer
+        name: fan_mode
+        mapping:
+          - dps_val: 1
+            value: low
+            icon: "mdi:fan-speed-1"
+          - dps_val: 2
+            value: medium
+            icon: "mdi:fan-speed-2"
+          - dps_val: 3
+            value: high
+            icon: "mdi:fan-speed-3"
+      - id: 8
+        type: integer
+        name: unknown_008
+      - id: 18
+        name: temperature
+        type: integer
+        unit: F
+        range:
+          min: 40
+          max: 95
+      - id: 19
+        name: current_temperature
+        type: integer
+        icon: "mdi:thermometer"
+        readonly: true
+  - entity: light
+    name: Display
+    dps:
+      - id: 102
+        type: integer
+        name: brightness
+        mapping:
+          - dps_val: 1
+            value: 85
+          - dps_val: 2
+            value: 170
+          - dps_val: 3
+            value: 255

--- a/custom_components/tuya_local/devices/aspen_fan.yaml
+++ b/custom_components/tuya_local/devices/aspen_fan.yaml
@@ -27,7 +27,7 @@ primary_entity:
           value: high
 secondary_entities:
   - entity: climate
-    name: Bedroom Fan
+    name: Fan
     dps:
       - id: 1
         type: boolean


### PR DESCRIPTION
Hello,

I have added a yaml device configuration for a window smart fan I use currently available in the US, [here](https://www.amazon.com/ASPEN-Controlled-Multi-Function-Detachable-Reversible/dp/B08KTQVN93)

The manual can be seen [here](https://static1.squarespace.com/static/5f7ce77e9aaa054d65fed97d/t/5f99a03c6dbd107a6123ede2/1603903564723/ASP-200+User+Manual.pdf)

Features:

- Turn On/OFF
- Set display brightness 1/2/3
- Set fan speed (High/Med/Low)
- Set fan direction ( in, out, exchange)
- View current temperature
- Enable/Disable 'temperature set point mode' and setting a temperature if enabled

The device allows control from a simple fan entity or a climate entity for easier integration with lovelace climate entity cards.