### PR TITLE
arlec_thermostat_smartplug: Correct typo in device yaml

### DIFF
--- a/custom_components/tuya_local/devices/arlec_thermostat_smartplug.yaml
+++ b/custom_components/tuya_local/devices/arlec_thermostat_smartplug.yaml
@@ -199,7 +199,7 @@ secondary_entities:
     dps:
       - id: 29
         type: integer
-        name: value 
+        name: value
         range:
           min: 10
           max: 90
@@ -295,5 +295,5 @@ secondary_entities:
           - dps_val: 0
             value: false
           - dps_val: null
-            value:: false
+            value: false
           - value: true


### PR DESCRIPTION
Double colon means `"value:": false`