### PR TITLE
Support for Brennenstuhl WFD 3050 P

### DIFF
--- a/custom_components/tuya_local/devices/pir_spotlight.yaml
+++ b/custom_components/tuya_local/devices/pir_spotlight.yaml
@@ -1,0 +1,168 @@
+name: PIR Spotlight
+products:
+  - id: reldobj3ny6fbgvw
+    name: WiFi Duo LED Light WFD 3050 P
+
+primary_entity:
+  entity: light
+  dps:
+    - id: 20
+      type: boolean
+      name: switch
+    - id: 21
+      type: string
+      name: work_mode
+      mapping:
+        - dps_val: colour
+          value: hs
+        - dps_val: white
+          value: white
+        - dps_val: music
+          value: Music
+        - dps_val: scene
+          value: Scene
+    - id: 22
+      name: brightness
+      type: integer
+      range:
+        min: 10
+        max: 1000
+      mapping:
+        - dps_val: null
+        - scale: 3.92
+    - id: 23
+      name: color_temp
+      type: integer
+      optional: true
+      range:
+        min: 0
+        max: 1000
+      mapping:
+        - invert: true
+secondary_entities:
+  - entity: number
+    name: Timer
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 26
+        name: value
+        type: integer
+        optional: true
+        range:
+          min: 0
+          max: 86400
+        unit: min
+        mapping:
+          - scale: 60
+            step: 60
+          - dps_val: null
+  - entity: select
+    name: Mode
+    category: config
+    dps:
+      - id: 51
+        type: string
+        name: option
+        mapping:
+          - dps_val: auto
+            value: Sensor
+          - dps_val: manual
+            value: Manual
+  - entity: switch
+    name: PIR enabled
+    category: config
+    dps:
+      - id: 56
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    class: motion
+    dps:
+      - id: 52
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "pir"
+            value: true
+          - dps_val: "none"
+            value: false
+  - entity: select
+    name: Motion Distance
+    category: config
+    dps:
+      - id: 54
+        type: string
+        name: option
+        mapping:
+          - dps_val: "high"
+            value: "Far"
+          - dps_val: "low"
+            value: "Near"
+          - dps_val: "middle"
+            value: "Medium"
+  - entity: number
+    name: Full light duration
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 55
+        name: value
+        type: integer
+        range:
+          min: 5
+          max: 3600
+        unit: s
+        mapping:
+          - scale: 1
+          - dps_val: null
+  - entity: number
+    name: Standby Delay
+    category: config
+    dps:
+      - id: 58
+        name: value
+        type: integer
+        range:
+          min: 1
+          max: 480
+        unit: m
+        mapping:
+          - scale: 1
+          - dps_val: null
+  - entity: number
+    name: Standby Bright
+    category: config
+    dps:
+      - id: 59
+        name: value
+        type: integer
+        range:
+          min: 0
+          max: 1000
+        unit: m
+        mapping:
+          - scale: 1
+          - dps_val: null
+  - entity: select
+    name: Ambient Light Sensor
+    category: config
+    dps:
+      - id: 53
+        type: string
+        name: option
+        mapping:
+          - dps_val: 10lux
+            value: 10lux
+          - dps_val: 2000lux
+            value: 2000lux
+          - dps_val: 300lux
+            value: 300lux
+          - dps_val: 50lux
+            value: 50lux
+          - dps_val: 10lux
+            value: 10lux
+          - dps_val: 5lux
+            value: 5lux
+          - dps_val: now
+            value: Now

--- a/custom_components/tuya_local/devices/pir_spotlight.yaml
+++ b/custom_components/tuya_local/devices/pir_spotlight.yaml
@@ -12,15 +12,6 @@ primary_entity:
     - id: 21
       type: string
       name: work_mode
-      mapping:
-        - dps_val: colour
-          value: hs
-        - dps_val: white
-          value: white
-        - dps_val: music
-          value: Music
-        - dps_val: scene
-          value: Scene
     - id: 22
       name: brightness
       type: integer
@@ -58,7 +49,7 @@ secondary_entities:
             step: 60
           - dps_val: null
   - entity: switch
-    name: Manual Mode
+    name: Manual mode
     category: config
     dps:
       - id: 51
