### PR TITLE
Add support for Catit Pixi Smart Fountain

### DIFF
--- a/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
@@ -29,7 +29,7 @@ secondary_entities:
           min: 0
           max: 43200
         mapping:
-          - scale: 0
+          - scale: 1
             step: 1
         unit: min
   - entity: switch
@@ -52,6 +52,6 @@ secondary_entities:
           min: 0
           max: 10800
         mapping:
-          - scale: 0
+          - scale: 1
             step: 1
         unit: s

--- a/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
@@ -1,0 +1,57 @@
+name: Catit Pixi Smart Fountain
+products:
+  - id: z3rpyvznfcch99aa
+primary_entity:
+  entity: switch
+  icon: "mdi:water-pump"
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+secondary_entities:
+  - entity: switch
+    name: Filter Replaced
+    icon: "mdi:air-filter"
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: switch
+  - entity: number
+    name: Filter Life
+    icon: "mdi:air-filter"
+    category: config
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 43200
+        mapping:
+          - scale: 0
+            step: 1
+        unit: min
+  - entity: switch
+    name: Run UV Cycle
+    icon: "mdi:bacteria"
+    category: config
+    dps:
+      - id: 10
+        type: boolean
+        name: switch
+  - entity: number
+    name: UV Runtime
+    icon: "mdi:timer-outline"
+    category: config
+    dps:
+      - id: 11
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10800
+        mapping:
+          - scale: 0
+            step: 1
+        unit: s

--- a/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
@@ -25,13 +25,15 @@ secondary_entities:
       - id: 4
         type: integer
         name: value
+        readonly: true
         range:
           min: 0
           max: 43200
         mapping:
-          - scale: 1
+          - scale: 1440 # minutes => days
             step: 1
-        unit: min
+            invert: true
+        unit: days
   - entity: switch
     name: Run UV Cycle
     icon: "mdi:bacteria"
@@ -48,10 +50,8 @@ secondary_entities:
       - id: 11
         type: integer
         name: value
-        range:
-          min: 0
-          max: 10800
+        readonly: true
         mapping:
-          - scale: 1
+          - scale: 60
             step: 1
-        unit: s
+        unit: min

--- a/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
@@ -42,6 +42,22 @@ secondary_entities:
       - id: 10
         type: boolean
         name: switch
+  - entity: select
+    name: Water Level
+    icon: "mdi:beaker-outline"
+    category: config
+    dps:
+      - id: 12
+        type: string
+        name: option
+        readonly: true
+        mapping:
+          - dps_val: level_1
+            value: Low
+          - dps_val: level_2
+            value: Medium
+          - dps_val: level_3
+            value: Full
   - entity: number
     name: UV Runtime
     icon: "mdi:timer-outline"


### PR DESCRIPTION
Adds initial support for the Catit Pixi Smart Fountain.

I've managed to successfully test the power switch and UV functionality, which turn on and off appropriately and report their status. I'm not 100% sure how I'm supposed to handle the runtime numbers and stuff - I'd appreciate some guidance on that - and I'm not sure whether there's existing support for the `Enum` tuya type, which this needs for the Water Level sensor

In relation to: https://github.com/make-all/tuya-local/issues/216 