### PR TITLE
fix(devices): instruct home assistant to fetch device state if unavailable

### DIFF
--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -403,6 +403,8 @@ class TuyaLocalDevice(object):
                 self._api_protocol_working = True
                 return retval
             except Exception as e:
+                for entity in self._children:
+                    entity.async_schedule_update_ha_state()
                 _LOGGER.debug(
                     f"Retrying after exception {e} ({i}/{connections})",
                 )


### PR DESCRIPTION
Hello,

Thanks for the great work, this module is really helpful to me.

I have one issue, when my devices go offline (bulb with no power anymore, or tuya switch unplugged), they are never reported as unavailable to HA, we can still try to control them.

After digging through the code, I discovered that we never tell HA to pull the state if we cannot connect to the device. Or, I think we should do so, like that HA we'll have the "available" property set to false, and the bulbs will display as greyed out until the power comes back.

I have tested this in HA 2023.1.7 with multiple tuya lights and switches.

Feel free to ask any questions or provide suggestions.