### PR TITLE
Support for a white-only generic table lamp

### DIFF
--- a/custom_components/tuya_local/devices/desk_lamp.yaml
+++ b/custom_components/tuya_local/devices/desk_lamp.yaml
@@ -1,0 +1,32 @@
+name: Desk Lamp
+products:
+  - id: b0j0lto1o0ijwb39
+    name: Desk Lamp Setti+ SL601
+primary_entity:
+  entity: light
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: string
+      name: color_mode
+      mapping:
+        - dps_val: white
+          value: color_temp
+    - id: 3
+      name: brightness
+      type: integer
+      optional: true
+      range:
+        min: 25
+        max: 255
+    - id: 4
+      name: color_temp
+      type: integer
+      optional: true
+      range:
+        min: 0
+        max: 255
+      mapping:
+        - invert: true


### PR DESCRIPTION
This is tested with [Desk Lamp Setti+ SL601](https://setti.pl/produkty/oswietlenie/lampy/lampa-biurkowa-sl601)
The device allows setting light temperature and brigthness.
In the Tuya app it is also possible to set a timer, but I couldn't find dp id for that. But the timer works, I've checked.
The device is also supposed to be a wireless phone charger (not tested, don't have such a phone), but I don't see any option/status related to that in Tuya app.

I've pulled the following info from iot.tuya.com:
```json
{
  "result": {
    "category": "dj",
    "functions": [
      {
        "code": "switch_led",
        "lang_config": {
          "false": "OFF",
          "true": "ON"
        },
        "name": "Switch",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "work_mode",
        "lang_config": {
          "colour": "Colour",
          "white": "White"
        },
        "name": "Mode",
        "type": "Enum",
        "values": "{\"range\":[\"white\",\"colour\"]}"
      },
      {
        "code": "bright_value",
        "lang_config": {
          "unit": ""
        },
        "name": "Bright",
        "type": "Integer",
        "values": "{\"unit\":\"\",\"min\":25,\"max\":255,\"scale\":0,\"step\":1}"
      },
      {
        "code": "temp_value",
        "lang_config": {
          "unit": ""
        },
        "name": "Colour Temp",
        "type": "Integer",
        "values": "{\"unit\":\"\",\"min\":0,\"max\":255,\"scale\":0,\"step\":1}"
      }
    ],
    "status": [
      {
        "code": "switch_led",
        "lang_config": {
          "false": "OFF",
          "true": "ON"
        },
        "name": "Switch",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "work_mode",
        "lang_config": {
          "colour": "Colour",
          "white": "White"
        },
        "name": "Mode",
        "type": "Enum",
        "values": "{\"range\":[\"white\",\"colour\"]}"
      },
      {
        "code": "bright_value",
        "lang_config": {
          "unit": ""
        },
        "name": "Bright",
        "type": "Integer",
        "values": "{\"unit\":\"\",\"min\":25,\"max\":255,\"scale\":0,\"step\":1}"
      },
      {
        "code": "temp_value",
        "lang_config": {
          "unit": ""
        },
        "name": "Colour Temp",
        "type": "Integer",
        "values": "{\"unit\":\"\",\"min\":0,\"max\":255,\"scale\":0,\"step\":1}"
      }
    ]
  },
  "success": true,
  "t": 1679936831612,
  "tid": "d0618756ccc111ed868e92fe0d59ba81"
}
```

The log from tuya_local before I've added this yaml:
`Device matches garage_door_opener with quality of 40%. DPS: {"updated_at": 1679935545.1487036, "1": true, "2": "Breathe", "3": 142, "4": 0, "101": false}`

Never figured out what the dpid 101 is for, but it's name is SOS ...
The "Breathe" value is only there when reading the mode, it is not one of valid writable values.

Works for me, hope this helps someone!
