### PR TITLE
Add support for Silvercrest Sous Vide Stick SSVSS 1200 A1 (100358082)

### DIFF
--- a/custom_components/tuya_local/devices/silvercrest_sousvide_cooker.yaml
+++ b/custom_components/tuya_local/devices/silvercrest_sousvide_cooker.yaml
@@ -1,0 +1,103 @@
+name: Silvercrest Sous Vide Stick SSVSS 1200 A1 (100358082)
+products:
+  - id: ljrmmds82n6kln4u
+    name: Sous Vide Stick
+primary_entity:
+  entity: climate
+  dps:
+    - id: 101
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: heat
+    - id: 103
+      type: integer
+      name: temperature
+      range:
+        min: 0
+        max: 960
+      mapping:
+        - scale: 10
+    - id: 104
+      type: integer
+      name: current_temperature
+      mapping:
+        - scale: 10
+    - id: 107
+      type: integer
+      name: fault
+      mapping:
+        - dps_val: 0
+          value: 0
+        - icon: "mdi:alert"
+          icon_priority: 1
+    - id: 108
+      type: boolean
+      name: temperature_unit
+      mapping:
+        - dps_val: true
+          value: C
+        - dps_val: false
+          value: F
+secondary_entities:
+  - entity: number
+    name: Cooking time
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 5999
+        unit: min
+  - entity: sensor
+    name: Remaining time
+    category: diagnostic
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    name: Fault
+    category: diagnostic
+    class: problem
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    name: Temperature unit
+    category: config
+    icon: "mdi:temperature-celsius"
+    dps:
+      - id: 108
+        type: boolean
+        name: option
+        mapping:
+          - dps_val: true
+            value: Celsius
+          - dps_val: false
+            value: Fahrenheit
+  - entity: number
+    name: Recipe
+    category: config
+    icon: "mdi:pot-steam"
+    dps:
+      - id: 109
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 1000


### PR DESCRIPTION
Device is similar to Inkbird sous vide, but doesn't support id: 102 for current status.