### PR TITLE
Add support for NovaDigital Switch (single/quad)

### DIFF
--- a/custom_components/tuya_local/devices/novadigital_quad_switch.yaml
+++ b/custom_components/tuya_local/devices/novadigital_quad_switch.yaml
@@ -1,0 +1,121 @@
+# Example DPS Status
+# {'dps': {'1': True, '2': True, '3': True, '4': True, '7': 0, '8': 0, '9': 0, '10': 0, '14': '0', '16': True}}
+name: Novadigital Quad Switch
+products:
+  - id: 6u3rzfddlfajqvn5
+    name: Interruptor touch novadigital
+primary_entity:
+  entity: switch
+  name: Switch 1
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+secondary_entities:
+  - entity: switch
+    name: Switch 2
+    dps:
+      - id: 2
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Switch 3
+    dps:
+      - id: 3
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Switch 4
+    dps:
+      - id: 4
+        name: switch
+        type: boolean
+  - entity: number
+    category: config
+    name: Timer Switch 1
+    icon: "mdi:timer"
+    dps:
+      - id: 7
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    name: Timer Switch 2
+    icon: "mdi:timer"
+    dps:
+      - id: 8
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    name: Timer Switch 3
+    icon: "mdi:timer"
+    dps:
+      - id: 9
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    name: Timer Switch 4
+    icon: "mdi:timer"
+    dps:
+      - id: 10
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: select
+    category: config
+    name: Restore power state
+    icon: "mdi:power-settings"
+    dps:
+      - id: 14
+        name: option
+        type: string
+        mapping:
+          - dps_val: 0
+            value: "Off"
+          - dps_val: 1
+            value: "On"
+          - dps_val: 2
+            value: Remember Last Status
+        optional: true
+        force: true
+  - entity: light
+    name: "Backlight"
+    category: config
+    dps:
+      - id: 16
+        name: switch
+        type: boolean
+        mapping:
+          - dps_val: true
+            icon: "mdi:lightbulb-on"
+          - dps_val: false
+            icon: "mdi:lightbulb-outline"

--- a/custom_components/tuya_local/devices/novadigital_quad_switch.yaml
+++ b/custom_components/tuya_local/devices/novadigital_quad_switch.yaml
@@ -3,7 +3,7 @@
 name: Novadigital Quad Switch
 products:
   - id: 6u3rzfddlfajqvn5
-    name: Interruptor touch novadigital
+    name: Novadigital quad switch
 primary_entity:
   entity: switch
   name: Switch 1


### PR DESCRIPTION
Add support for [NovaDigital Switch](https://www.novadigitalsmart.com.br/produtos/interruptor-touch-wi-fi-ws-us)

- Single:
<img width="337" alt="image" src="https://github.com/make-all/tuya-local/assets/19254287/e7250cab-d3dc-4d2f-aeac-df1bdbd3be79">


- Quad:
<img width="349" alt="image" src="https://github.com/make-all/tuya-local/assets/19254287/d925bd55-a9c5-4d38-8f27-6078d15781fd">
