### PR TITLE
Added Support for Catit Pixi Smart Feeder

### DIFF
--- a/custom_components/tuya_local/devices/Catit_cat_feeder.yaml
+++ b/custom_components/tuya_local/devices/Catit_cat_feeder.yaml
@@ -1,0 +1,45 @@
+name: Catit Cat Feeder
+primary_entity:
+  entity: button
+  name: Quick Feed
+  icon: "mdi:food-drumstick"
+  dps:
+    - id: 2
+      type: boolean
+      name: button
+      optional: true
+    - id: 1
+      name: meal_plan
+      type: string
+      optional: true
+secondary_entities:
+  - entity: sensor
+    icon: "mdi:paw"
+    name: Feed report
+    category: diagnostic
+    dps:
+      - id: 15
+        name: sensor
+        type: integer
+        optional: true
+  - entity: button
+    class: restart
+    name: Factory reset
+    category: config
+    dps:
+      - id: 9
+        type: boolean
+        name: button
+        optional: true
+  - entity: number
+    icon: "mdi:paw"
+    name: Manual feed
+    category: config
+    dps:
+      - id: 3
+        name: value
+        type: integer
+        range:
+          min: 1
+          max: 12
+        optional: true

--- a/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
@@ -1,4 +1,4 @@
-name: Catit Cat Feeder
+name: Catit Pixi Smart Feeder
 primary_entity:
   entity: button
   name: Quick Feed

--- a/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
@@ -21,7 +21,7 @@ secondary_entities:
       - id: 15
         name: sensor
         type: integer
-        optional: true
+        optional: false
   - entity: button
     class: restart
     name: Factory reset
@@ -42,4 +42,4 @@ secondary_entities:
         range:
           min: 1
           max: 12
-        optional: true
+        optional: false


### PR DESCRIPTION
Basically a copy of the catit 6 feeder device with tweaked device IDs for the catit smart feeder 

for this device : 
https://www.amazon.co.uk/Catit-Feeder-Automatic-Feeding-Station/dp/B093MF7X18/ref=sr_1_8?crid=1OC13MDXL5BKO&keywords=catit+feeder&qid=1685732265&sprefix=catit+feeder%2Caps%2C74&sr=8-8 

This is the dps:

{
  "result": {
    "category": "cwwsq",
    "functions": [
      {
        "code": "meal_plan",
        "dp_id": 1,
        "type": "Raw",
        "values": "{}"
      },
      {
        "code": "quick_feed",
        "dp_id": 2,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "manual_feed",
        "dp_id": 3,
        "type": "Integer",
        "values": "{\"min\":1,\"max\":12,\"scale\":0,\"step\":1}"
      },
      {
        "code": "factory_reset",
        "dp_id": 9,
        "type": "Boolean",
        "values": "{}"
      }
    ],
    "status": [
      {
        "code": "meal_plan",
        "dp_id": 1,
        "type": "Raw",
        "values": "{}"
      },
      {
        "code": "quick_feed",
        "dp_id": 2,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "manual_feed",
        "dp_id": 3,
        "type": "Integer",
        "values": "{\"min\":1,\"max\":12,\"scale\":0,\"step\":1}"
      },
      {
        "code": "factory_reset",
        "dp_id": 9,
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "feed_report",
        "dp_id": 15,
        "type": "Integer",
        "values": "{\"min\":0,\"max\":12,\"scale\":0,\"step\":1}"
      }
    ]
  },