### PR TITLE
Fix diagnostics and another device_id usage for subdevices

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -253,7 +253,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    _LOGGER.debug("Unloading entry for device: %s", entry.data[CONF_DEVICE_ID])
+    _LOGGER.debug("Unloading entry for device: %s", get_device_id(entry.data))
     config = entry.data
     data = hass.data[DOMAIN][get_device_id(config)]
     device_conf = get_config(config[CONF_TYPE])
@@ -279,6 +279,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry):
-    _LOGGER.debug("Updating entry for device: %s", entry.data[CONF_DEVICE_ID])
+    _LOGGER.debug("Updating entry for device: %s", get_device_id(entry.data))
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)

--- a/custom_components/tuya_local/diagnostics.py
+++ b/custom_components/tuya_local/diagnostics.py
@@ -14,8 +14,10 @@ from .const import (
     CONF_PROTOCOL_VERSION,
     CONF_TYPE,
     DOMAIN,
+    CONF_DEVICE_CID,
 )
 from .device import TuyaLocalDevice
+from .helpers.config import get_device_id
 
 
 async def async_get_config_entry_diagnostics(
@@ -39,12 +41,13 @@ def _async_get_diagnostics(
     device: DeviceEntry | None = None,
 ) -> dict[str, Any]:
     """Return diagnostics for a tuya-local config entry."""
-    hass_data = hass.data[DOMAIN][entry.data["device_id"]]
+    hass_data = hass.data[DOMAIN][get_device_id(entry.data)]
 
     data = {
         "name": entry.title,
         "type": entry.data[CONF_TYPE],
         "device_id": REDACTED,
+        "device_cid": REDACTED if entry.data.get(CONF_DEVICE_CID, "") != "" else "",
         "local_key": REDACTED,
         "host": REDACTED,
         "protocol_version": entry.data[CONF_PROTOCOL_VERSION],
@@ -63,7 +66,7 @@ def _async_get_diagnostics(
 def _async_device_as_dict(
     hass: HomeAssistant, device: TuyaLocalDevice
 ) -> dict[str, Any]:
-    """Represent a Tuya Local devcie as a dictionary."""
+    """Represent a Tuya Local device as a dictionary."""
 
     # Base device information, without sensitive information
     data = {


### PR DESCRIPTION
Diagnostics returns KeyError for subdevices. I try to find all places and replace it with get_device_id function.