### PR TITLE
Add support for Stadler Form Karl / Karl big

### DIFF
--- a/custom_components/tuya_local/devices/stadlerform_karl_humidifier.yaml
+++ b/custom_components/tuya_local/devices/stadlerform_karl_humidifier.yaml
@@ -1,0 +1,114 @@
+name: Stadler Form Karl / Karl big
+products:
+  - id: gi2d3je5upa9ngx4
+    name: Stadler Form Karl
+  - id: qgv0pltei9nuuatv
+    name: Stadler Form Karl big
+primary_entity:
+  entity: humidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 103
+      name: humidity
+      type: integer
+      range:
+        min: 40
+        max: 55
+      mapping:
+        - step: 5
+    - id: 102
+      type: boolean
+      name: mode
+      mapping:
+        - dps_val: true
+          value: Auto
+        - dps_val: false
+          value: Continuous
+secondary_entities:
+  - entity: sensor
+    name: Humidity
+    class: humidity
+    dps:
+      - id: 14
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    name: Low water
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: lock
+    name: Child lock   
+    category: config
+    dps:
+      - id: 29
+        type: boolean
+        name: lock
+        mapping:
+          - dps_val: true
+            icon: "mdi:hand-back-right-off"
+          - dps_val: false
+            icon: "mdi:hand-back-right"
+  - entity: sensor
+    name: Filter
+    icon: "mdi:filter"
+    category: diagnostic
+    dps:
+      - id: 33 
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: light
+    name: Lights
+    category: config
+    dps:
+      - id: 34
+        name: brightness
+        type: string
+        mapping:
+          - dps_val: "Fully"
+            value: 255
+          - dps_val: "Half"
+            value: 128
+          - dps_val: "Close"
+            value: 0
+  - entity: fan
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 101
+        name: speed
+        type: string
+        mapping:
+          - dps_val: "level_1"
+            value: 25
+          - dps_val: "level_2"
+            value: 50
+          - dps_val: "level_3"
+            value: 75
+          - dps_val: "level_4"
+            value: 100
+  - entity: binary_sensor
+    name: Filter change
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 104
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true


### PR DESCRIPTION
This adds supports for Stadler Form Karl and Karl big that I have:
[Stadler Form Karl][(https://www.stadlerform.com/en/humidifier/karl-black-k-004](https://www.stadlerform.com/en/humidifier/karl-black-k-004))
[Stadler Form Karl big][(https://www.stadlerform.com/en/humidifier/karl-big-black-k-006](https://www.stadlerform.com/en/humidifier/karl-big-black-k-006))

I managed to get all required information from Tuya Cloud and this thread [[LocalTuya: Stadler Form Eva Humidifier](https://community.home-assistant.io/t/localtuya-stadler-form-eva-humidifier/414349)][(https://community.home-assistant.io/t/localtuya-stadler-form-eva-humidifier/414349/8](https://community.home-assistant.io/t/localtuya-stadler-form-eva-humidifier/414349/8))

Only gotchas I detected are as follows:
- Lights can be turned off but switching the lights on via toggle does not wor
- Both devices are detected but the global name "Stadler Form Karl / Karl big" is shown instead the name from product id

Here is a screenshot from Home Assistant:

![grafik](https://github.com/make-all/tuya-local/assets/2655169/b8710199-3396-4b9c-9df1-a808d154cf6c)
