### PR TITLE
Eurom wall Designheat 2000 heater fix heat modes

### DIFF
--- a/custom_components/tuya_local/devices/eurom_walldesignheat2000_heater.yaml
+++ b/custom_components/tuya_local/devices/eurom_walldesignheat2000_heater.yaml
@@ -19,10 +19,10 @@ primary_entity:
             - dps_val: auto
               value: heat
               icon: "mdi:radiator"
-            - dps_val: "50_perc"
+            - dps_val: "50_per"
               value: heat
               icon: "mdi:radiator"
-            - dps_val: "100_perc"
+            - dps_val: "100_per"
               value: heat
               icon: "mdi:radiator"
     - id: 2
@@ -40,9 +40,9 @@ primary_entity:
       mapping:
         - dps_val: "off"
           value: fan
-        - dps_val: "50_perc"
+        - dps_val: "50_per"
           value: eco
-        - dps_val: "100_perc"
+        - dps_val: "100_per"
           value: boost
         - dps_val: auto
           value: comfort


### PR DESCRIPTION
The eco & boost mode were not working because of a spelling mistake in the yaml.

Attached is a screenshot from Tuya IoT showing the correct values

![image](https://user-images.githubusercontent.com/5102352/207161037-36a6e618-fbff-40f3-a446-90eb571ae456.png)
