### PR TITLE
Add support for generic lightbulbs.

### DIFF
--- a/custom_components/tuya_local/devices/simple_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/simple_lightbulb.yaml
@@ -1,0 +1,13 @@
+name: Simple lightbulb
+primary_entity:
+  entity: light
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 2
+      name: brightness
+      type: integer
+      range:
+        min: 10
+        max: 255


### PR DESCRIPTION
There does not seem to be a configuration file for generic white Tuya bulbs.

This file is working with 2 of my basic Merkury bulbs. I'm sure it works with other white Tuya bulbs also such as Feit.

> DP 1: `switch`
> DP 2: `brightness`

I don't like making it a generic config, but I was surprised when I was setting up the integration that none of the included ones worked with these basic bulbs.

**Suggestion**: Add an "override" option on stage two of the configuration in HA. It wouldn't have made a difference in my case as there isn't a config for these DPs, but it would have saved me some troubleshooting time.

![MI-BW911-999W](https://user-images.githubusercontent.com/5241478/215386250-f58c1e9d-ab32-443a-8653-8b29b4da5cf0.jpg)

![MI-BW932-999W](https://user-images.githubusercontent.com/5241478/215386496-77f4fbbb-a75a-4f59-b7c6-908f7b6e61f2.jpeg)
