### PR TITLE
Fix open/close for some covers and fixes for zemismart

### DIFF
--- a/custom_components/tuya_local/cover.py
+++ b/custom_components/tuya_local/cover.py
@@ -42,6 +42,7 @@ class TuyaLocalCover(TuyaLocalEntity, CoverEntity):
         self._currentpos_dp = dps_map.pop("current_position", None)
         self._control_dp = dps_map.pop("control", None)
         self._action_dp = dps_map.pop("action", None)
+        self._action_stuck_dp = dps_map.pop("action_stuck", None)
         self._open_dp = dps_map.pop("open", None)
         self._reversed_dp = dps_map.pop("reversed", None)
         self._init_end(dps_map)
@@ -115,6 +116,11 @@ class TuyaLocalCover(TuyaLocalEntity, CoverEntity):
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
+        # this fix an issue where is some of shades actions is stuck
+        if self._action_stuck_dp:
+            pos = self.current_cover_position
+            if pos < 100:
+                return self._action_stuck_dp.get_value(self._device) == None
         # If dps is available to inform current action, use that
         if self._action_dp:
             return self._action_dp.get_value(self._device) == "opening"
@@ -130,6 +136,11 @@ class TuyaLocalCover(TuyaLocalEntity, CoverEntity):
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
+        # this fix an issue where is some of shades actions is firmware stuck
+        if self._action_stuck_dp:
+            pos = self.current_cover_position
+            if pos > 0:
+                return self._action_stuck_dp.get_value(self._device) == None
         # If dps is available to inform current action, use that
         if self._action_dp:
             return self._action_dp.get_value(self._device) == "closing"

--- a/custom_components/tuya_local/devices/zemismart_roller_shade.yaml
+++ b/custom_components/tuya_local/devices/zemismart_roller_shade.yaml
@@ -86,7 +86,7 @@ secondary_entities:
         type: string
         name: option
         mapping:
-          - dps_val: continuation
+          - dps_val: contiuation
             value: Auto
           - dps_val: point
             value: Manual

--- a/custom_components/tuya_local/devices/zemismart_roller_shade_v2.yaml
+++ b/custom_components/tuya_local/devices/zemismart_roller_shade_v2.yaml
@@ -86,7 +86,7 @@ secondary_entities:
         type: string
         name: option
         mapping:
-          - dps_val: continuation
+          - dps_val: contiuation
             value: Auto
           - dps_val: point
             value: Manual

--- a/custom_components/tuya_local/devices/zemismart_roller_shade_v2.yaml
+++ b/custom_components/tuya_local/devices/zemismart_roller_shade_v2.yaml
@@ -1,0 +1,135 @@
+name: Roller shade
+products:
+  - id: jzmy5ut0vishwscm
+    name: Zemismart ZM25TQ
+primary_entity:
+  entity: cover
+  class: shade
+  dps:
+    - id: 1
+      name: control
+      type: string
+      mapping:
+        - dps_val: open
+          value: open
+        - dps_val: close
+          value: close
+        - dps_val: stop
+          value: stop
+        - dps_val: continue
+          value: continue
+    - id: 2
+      name: position
+      type: integer
+      range:
+        min: 0
+        max: 100
+      invert: true
+    - id: 3
+      name: current_position
+      type: integer
+      range:
+        min: 0
+        max: 100
+      invert: true
+    - id: 7
+      name: action_stuck
+      type: string
+    - id: 12
+      name: fault_code
+      type: bitfield
+secondary_entities:
+  - entity: select
+    name: Direction
+    icon: "mdi:swap-horizontal"
+    category: config
+    dps:
+      - id: 5
+        type: string
+        name: option
+        mapping:
+          - dps_val: forward
+            value: Forward
+          - dps_val: back
+            value: Reverse
+  - entity: sensor
+    name: Situation
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 11
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: fully_open
+            value: Fully open
+          - dps_val: fully_close
+            value: Fully closed
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 12
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    name: Motor mode
+    icon: "mdi:cog-transfer"
+    category: config
+    dps:
+      - id: 106
+        type: string
+        name: option
+        mapping:
+          - dps_val: continuation
+            value: Auto
+          - dps_val: point
+            value: Manual
+  - entity: button
+    name: Upper limit reset
+    icon: "mdi:arrow-collapse-up"
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: button
+  - entity: button
+    name: Intermediate limit reset
+    icon: "mdi:format-vertical-align-center"
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        name: button
+  - entity: button
+    name: Lower limit reset
+    icon: "mdi:arrow-collapse-down"
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        name: button
+  - entity: button
+    name: Remote pairing
+    icon: "mdi:remote"
+    category: config
+    dps:
+      - id: 101
+        type: boolean
+        name: button
+        optional: true
+  - entity: button
+    name: All limits reset
+    icon: "mdi:refresh"
+    category: config
+    dps:
+      - id: 102
+        type: boolean
+        name: button
+        optional: true
+            


### PR DESCRIPTION
There is a common issue in some covers where is some of them action is stuck on opening or closing and as for my motor is stuck on "opening " and the open button always disabled in HA in case it stuck on "closing" the close button will always be disabled.
This PR contains:
- Fix typo in motor mode continuation -> contiuation ```Probably Tuya typo```
  I don't know for sure if this typo's only in my motor model ```[Blind] 192.168.1.4 - [Off] - DPS: {'1': 'open', '2': 100, '3': 80, '5': 'forward', '7': 'opening', '11': 'fully_open', '12': 0, '103': True, '104': False, '105': True, '106': 'contiuation'}```
- Add new device ```zemismart_roller_shade_v2.yaml``` fixed the shade that have stuck action
- added _action_stuck in cover.py for stuck covers ```This the best way I found without breaking anything```