### PR TITLE
Add Honeywell TP dehumidifier

### DIFF
--- a/custom_components/tuya_local/devices/honeywell_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/honeywell_dehumidifier.yaml
@@ -1,0 +1,68 @@
+name: Honeywell TP Series Dehumidifier
+products:
+  - id: anAaZAfvsdrdl9Oy
+primary_entity:
+  entity: humidifier
+  class: dehumidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+      mapping:
+        - dps_val: false
+          icon: "mdi:air-humidifier-off"
+          icon_priority: 1
+        - dps_val: true
+          icon: "mdi:air-humidifier"
+          icon_priority: 4
+    - id: 6
+      name: humidity
+      type: integer
+      range:
+        min: 15
+        max: 90
+      mapping:
+        - step: 5
+    - id: 8
+      name: mode
+      type: integer
+      mapping:
+        - dps_val: 0
+          value: low
+        - dps_val: 2
+          value: high
+    - id: 15
+      name: error
+      type: bitfield
+      mapping:
+        - dps_val: 0
+          value: OK
+        - dps_val: 1
+          value: Sensor fault
+        - dps_val: 2
+          value: Temperature fault
+    - id: 18
+      name: current_humidity
+      type: integer
+    - id: 25
+      name: filter_cleaning_reminder
+      type: boolean
+secondary_entities:
+  - entity: sensor
+    name: Current humidity
+    class: humidity
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: binary_sensor
+    name: Filter cleaning reminder
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 25
+        type: boolean
+        name: sensor


### PR DESCRIPTION
Adding support for Honeywell TP dehumidifiers:

- https://www.honeywellstore.com/store/products/honeywell-smart-wifi-50-pint-energy-star-dehumidifier-tp50awkn.htm
- https://www.honeywellstore.com/store/products/honeywell-smart-wifi-30-pint-energy-star-dehumidifier-tp30awkn.htm
- https://www.honeywellstore.com/store/products/honeywell-smart-wifi-70-pint-energy-star-dehumidifier-tp70awkn.htm

These are the same, just bigger tanks and some have automated pumps for the water tank

Capabilities:

![Screenshot from 2022-12-08 11-52-26](https://user-images.githubusercontent.com/1641464/206514156-c0be8084-fdc9-4222-ab8e-862d83675fff.png)

Setable values:
![Screenshot from 2022-12-08 11-51-40](https://user-images.githubusercontent.com/1641464/206514192-fdaad334-2b05-463d-a19d-3a94833f55f5.png)

DPs:
![Screenshot from 2022-12-08 11-27-22](https://user-images.githubusercontent.com/1641464/206514270-40e3e7aa-5c0f-4d32-b059-3a32407e93bf.png)

1 - Switch
18 - Current humidity
6 - Humidity setting
8 - Speed 
25 - Filter cleaning reminder
15 - Fault