### PR TITLE
[BUGFIX] Feit-dimmer: Removing optional and DPS null value to make it work

### DIFF
--- a/custom_components/tuya_local/devices/feit_dimmer.yaml
+++ b/custom_components/tuya_local/devices/feit_dimmer.yaml
@@ -9,10 +9,6 @@ primary_entity:
     - id: 1
       name: switch
       type: boolean
-      optional: true
-      mapping:
-        - dps_val: null
-          value: false
     - id: 2
       name: brightness
       type: integer


### PR DESCRIPTION
WIthout this fix, I can add the device, it reads the switch status, but when trying to control it dows not work.