### PR TITLE
Add support for Benexmart Wi-Fi Blind Motor

### DIFF
--- a/custom_components/tuya_local/devices/benexmart_blind_motor.yaml
+++ b/custom_components/tuya_local/devices/benexmart_blind_motor.yaml
@@ -1,0 +1,26 @@
+name: benexmart blind motor
+primary_entity:
+  entity: cover
+  class: blind
+  dps:
+    - id: 1
+      name: control
+      type: string
+      mapping:
+        - dps_val: open
+          value: open
+        - dps_val: close
+          value: close
+        - dps_val: stop
+          value: stop
+    - id: 2
+      name: position
+      type: integer
+      range:
+        min: 0
+        max: 100
+      mapping:
+        - invert: true
+    - id: 5
+      name: motor_reverse
+      type: boolean

--- a/custom_components/tuya_local/devices/benexmart_blind_motor.yaml
+++ b/custom_components/tuya_local/devices/benexmart_blind_motor.yaml
@@ -19,8 +19,15 @@ primary_entity:
       range:
         min: 0
         max: 100
-      mapping:
-        - invert: true
     - id: 5
-      name: motor_reverse
       type: boolean
+      name: reversed
+secondary_entities:
+    - entity: switch
+      category: config
+      name: Reversed
+      icon: "mdi:arrow-u-down-left"
+      dps:
+        - id: 5
+          type: boolean
+          name: switch


### PR DESCRIPTION
Add support for the Benexmart WiFi Blind Motor.

Only 3 dps are being exposed to HA even though cloud debug shows more available.

  },
  "data": {
    "name": "Right Curtain",
    "type": "benexmart_blind_motor",
    "device_id": "**REDACTED**",
    "local_key": "**REDACTED**",
    "host": "**REDACTED**",
    "api_version": 3.3,
    "status": {},
    "cached_state": {
      "updated_at": 1670793080.225058,
      "1": "stop",
      "2": 0,
      "5": true
    },

<img width="479" alt="Screenshot 2022-12-11 at 21 34 07" src="https://user-images.githubusercontent.com/57048835/206930069-b89dc1b8-7b64-4599-b7a0-d7c99dda24a5.png">


![IMG_4252](https://user-images.githubusercontent.com/57048835/206929940-8739a486-fe68-450b-b8b4-081b6ac1e8f2.PNG)
![IMG_4251](https://user-images.githubusercontent.com/57048835/206929944-a8572a07-f7e3-4478-8608-6b7a901f35d2.PNG)


https://amzn.eu/d/drCsbO4