### PR TITLE
Added CBI Astute Smart Controller (ASC) breaker switch

### DIFF
--- a/custom_components/tuya_local/devices/asc_wifi_circuit_breaker.yaml
+++ b/custom_components/tuya_local/devices/asc_wifi_circuit_breaker.yaml
@@ -1,0 +1,67 @@
+name: ASC (Wi-Fi)
+product:
+  - id: yrzel5nutomegk6z
+primary_entity:
+  entity: switch
+  dps:
+    - id: 1
+      name: switch
+      type: boolean     
+secondary_entities:
+  - entity: number
+    name: Countdown
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 7
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 0
+            step: 1
+        unit: s
+  - entity: sensor
+    name: Current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        unit: A
+        mapping:
+          - scale: 1000
+        optional: true
+  - entity: sensor
+    name: Voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        unit: V
+        mapping:
+          - scale: 10
+        optional: true
+  - entity: sensor
+    name: Power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: W
+        optional: true
+        mapping:
+          - scale: 10
+
+        
+
+
+            
+


### PR DESCRIPTION
Added the CBI Astute Smart Controller DIN circuit breaker switch. It identifies as ASC (Wi-Fi) on Tuya Cloud. This switch is available in this configuration in South Africa.