### PR TITLE
Add support for Zemismart Roller Shade Controller ZM16EL

### DIFF
--- a/custom_components/tuya_local/devices/zemismart_roller_shade_controller.yaml
+++ b/custom_components/tuya_local/devices/zemismart_roller_shade_controller.yaml
@@ -1,0 +1,26 @@
+name: Zemismart Roller Shade Controller
+product:
+  - id: hwbhrbadjynv7w70
+    name: ZM16EL+ZMRS-1W
+primary_entity:
+  entity: cover
+  class: blind
+  dps:
+    - id: "1"
+      name: control
+      type: string
+      mapping:
+        - dps_val: open
+          value: open
+        - dps_val: stop
+          value: stop
+        - dps_val: close
+          value: close
+        - dps_val: continue
+          value: continue
+    - id: "2"
+      name: percent_control
+      type: integer
+      range:
+        min: 0
+        max: 100

--- a/custom_components/tuya_local/devices/zemismart_roller_shade_zm16el.yaml
+++ b/custom_components/tuya_local/devices/zemismart_roller_shade_zm16el.yaml
@@ -19,8 +19,12 @@ primary_entity:
         - dps_val: continue
           value: continue
     - id: "2"
-      name: percent_control
+      name: position
       type: integer
+      # We set persist to false because
+      # this is used as a control, not
+      # a status
+      persist: false
       range:
         min: 0
         max: 100

--- a/custom_components/tuya_local/devices/zemismart_roller_shade_zm16el.yaml
+++ b/custom_components/tuya_local/devices/zemismart_roller_shade_zm16el.yaml
@@ -18,13 +18,3 @@ primary_entity:
           value: close
         - dps_val: continue
           value: continue
-    - id: "2"
-      name: position
-      type: integer
-      # We set persist to false because
-      # this is used as a control, not
-      # a status
-      persist: false
-      range:
-        min: 0
-        max: 100


### PR DESCRIPTION
This pull requests adds basic support for the Zemismart Roller Shade Controller ZM16EL. It only has open, close, and stop support. This device has some quirks, which are detailed at the bottom of the pull request.

### Information about DPS Mappings
```
{
  "result": {
    "category": "cl",
    "functions": [
      {
        "code": "control",
        "desc": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}",
        "name": "控制",
        "type": "Enum",
        "values": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}"
      },
      {
        "code": "percent_control",
        "desc": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}",
        "name": "开启百分比控制",
        "type": "Integer",
        "values": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
      },
      {
        "code": "control_back_mode",
        "desc": "{\"range\":[\"forward\",\"back\"]}",
        "name": "电机反转模式",
        "type": "Enum",
        "values": "{\"range\":[\"forward\",\"back\"]}"
      },
      {
        "code": "border",
        "desc": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}",
        "name": "设置限位",
        "type": "Enum",
        "values": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}"
      }
    ],
    "status": [
      {
        "code": "control",
        "name": "控制",
        "type": "Enum",
        "values": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}"
      },
      {
        "code": "percent_control",
        "name": "开启百分比控制",
        "type": "Integer",
        "values": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
      },
      {
        "code": "percent_state",
        "name": "开启百分比状态",
        "type": "Integer",
        "values": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
      },
      {
        "code": "control_back_mode",
        "name": "电机反转模式",
        "type": "Enum",
        "values": "{\"range\":[\"forward\",\"back\"]}"
      },
      {
        "code": "work_state",
        "name": "工作状态",
        "type": "Enum",
        "values": "{\"range\":[\"opening\",\"closing\"]}"
      },
      {
        "code": "fault",
        "name": "自动开启",
        "type": "Bitmap",
        "values": "{\"label\":[\"motor_fault\"]}"
      },
      {
        "code": "border",
        "name": "设置限位",
        "type": "Enum",
        "values": "{\"range\":[\"up\",\"down\",\"up_delete\",\"down_delete\",\"remove_top_bottom\"]}"
      }
    ]
  },
  "success": true,
  "t": 1682382994647,
  "tid": "3b2f95c4e30111ed83372ea9d702e4ea"
}
```

### Product ID (snipped)
```
{
  "result": {
    "category": "cl",
    "category_name": "Curtain",
    "model": "",
    "product_id": "hwbhrbadjynv7w70",
    "product_name": "Wifi Roller Shade Converter",
  },
  "success": true,
  "t": 1682383256381,
  "tid": "d732dc7ee30111ed880d8ee1cbe35557"
}
```

### Information about how the device functions
This required a lot of troubleshooting, so I'm putting a few pointers for anyone else who might come across this or a similar issue. Some of those issues are:

#### Issue (A): Tuya IOT platform did not have DP IDs
Strangely, when I went to get DP IDs from Tuya the API did not return them (see the first code block with DPS mappings, no IDs!)

#### Issue (B): `tuyadebug/test.py` sometimes returns DP IDs, sometimes it does not.
This is a weird one to reproduce. Sometimes this tool returns DP IDs, and sometimes it doesn't. I don't really understand why. Here is one response I was able to get to ultimately get the IDs:
```
% python3 test.py <snip>
**** deviceInfo returned OK ****

TuyaDebug (Tuya DPs dump) [1.0.0]

Device <snip> protocol 3.3 dev_type type_0a:
    DPS [1] VALUE [stop] 
    DPS [2] VALUE [0] 
    DPS [5] VALUE [forward] 
    DPS [16] VALUE [up] 
```
I used https://github.com/rospogrigio/localtuya/wiki/HOWTO-get-a-DPs-dump . To get a dump. Anecdotally, when I would use the tuya app to open/close sometimes the DP would show up more reliably after that.

This old PR was helpful in diagnosing: https://github.com/rospogrigio/localtuya/issues/838

#### Issue (C): DP_ID 2 does not accurately report position
This is a control where you can set the position percentage instead of just opening and closing. It's useless for reporting the position status.

#### Issue (D): Home Assistant gets confused by the `position` DP
I had a previous version where I set the DP_ID 2 to `position` and `persist: false`. This caused home assistant to show a "Opening/Closing" status (which was never correct) and sometimes it would get "stuck" at the position value because, as mentioned above, it doesn't actually reflect the position.

### Remaining work: what about `percent_state` and `work_state`?
Despite these being available in the Tuya IOT API, I cannot get these DPs to actually show up on the device. If anyone has any pointers I would be happy to try and test a few things.