### PR TITLE
Add Klarstein DryFy Connect support

### DIFF
--- a/custom_components/tuya_local/devices/klarstein_dryfy_connect_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/klarstein_dryfy_connect_dehumidifier.yaml
@@ -1,0 +1,212 @@
+name: Klarstein DryFy Connect
+# {'updated_at': 1674605185.2896934, '1': False, '2': '0', '3': 61, '4': 45, '5': False, '6': '1', '7': False, '8': False, '11': 0, '12': '0', '13': 0, '101': False, '102': False}
+products:
+  - id: to4nyl9qxvkqmcmk
+    name: DryFy Connect
+primary_entity:
+  entity: humidifier
+  class: dehumidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 2
+      name: mode
+      type: string
+      mapping:
+        - dps_val: 0
+          value: Auto
+        - dps_val: 1
+          value: Continuous
+    - id: 4
+      type: integer
+      name: humidity
+      range:
+        min: 35
+        max: 80
+      mapping:
+        - step: 5
+secondary_entities:
+  - entity: sensor
+    name: Current humidity
+    class: humidity
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        class: measurement
+        unit: "%"
+  - entity: fan
+    dps:
+      - id: 8
+        name: switch
+        type: boolean
+      - id: 6
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: 0
+            value: High
+          - dps_val: 1
+            value: Low
+  - entity: lock
+    name: Child Lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+        mapping:
+          - dps_val: true
+            icon: "mdi:hand-back-right"
+          - dps_val: false
+            icon: "mdi:hand-back-right-off"
+  - entity: switch
+    name: Inside Drying
+    icon: "mdi:dots-circle"
+    category: config
+    dps:
+      - id: 101
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Water Pump
+    icon: "mdi:pump"
+    category: config
+    dps:
+      - id: 102
+        name: switch
+        type: boolean
+  - entity: select
+    name: Timer
+    icon: "mdi:timer-settings"
+    category: config
+    dps:
+      - id: 12
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: null
+            value: "Off"
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: 1 hour
+          - dps_val: "2"
+            value: 2 hours
+          - dps_val: "3"
+            value: 3 hours
+          - dps_val: "4"
+            value: 4 hours
+          - dps_val: "5"
+            value: 5 hours
+          - dps_val: "6"
+            value: 6 hours
+          - dps_val: "7"
+            value: 7 hours
+          - dps_val: "8"
+            value: 8 hours
+          - dps_val: "9"
+            value: 9 hours
+          - dps_val: "10"
+            value: 10 hours
+          - dps_val: "11"
+            value: 11 hours
+          - dps_val: "12"
+            value: 12 hours
+          - dps_val: "13"
+            value: 13 hours
+          - dps_val: "14"
+            value: 14 hours
+          - dps_val: "15"
+            value: 15 hours
+          - dps_val: "16"
+            value: 16 hours
+          - dps_val: "17"
+            value: 17 hours
+          - dps_val: "18"
+            value: 18 hours
+          - dps_val: "19"
+            value: 19 hours
+          - dps_val: "20"
+            value: 20 hours
+          - dps_val: "21"
+            value: 21 hours
+          - dps_val: "22"
+            value: 22 hours
+          - dps_val: "23"
+            value: 23 hours
+          - dps_val: "24"
+            value: 24 hours
+  - entity: sensor
+    name: Time remaing
+    icon: "mdi:timer"
+    class: duration
+    category: config
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: min
+
+  - entity: binary_sensor
+    name: Fault
+    icon: mdi:alert
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 11
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: null
+            value: false
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: sensor
+    name: Fault Code
+    icon: mdi:alert
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 11
+        name: sensor
+        type: string
+        readonly: true
+        mapping:
+          - dps_val: null
+            value: OK
+          - dps_val: 0
+            value: OK
+          - dps_val: 1
+            value: Temperature sensor failure (E2)
+          - dps_val: 2
+            value: Coil sensor (E1)
+          - dps_val: 4
+            value: Defrost (P1)
+          - dps_val: 8
+            value: Water full (FL)
+            icon: "mdi:cup-water"
+            icon_priority: 1
+          - dps_val: 16
+            value: Low temperature alarm (LO)
+          - dps_val: 32
+            value: High temperature alarm (HI)
+  - entity: binary_sensor
+    name: WaterTank
+    icon: "mdi:cup-outline"
+    icon-priority: 1
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 11
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 8
+            value: true
+            icon: "mdi:cup-water"
+            icon_priority: 1
+          - value: false


### PR DESCRIPTION
This MR adds full support for the Klarstein DryFy Connect dehumidifier (not the PRO version).

Note: The [PRO version ](https://github.com/make-all/tuya-local/blob/main/custom_components/tuya_local/devices/klarstein_dryfy_pro_connect_dehumidifier.yaml) benefit from this update it just has some additional features.

@make-all Thanks for creating this integration this one is way more flexible then the OOTB one, hope to see this get integrated into the HACS.