### PR TITLE
Add support for Betterlife BL1500 IR Heater

### DIFF
--- a/custom_components/tuya_local/devices/betterlife_bl1500_heater.yaml
+++ b/custom_components/tuya_local/devices/betterlife_bl1500_heater.yaml
@@ -24,7 +24,10 @@ primary_entity:
         - constraint: preset_mode
           conditions:
             - dps_val: "2"
-              invalid: true
+              value: 20
+              range:
+                min: 20
+                max: 20
     - id: 4
       type: string
       name: preset_mode

--- a/custom_components/tuya_local/devices/betterlife_bl1500_heater.yaml
+++ b/custom_components/tuya_local/devices/betterlife_bl1500_heater.yaml
@@ -1,0 +1,95 @@
+name: Betterlife BL1500 Heater
+products:
+  - id: ptiFKEk2bgAslxOA
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: true
+          value: heat
+          icon: "mdi:radiator"
+        - dps_val: false
+          value: "off"
+          icon: "mdi:radiator-disabled"
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 15
+        max: 30
+      mapping:
+        - constraint: preset_mode
+          conditions:
+            - dps_val: "2"
+              invalid: true
+    - id: 4
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: "0"
+          value: comfort
+        - dps_val: "1"
+          value: boost
+        - dps_val: "2"
+          value: eco
+secondary_entities:
+  - entity: lock
+    name: Child Lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+        mapping:
+          - dps_val: true
+            icon: "mdi:hand-back-right-off"
+          - dps_val: false
+            icon: "mdi:hand-back-right"
+  - entity: select
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: "1 hour"
+          - dps_val: "2"
+            value: "2 hours"
+          - dps_val: "3"
+            value: "3 hours"
+          - dps_val: "4"
+            value: "4 hours"
+          - dps_val: "5"
+            value: "5 hours"
+          - dps_val: "6"
+            value: "6 hour"
+          - dps_val: "7"
+            value: "7 hours"
+          - dps_val: "8"
+            value: "8 hours"
+          - dps_val: "9"
+            value: "9 hours"
+          - dps_val: "10"
+            value: "10 hours"
+          - dps_val: "11"
+            value: "11 hours"
+          - dps_val: "12"
+            value: "12 hours"
+  - entity: sensor
+    name: Timer Countdown
+    icon: "mdi:timer"
+    category: diagnostic
+    dps:
+      - id: 12
+        type: integer
+        name: sensor
+        readonly: true
+        unit: "min"


### PR DESCRIPTION
- Supports all 3 heat modes including eco, child-lock, setting countdowns and reading remaining time.
- Tested