### PR TITLE
Create arlec_motion_sensor_light.yaml

### DIFF
--- a/custom_components/tuya_local/devices/arlec_motion_sensor_light.yaml
+++ b/custom_components/tuya_local/devices/arlec_motion_sensor_light.yaml
@@ -1,0 +1,76 @@
+name: Arlec Grid Connect Smart Security Light
+products:
+  - id: pxyhz90upglpoedu
+    name: MAL315HA
+#https://www.bunnings.com.au/arlec-20w-grid-connect-smart-security-light-with-movement-activated-sensor_p0223575
+primary_entity:
+  entity: light
+  dps:
+    - id: 102
+      type: boolean
+      name: switch
+secondary_entities:
+  - entity: select
+    name: Mode
+    category: config
+    dps:
+      - id: 101
+        type: string
+        name: option
+        mapping:
+        - dps_val: mode_off
+          value: "Off"
+        - dps_val: mode_auto
+          value: Auto
+        - dps_val: mode_on
+          value: "On"
+  - entity: number
+    name: Sensitivity
+    icon: "mdi:human-greeting-proximity"
+    category: config
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 4
+        mapping:
+          - invert: true
+  - entity: number
+    name: Duration
+    icon: "mdi:camera-timer"
+    category: config
+    dps:
+      - id: 104
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 10
+          max: 900
+        mapping:
+          - step: 10
+  - entity: number
+    name: Light Level
+    icon: "mdi:theme-light-dark"
+    category: config
+    mode: slider
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: lx
+        range:
+          min: 0
+          max: 3900
+        mapping:
+          - invert: true
+  - entity: switch
+    name: Auto Reset
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: sensor
+


### PR DESCRIPTION
HI,
Thanks for this great project!
I have been playing around with it for a few days and find it to be more stable than other integrations I've used for Tuya devices. I really like that I can create  device.yaml files to fine tune how devices are handled.

Here is one that I have put together and provides the same functionality as the manufacturer's app (e.g. Grid Connect; or Tuya apps) Product is sold by Bunnings in Australia
https://www.bunnings.com.au/arlec-20w-grid-connect-smart-security-light-with-movement-activated-sensor_p0223575

Entities & DPs:
This smart motion sensor light is a bit odd as it doesn't have a DP to represent a switch but instead has a select entity to choose between modes (On, Off, or Auto)  This means that the generic motion_sensor_light.yaml doesn't work with this device. There is a binary sensor that is read only and represents the state of the light's relay. I haven't quite figure out how to best configure that and currently have it as the primary entity. This works well with the exception that the HA UI provides a switch that can be toggled but doesn't actually have any effect. The UI does correctly represent when the switch is on/off based on the select.sensor_mode entity. The only other DP that I have not configured correctly yet  is DP106 : Auto Rest. This is supposed to be a switch to turns on a 1 hr timer for the mode to switch back to Auto if it has been turned On or Off. The native app does not use this feature either, so it is not really necessary and is better handled by an automation anyway :)

Entity type | ID | Friendly Name
Select | 101 | Sensor Mode
Binary sensor | 102 | Relay Status
Number | 103 | Sensitivity
Number | 104 | Duration
Number | 105 | Light Threshold
Switch | 106 | Auto Reset(unused)