### PR TITLE
Add support for Breville Smart Air Connect Purifier

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -112,7 +112,7 @@
 ### Air Purifiers
 
 - Breville Easy Air purifier
-- Breville Smart Air purifier
+- Breville Smart Air Connect purifier
 - essentials portable air purifier
 - Himox H05 and H06 air purifiers
 - Hosome air purifier

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -112,6 +112,7 @@
 ### Air Purifiers
 
 - Breville Easy Air purifier
+- Breville Smart Air purifier
 - essentials portable air purifier
 - Himox H05 and H06 air purifiers
 - Hosome air purifier

--- a/custom_components/tuya_local/devices/breville_smartair_purifier.yaml
+++ b/custom_components/tuya_local/devices/breville_smartair_purifier.yaml
@@ -1,0 +1,125 @@
+name: Breville Smart Air
+products:
+  - id: tltdxtehttjbkjni
+primary_entity:
+  entity: fan
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+      mapping:
+        - dps_val: true
+          icon: "mdi:air-purifier"
+        - dps_val: false
+          icon: "mdi:air-purifier-off"
+    - id: 3
+      name: mode
+      type: string
+      mapping:
+        - dps_val: "manual"
+          value: "Manual"
+        - dps_val: "auto"
+          value: "Auto"
+    - id: 4
+      type: string
+      name: speed
+      mapping:
+        - dps_val: low
+          value: 33
+        - dps_val: mid
+          value: 66
+        - dps_val: high
+          value: 100
+secondary_entities:
+  - entity: sensor
+    name: PM2.5
+    icon: "mdi:air-filter"
+    class: pm25
+    dps:
+      - id: 2
+        name: sensor
+        class: measurement
+        type: integer
+        unit: µg/m3
+  - entity: select
+    name: Fan Mode
+    icon: "mdi:auto-mode"
+    category: config
+    dps:
+      - id: 3
+        type: string
+        name: option
+        mapping:
+          - dps_val: "auto"
+            value: "Auto"
+          - dps_val: "manual"
+            value: "Manual"
+  - entity: switch
+    name: Night mode
+    category: config
+    icon: "mdi:lightbulb-night"
+    dps:
+      - id: 8
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Micro shield
+    category: config
+    icon: "mdi:shield-bug"
+    dps:
+      - id: 9
+        name: switch
+        type: boolean
+  - entity: sensor
+    name: Filter days left
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 16
+        name: sensor
+        type: integer
+        unit: day
+  - entity: select
+    name: Timer
+    icon: "mdi:fan-clock"
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: "cancle"
+            value: "Cancel"
+          - dps_val: "2"
+            value: "2 hour"
+          - dps_val: "4"
+            value: "4 hours"
+          - dps_val: "8"
+            value: "8 hours"
+  - entity: sensor
+    name: Time left
+    category: diagnostic
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 20
+        name: sensor
+        type: integer
+        unit: min
+  - entity: sensor
+    name: Air quality
+    class: enum
+    icon: "mdi:air-filter"
+    dps:
+      - id: 22
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: "great"
+            value: "Great"
+          - dps_val: "good"
+            value: "Good"
+          - dps_val: "medium"
+            value: "Medium"
+          - dps_val: "severe"
+            value: "Severe"

--- a/custom_components/tuya_local/devices/breville_smartairconnect_purifier.yaml
+++ b/custom_components/tuya_local/devices/breville_smartairconnect_purifier.yaml
@@ -13,7 +13,7 @@ primary_entity:
         - dps_val: false
           icon: "mdi:air-purifier-off"
     - id: 3
-      name: mode
+      name: preset_mode
       type: string
       mapping:
         - dps_val: "manual"
@@ -41,19 +41,6 @@ secondary_entities:
         class: measurement
         type: integer
         unit: µg/m3
-  - entity: select
-    name: Fan Mode
-    icon: "mdi:auto-mode"
-    category: config
-    dps:
-      - id: 3
-        type: string
-        name: option
-        mapping:
-          - dps_val: "auto"
-            value: "Auto"
-          - dps_val: "manual"
-            value: "Manual"
   - entity: switch
     name: Night mode
     category: config
