### PR TITLE
Update wistar_roller_blind_nopos to match Tuya and TuyaLocal pre-2023…

### DIFF
--- a/custom_components/tuya_local/devices/wistar_roller_blind_nopos.yaml
+++ b/custom_components/tuya_local/devices/wistar_roller_blind_nopos.yaml
@@ -22,7 +22,15 @@ primary_entity:
         min: 0
         max: 100
       mapping:
-        - invert: true
+        - invert: false
+    - id: 103
+      type: boolean
+      name: reversed
+      mapping:
+        - dps_val: true
+          value: false
+        - dps_val: false
+          value: true
     - id: 105
       type: boolean
       name: curtain_hand
@@ -138,3 +146,8 @@ secondary_entities:
       - id: 103
         type: boolean
         name: switch
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true


### PR DESCRIPTION
For the primary entity cover: Inverted dp_id 102, re-added dp_id 103 with inverted mapping.
Inverted the mapping of secondary entity switch dp_id 103.