### PR TITLE
Add support for Bresser 7-in-1 ClimateConnect Weather Centre

### DIFF
--- a/custom_components/tuya_local/devices/bresser_weather_station.yaml
+++ b/custom_components/tuya_local/devices/bresser_weather_station.yaml
@@ -1,0 +1,322 @@
+# Bresser 7-in-1 ClimateConnect Tuya Smart Home Weather Centre
+# https://www.bresser.de/en/Weather-Time/BRESSER-7-in-1-ClimateConnect-Tuya-Smart-Home-Weather-Centre.html
+name: Bresser ClimateConnect
+products:
+  - id: 8qk6p78udvbjwlof
+    name: Bresser Weather Station
+    model: C6085A
+primary_entity:
+  entity: sensor
+  name: Indoor Temperature
+  class: temperature
+  dps:
+    - id: 1
+      <<: &temperature
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+        readonly: true
+#    - id: 22
+#      type: string
+#      name: fault_type
+    - id: 58
+      type: string
+      name: wind_direct
+    - id: 68
+      type: string
+      name: com_index
+secondary_entities:
+  - entity: sensor
+    name: Indoor Humidity
+    class: humidity
+    dps:
+      - id: 2
+        <<: &humidity
+          type: integer
+          name: sensor
+          unit: "%"
+          class: measurement
+          readonly: true
+  - entity: binary_sensor
+    name: Base Station Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 3
+        <<: &battery
+          type: string
+          name: sensor
+          mapping:
+            - dps_val: low
+              value: true
+            - dps_val: high
+              value: false
+  - entity: select
+    name: Temperature Unit
+    icon: mdi:thermometer
+    category: config
+    dps:
+      - id: 9
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: "°C"
+          - dps_val: f
+            value: "°F"
+  - entity: select
+    name: Wind Speed Unit
+    icon: mdi:weather-windy
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        mapping:
+          - dps_val: m_s
+            value: m/s
+          - dps_val: km_h
+            value: km/h
+          - dps_val: knots
+            value: knots
+          - dps_val: mph
+            value: mph
+  - entity: select
+    name: Pressure Unit
+    icon: mdi:gauge
+    category: config
+    dps:
+      - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: hpa
+            value: hPa
+          - dps_val: inhg
+            value: inHg
+          - dps_val: mmhg
+            value: mmHg
+  - entity: select
+    name: Rain Unit
+    icon: mdi:weather-rainy
+    category: config
+    dps:
+      - id: 12
+        type: string
+        name: option
+        mapping:
+          - dps_val: mm
+            value: mm
+          - dps_val: inch
+            value: inch
+  - entity: select
+    name: Light Intensity Unit
+    icon: mdi:brightness-5
+    category: config
+    dps:
+      - id: 13
+        type: string
+        name: option
+        mapping:
+          - dps_val: lux
+            value: lux
+          - dps_val: fc
+            value: fc
+          - dps_val: wm2
+            value: W/m2
+  - entity: binary_sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 30
+        <<: *battery
+#  - entity: binary_sensor
+#    name: Battery Ch1
+#    class: battery
+#    category: diagnostic
+#    dps:
+#      - id: 31
+#        <<: *battery
+#  - entity: binary_sensor
+#    name: Battery Ch2
+#    class: battery
+#    category: diagnostic
+#    dps:
+#      - id: 32
+#        <<: *battery
+#  - entity: binary_sensor
+#    name: Battery Ch3
+#    class: battery
+#    category: diagnostic
+#    dps:
+#      - id: 33
+#        <<: *battery
+  - entity: sensor
+    name: Temperature
+    class: temperature
+    dps:
+      - id: 38
+        <<: *temperature
+  - entity: sensor
+    name: Humidity
+    class: humidity
+    dps:
+      - id: 39
+        <<: *humidity
+#  - entity: sensor
+#    name: Temperature Ch1
+#    class: temperature
+#    dps:
+#      - id: 40
+#        <<: *temperature
+#  - entity: sensor
+#    name: Humidity Ch1
+#    class: humidity
+#    dps:
+#      - id: 41
+#        <<: *humidity
+#  - entity: sensor
+#    name: Temperature Ch2
+#    class: temperature
+#    dps:
+#      - id: 42
+#        <<: *temperature
+#  - entity: sensor
+#    name: Humidity Ch2
+#    class: humidity
+#    dps:
+#      - id: 43
+#        <<: *humidity
+#  - entity: sensor
+#    name: Temperature Ch3
+#    class: temperature
+#    dps:
+#      - id: 44
+#        <<: *temperature
+#  - entity: sensor
+#    name: Humidity Ch3
+#    class: humidity
+#    dps:
+#      - id: 45
+#        <<: *humidity
+  - entity: sensor
+    name: Pressure
+    class: pressure
+    dps:
+      - id: 54
+        type: integer
+        name: sensor
+        unit: hPa
+        mapping:
+          - scale: 10
+        class: measurement
+        readonly: true
+  - entity: sensor
+    name: Pressure Drop
+    class: pressure
+    dps:
+      - id: 55
+        type: integer
+        name: sensor
+        unit: hPa
+        class: measurement
+        readonly: true
+  - entity: sensor
+    name: Wind Speed
+    icon: mdi:weather-windy
+    dps:
+      - id: 56
+        <<: &wind_speed
+          type: integer
+          name: sensor
+          unit: m/s
+          mapping:
+            - scale: 10
+          class: measurement
+          readonly: true
+  - entity: sensor
+    name: Wind Gust
+    icon: mdi:weather-windy
+    dps:
+      - id: 57
+        <<: *wind_speed
+  - entity: sensor
+    name: Rain
+    icon: mdi:weather-rainy
+    dps:
+      - id: 60
+        <<: &rain
+          type: integer
+          name: sensor
+          mapping:
+            - scale: 1000
+          class: measurement
+          readonly: true
+        unit: mm
+  - entity: sensor
+    name: Rainfall Rate
+    icon: mdi:weather-pouring
+    dps:
+      - id: 61
+        <<: *rain
+        unit: mm/h
+  - entity: sensor
+    name: UV Index
+    icon: mdi:weather-sunny
+    dps:
+      - id: 62
+        type: integer
+        name: sensor
+        unit: UV Index
+        mapping:
+          - scale: 10
+        class: measurement
+        readonly: true
+  - entity: sensor
+    name: Light Intensity
+    class: illuminance
+    dps:
+      - id: 63
+        type: integer
+        name: sensor
+        unit: lx
+        class: measurement
+        readonly: true
+  - entity: sensor
+    name: Dew Point
+    class: temperature
+    dps:
+      - id: 64
+        <<: *temperature
+  - entity: sensor
+    name: Feels Like Temperature
+    class: temperature
+    dps:
+      - id: 65
+        <<: *temperature
+  - entity: sensor
+    name: Heat Index
+    class: temperature
+    dps:
+      - id: 66
+        <<: *temperature
+  - entity: sensor
+    name: Wind Chill Index
+    class: temperature
+    dps:
+      - id: 67
+        <<: *temperature
+  - entity: sensor
+    name: Wind Bearing
+    icon: mdi:compass-outline
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: "°"
+        class: measurement
+        readonly: true


### PR DESCRIPTION
Support for [Bresser 7-in-1 ClimateConnect Tuya Smart Home Weather Centre](https://www.bresser.de/en/Weather-Time/BRESSER-7-in-1-ClimateConnect-Tuya-Smart-Home-Weather-Centre.html) and extra wireless sensors like [Bresser Precision thermo-hygro sensor](https://www.bresser.de/en/Weather-Time/BRESSER-Precision-thermo-hygro-sensor.html)

For now please count this PR as a draft because it's has some issues which we will discus in appropriate issue.