@@ -105,7 +92,7 @@ secondary_entities:
       - id: 20
         name: sensor
         type: integer
-        unit: min
+        unit: d
   - entity: sensor
     name: Air quality
     class: enum

--- a/custom_components/tuya_local/devices/breville_smartairconnect_purifier.yaml
+++ b/custom_components/tuya_local/devices/breville_smartairconnect_purifier.yaml
@@ -1,4 +1,4 @@
-name: Breville Smart Air
+name: Breville Smart Air Connect Purifier
 products:
   - id: tltdxtehttjbkjni
 primary_entity:

--- a/custom_components/tuya_local/devices/breville_smartairconnect_purifier.yaml
+++ b/custom_components/tuya_local/devices/breville_smartairconnect_purifier.yaml
@@ -40,7 +40,7 @@ secondary_entities:
         name: sensor
         class: measurement
         type: integer
-        unit: µg/m3
+        unit: ugm3
   - entity: switch
     name: Night mode
     category: config
@@ -92,7 +92,7 @@ secondary_entities:
       - id: 20
         name: sensor
         type: integer
-        unit: d
+        unit: min
   - entity: sensor
     name: Air quality
     class: enum


### PR DESCRIPTION
This PR adds support for the Breville Smart Air Connect Purifier (model lap308). I've modeled this off of the Breville Easy Air Purifier. The key differences between the models is the addition of a PM2.5 sensor, Air Quality indicator and automatic/manual fan mode.

### Reference device information:
Manufacturer website: https://www.breville.com/au/en/products/air-purifier/lap308.html

Product ID: tltdxtehttjbkjni

#### Device Attributes
```
{
  "result": {
    "category": "kj",
    "functions": [
      {
        "code": "switch",
        "dp_id": 1,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "mode",
        "dp_id": 3,
        "type": "Enum",
        "values": "{\"range\":[\"manual\",\"auto\"]}"
      },
      {
        "code": "light",
        "dp_id": 8,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "uv",
        "dp_id": 9,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "filter_reset",
        "dp_id": 11,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "countdown_set",
        "dp_id": 19,
        "type": "Enum",
        "values": "{\"range\":[\"cancle\",\"2h\",\"4h\",\"8h\"]"
      },
      {
        "code": "fan_speed_enum",
        "dp_id": 4,
        "type": "Enum",
        "values": "{\"range\":[\"low\",\"mid\",\"high\"]}"
      }
    ],
    "status": [
      {
        "code": "switch",
        "dp_id": 1,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "pm25",
        "dp_id": 2,
        "type": "Integer",
        "values": "{\"unit\":\"\",\"min\":0,\"max\":9999,\"scale\":1,\"step\":1}"
      },
      {
        "code": "mode",
        "dp_id": 3,
        "type": "Enum",
        "values": "{\"range\":[\"manual\",\"auto\"]}"
      },
      {
        "code": "light",
        "dp_id": 8,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "uv",
        "dp_id": 9,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "filter_reset",
        "dp_id": 11,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "filter_days",
        "dp_id": 16,
        "type": "Integer",
        "values": "{\"unit\":\"day\",\"min\":0,\"max\":1000,\"scale\":0,\"step\":1}"
      },
      {
        "code": "countdown_set",
        "dp_id": 19,
        "type": "Enum",
        "values": "{\"range\":[\"cancle\",\"2h\",\"4h\",\"8h\"]}"
      },
      {
        "code": "countdown_left",
        "dp_id": 20,
        "type": "Integer",
        "values": "{\"unit\":\"分钟\",\"min\":0,\"max\":720,\"scale\":0,\"step\":1}"
      },
      {
        "code": "air_quality",
        "dp_id": 22,
        "type": "Enum",
        "values": "{\"range\":[\"great\",\"good\",\"medium\",\"severe\"]}"
      },
      {
        "code": "fan_speed_enum",
        "dp_id": 4,
        "type": "Enum",
        "values": "{\"range\":[\"low\",\"mid\",\"high\"]}"
      }
    ]
  },
  "success": true,
  "t": 1677236178619,
  "tid": "ddca0830b43111edad0316dc0085482e"
}
```
