### PR TITLE
Update tesla_air_purifier_pro.yaml

### DIFF
--- a/custom_components/tuya_local/devices/tesla_air_purifier_pro.yaml
+++ b/custom_components/tuya_local/devices/tesla_air_purifier_pro.yaml
@@ -98,10 +98,10 @@ secondary_entities:
             value: "cancel"
           - dps_val: "1h"
             value: "1 hour"
-          - dps_val: "2h"
-            value: "2 hours"
           - dps_val: "4h"
             value: "4 hours"
+          - dps_val: "8h"
+            value: "8 hours"
   - entity: sensor
     name: PM2.5
     class: pm25


### PR DESCRIPTION
Correction of the timer - cancel, 1h, 4h, 8h. Checked with the device and Tuya API.

      {
        "code": "countdown_set",
        "dp_id": 18,
        "type": "Enum",
        "values": "{\"range\":[\"cancel\",\"1h\",\"4h\",\"8h\"]}"
      }