@@ -94,7 +85,7 @@ secondary_entities:
         optional: true
         force: true
   - entity: select
-    name: Motion Distance
+    name: Motion distance
     category: config
     dps:
       - id: 54
@@ -127,7 +118,7 @@ secondary_entities:
         optional: true
         force: true
   - entity: number
-    name: Standby Delay
+    name: Standby delay
     category: config
     dps:
       - id: 58
@@ -143,7 +134,7 @@ secondary_entities:
         optional: true
         force: true
   - entity: number
-    name: Standby Bright
+    name: Standby bright
     category: config
     dps:
       - id: 59
@@ -159,7 +150,7 @@ secondary_entities:
         optional: true
         force: true
   - entity: select
-    name: Ambient Light Sensor
+    name: Ambient light sensor
     category: config
     dps:
       - id: 53

--- a/custom_components/tuya_local/devices/pir_spotlight.yaml
+++ b/custom_components/tuya_local/devices/pir_spotlight.yaml
@@ -57,18 +57,20 @@ secondary_entities:
           - scale: 60
             step: 60
           - dps_val: null
-  - entity: select
-    name: Mode
+  - entity: switch
+    name: Manual Mode
     category: config
     dps:
       - id: 51
         type: string
-        name: option
+        name: switch
         mapping:
-          - dps_val: auto
-            value: Sensor
-          - dps_val: manual
-            value: Manual
+        - dps_val: auto
+          value: false
+        - dps_val: manual
+          value: true
+        optional: true
+        force: true
   - entity: switch
     name: PIR enabled
     category: config
@@ -76,6 +78,8 @@ secondary_entities:
       - id: 56
         type: boolean
         name: switch
+        optional: true
+        force: true
   - entity: binary_sensor
     class: motion
     dps:
@@ -87,6 +91,8 @@ secondary_entities:
             value: true
           - dps_val: "none"
             value: false
+        optional: true
+        force: true
   - entity: select
     name: Motion Distance
     category: config
@@ -101,6 +107,8 @@ secondary_entities:
             value: "Near"
           - dps_val: "middle"
             value: "Medium"
+        optional: true
+        force: true
   - entity: number
     name: Full light duration
     category: config
@@ -112,10 +120,12 @@ secondary_entities:
         range:
           min: 5
           max: 3600
-        unit: s
+        unit: sec
         mapping:
           - scale: 1
           - dps_val: null
+        optional: true
+        force: true
   - entity: number
     name: Standby Delay
     category: config
@@ -126,10 +136,12 @@ secondary_entities:
         range:
           min: 1
           max: 480
-        unit: m
+        unit: min
         mapping:
           - scale: 1
           - dps_val: null
+        optional: true
+        force: true
   - entity: number
     name: Standby Bright
     category: config
@@ -140,10 +152,12 @@ secondary_entities:
         range:
           min: 0
           max: 1000
-        unit: m
+        unit: min
         mapping:
           - scale: 1
           - dps_val: null
+        optional: true
+        force: true
   - entity: select
     name: Ambient Light Sensor
     category: config
@@ -166,3 +180,5 @@ secondary_entities:
             value: 5lux
           - dps_val: now
             value: Now
+        optional: true
+        force: true


### PR DESCRIPTION
This adds supports for a PIR-activated spotlight that I have: [Brennenstuhl WFD 3050 P](https://www.brennenstuhl.co.uk/en-GB/products/led-floodlights/brennenstuhl-r-connect-led-wifi-duo-spotlight-with-motion-detector-wfd-3050-p-3500lm-pir-ip54).

The device has white-only light and 2 modes:
- Sensor mode: the light is activated automatically on motion and is switched off after some configurable time
- Manual mode: the light can be activated by a switch and you can control both the temperature and brightness.

For sensor mode there are some configuration options like:
- Sensitivity of the sensor
- Time after the light is dimmed and how dim the light should be
- Time after the light is switched off completely

There is also a switch to set the PIR sensor off, which (in sensor mode) effectively disables the light completely. So there really are **3 modes**: off/sensor/manual, but there are 2 dpids to control it, so I didn't know how to model this in yaml.

Not sure which of these dpids should be made optional... in my device they all are reported via broadcast.