### PR TITLE
Add 9in1 Air Quality Monitor

### DIFF
--- a/custom_components/tuya_local/devices/9in1_airquality_monitor.yaml
+++ b/custom_components/tuya_local/devices/9in1_airquality_monitor.yaml
@@ -41,9 +41,6 @@ secondary_entities:
         name: sensor
         unit: "%"
         class: measurement
-        range:
-          min: 0
-          max: 100
   - entity: sensor
     name: CO2
     class: carbon_dioxide
@@ -74,9 +71,6 @@ secondary_entities:
         name: sensor
         unit: µg/m³
         class: measurement
-        range:
-          min: 0
-          max: 1000
         mapping:
           - scale: 1
             step: 1
@@ -90,9 +84,6 @@ secondary_entities:
         name: sensor
         unit: µg/m³
         class: measurement
-        range:
-          min: 0
-          max: 999
         mapping:
           - scale: 1
             step: 1
@@ -106,9 +97,6 @@ secondary_entities:
         name: sensor
         unit: µg/m³
         class: measurement
-        range:
-          min: 0
-          max: 999
   - entity: sensor
     name: PM 10
     class: pm10
@@ -119,9 +107,6 @@ secondary_entities:
         name: sensor
         unit: µg/m³
         class: measurement
-        range:
-          min: 0
-          max: 999
   - entity: sensor
     name: Battery
     class: battery
@@ -132,9 +117,6 @@ secondary_entities:
         name: sensor
         unit: "%"
         class: measurement
-        range:
-          min: 0
-          max: 100
   - entity: sensor
     name: Charge State
     class: enum
@@ -150,7 +132,6 @@ secondary_entities:
           - dps_val: true
             value: "Charging"
             icon: "mdi:battery-charging"
-            default: true
   - entity: sensor
     name: Alarm Volume
     category: diagnostic

--- a/custom_components/tuya_local/devices/9in1_airquality_monitor.yaml
+++ b/custom_components/tuya_local/devices/9in1_airquality_monitor.yaml
@@ -1,0 +1,161 @@
+name: Air Quality
+products:
+  - id: rqhuxgkizawedhxj
+    name: ZN-2C09
+  - id: rqhuxgkizawedhxj
+primary_entity:
+  entity: sensor
+  name: Air Quality
+  class: enum
+  icon: "mdi:factory"
+  dps:
+    - id: 1
+      type: string
+      name: sensor
+      readonly: true
+      mapping:
+        - dps_val: "level_1"
+          value: "Excellent"
+        - dps_val: "level_2"
+          value: "Good"
+        - dps_val: level_3
+          value: "Lightly polluted"
+
+secondary_entities:
+  - entity: sensor
+    name: Temperature
+    class: temperature
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Humidity
+    class: humidity
+    icon: "mdi:water-percent"
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        range:
+          min: 0
+          max: 100
+  - entity: sensor
+    name: CO2
+    class: carbon_dioxide
+    icon: "mdi:factory"
+    dps:
+      - id: 4
+        type: integer
+        name: sensor
+        unit: ppm
+        class: measurement
+  - entity: sensor
+    name: CO
+    class: carbon_monoxide
+    icon: "mdi:factory"
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: ppm
+        class: measurement
+  - entity: sensor
+    name: HCHO
+    class: volatile_organic_compounds
+    icon: "mdi:factory"
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: µg/m³
+        class: measurement
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - scale: 1
+            step: 1
+  - entity: sensor
+    name: TVOC
+    class: volatile_organic_compounds
+    icon: "mdi:factory"
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: µg/m³
+        class: measurement
+        range:
+          min: 0
+          max: 999
+        mapping:
+          - scale: 1
+            step: 1
+  - entity: sensor
+    name: PM 2.5
+    class: pm25
+    icon: "mdi:factory"
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: µg/m³
+        class: measurement
+        range:
+          min: 0
+          max: 999
+  - entity: sensor
+    name: PM 10
+    class: pm10
+    icon: "mdi:factory"
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: µg/m³
+        class: measurement
+        range:
+          min: 0
+          max: 999
+  - entity: sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        range:
+          min: 0
+          max: 100
+  - entity: sensor
+    name: Charge State
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 23
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: false
+            value: "Battery"
+            icon: "mdi:battery"
+          - dps_val: true
+            value: "Charging"
+            icon: "mdi:battery-charging"
+            default: true
+  - entity: sensor
+    name: Alarm Volume
+    category: diagnostic
+    icon: "mdi:signal"
+    dps:
+      - id: 28
+        type: string
+        name: sensor


### PR DESCRIPTION
Add support for the `ZN-2C09` 9in1 Air Quality Monitor

https://fr.aliexpress.com/item/1005005418667771.html
<img width="338" alt="CleanShot 2023-06-02 at 12 17 16" src="https://github.com/make-all/tuya-local/assets/333081/e54bbd37-840c-41ef-8a51-e7e076327f4e">

