### PR TITLE
Add Merkury BW904 Smart Bulb and handle  attribute

### DIFF
--- a/custom_components/tuya_local/devices/rgbw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbw_lightbulb.yaml
@@ -1,0 +1,46 @@
+name: RGBW lightbulb
+primary_entity:
+  entity: light
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      name: color_mode
+      type: string
+      mapping:
+        - dps_val: white
+          value: white
+        - dps_val: colour
+          value: rgbw
+    - id: 3
+      name: brightness
+      type: integer
+      range:
+        min: 25
+        max: 255
+    - id: 5
+      name: rgbhsv
+      type: hex
+      format:
+        - name: r
+          bytes: 1
+        - name: g
+          bytes: 1
+        - name: b
+          bytes: 1
+        - name: h
+          bytes: 2
+          range:
+            min: 0
+            max: 360
+        - name: s
+          bytes: 1
+          range:
+            min: 0
+            max: 255
+        - name: v
+          bytes: 1
+          range:
+            min: 0
+            max: 255

--- a/custom_components/tuya_local/devices/rgbw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbw_lightbulb.yaml
@@ -1,4 +1,9 @@
 name: RGBW lightbulb
+products:
+  - id: cqekgipywslyavsr
+    name: Merkury BW904 Smart Bulb
+  - id: p2i2oapbnxftdukj
+    name: Merkury BW904 Smart Bulb
 primary_entity:
   entity: light
   dps:

--- a/custom_components/tuya_local/devices/rgbw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbw_lightbulb.yaml
@@ -44,3 +44,23 @@ primary_entity:
           range:
             min: 0
             max: 255
+    - id: 6
+      name: scene
+      type: hex
+      optional: true
+    - id: 7
+      name: flash_scene1
+      type: hex
+      optional: true
+    - id: 8
+      name: flash_scene2
+      type: hex
+      optional: true
+    - id: 9
+      name: flash_scene3
+      type: hex
+      optional: true
+    - id: 10
+      name: flash_scene4
+      type: hex
+      optional: true

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -53,6 +53,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
         self._color_temp_dps = dps_map.pop("color_temp", None)
         self._rgbhsv_dps = dps_map.pop("rgbhsv", None)
         self._effect_dps = dps_map.pop("effect", None)
+        self._white_dps = dps_map.pop("white", None)
         self._init_end(dps_map)
 
     @property
@@ -214,19 +215,19 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
         if self._color_mode_dps and ATTR_WHITE in params:
             if self.color_mode != ColorMode.WHITE:
                 color_mode = ColorMode.WHITE
-                if (
-                   ATTR_BRIGHTNESS not in params
-                   and self._brightness_dps
-                 ):
-                   bright = params.get(ATTR_WHITE)
-                   _LOGGER.debug(f"Setting brightness via WHITE parameter to {bright}")
-                   settings = {
-                       **settings,
-                       **self._brightness_dps.get_values_to_set(
-                           self._device,
-                           bright,
-                       ),
-                   }
+            if (
+               ATTR_BRIGHTNESS not in params
+               and self._brightness_dps
+             ):
+                bright = params.get(ATTR_WHITE)
+                _LOGGER.debug(f"Setting brightness via WHITE parameter to {bright}")
+                settings = {
+                    **settings,
+                    **self._brightness_dps.get_values_to_set(
+                        self._device,
+                        bright,
+                    ),
+                }
         elif self._color_temp_dps and ATTR_COLOR_TEMP in params:
             if self.color_mode != ColorMode.COLOR_TEMP:
                 color_mode = ColorMode.COLOR_TEMP

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -214,10 +214,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
         if self._color_mode_dps and ATTR_WHITE in params:
             if self.color_mode != ColorMode.WHITE:
                 color_mode = ColorMode.WHITE
-            if (
-               ATTR_BRIGHTNESS not in params
-               and self._brightness_dps
-             ):
+            if ATTR_BRIGHTNESS not in params and self._brightness_dps:
                 bright = params.get(ATTR_WHITE)
                 _LOGGER.debug(f"Setting brightness via WHITE parameter to {bright}")
                 settings = {

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -53,7 +53,6 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
         self._color_temp_dps = dps_map.pop("color_temp", None)
         self._rgbhsv_dps = dps_map.pop("rgbhsv", None)
         self._effect_dps = dps_map.pop("effect", None)
-        self._white_dps = dps_map.pop("white", None)
         self._init_end(dps_map)
 
     @property

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -7,6 +7,7 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_RGBW_COLOR,
+    ATTR_WHITE,
     ColorMode,
     LightEntity,
     LightEntityFeature,
@@ -52,6 +53,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
         self._color_temp_dps = dps_map.pop("color_temp", None)
         self._rgbhsv_dps = dps_map.pop("rgbhsv", None)
         self._effect_dps = dps_map.pop("effect", None)
+        self._white_dps = dps_map.pop("white", None)
         self._init_end(dps_map)
 
     @property
@@ -210,7 +212,23 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
         settings = {}
         color_mode = None
 
-        if self._color_temp_dps and ATTR_COLOR_TEMP in params:
+        if self._color_mode_dps and ATTR_WHITE in params:
+            if self.color_mode != ColorMode.WHITE:
+                color_mode = ColorMode.WHITE
+                if (
+                   ATTR_BRIGHTNESS not in params
+                   and self._brightness_dps
+                 ):
+                   bright = params.get(ATTR_WHITE)
+                   _LOGGER.debug(f"Setting brightness via WHITE parameter to {bright}")
+                   settings = {
+                       **settings,
+                       **self._brightness_dps.get_values_to_set(
+                           self._device,
+                           bright,
+                       ),
+                   }
+        elif self._color_temp_dps and ATTR_COLOR_TEMP in params:
             if self.color_mode != ColorMode.COLOR_TEMP:
                 color_mode = ColorMode.COLOR_TEMP
 


### PR DESCRIPTION
I can split this into 2 PRs if you wish.

I bought some of this bulbs on clearance. Mixture of WIFI 3 (cqekgipywslyavsr) and WIFI4 (p2i2oapbnxftdukj) with identical boxes and product names. 

iot.tuya.com shows same DPs as rgbcw_lightbulbv2.yaml minus the color_temp DP4.  When adding, debug log only shows DPs 1,2,3 and 5 in status so marked others as optional.

light.py doesn't seem handle switching from rgbw to white mode.  Code didn't seem to have a case to handle a `white` parameter sent by HA so I added an additional condition at the top of the main if statement based on my interpretation of how `white` is documented for a HA Light Entity.

This is the first time I am touching Python and HA code so there is a good possibility of a mistake. 
