### PR TITLE
Create costway_portable_ac.yaml

### DIFF
--- a/custom_components/tuya_local/devices/costway_portable_ac.yaml
+++ b/custom_components/tuya_local/devices/costway_portable_ac.yaml
@@ -1,0 +1,65 @@
+name: COSTWAY Portable Air Conditioner
+products:
+  - id: 86sjxqebxymrjt3z
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+          icon: "mdi:hvac-off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: cold
+              icon: "mdi:snowflake"
+              value: cool
+            - dps_val: wind
+              icon: "mdi:fan"
+              value: fan_only
+            - dps_val: wet
+              icon: "mdi:water"
+              value: dry
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 16
+        max: 30
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: C
+              range:
+                min: 16
+                max: 31
+    - id: 3
+      type: integer
+      name: current_temperature
+    - id: 4
+      type: string
+      name: mode
+      hidden: true
+    - id: 5
+      type: string
+      name: fan_mode
+      mapping:
+        - dps_val: low
+          value: low
+        - dps_val: high
+          value: high
+    - id: 20
+      type: integer
+      name: unknow_20
+    - id: 103
+      type: boolean
+      name: unknown_103
+    - id: 107
+      type: integer
+      name: unknown_106
+    - id: 109
+      type: integer
+      name: unknown_107


### PR DESCRIPTION
Add support for Costway Portable AC. 

All important functions are included, modes, and actual temperature ranges the devices uses. 

Not included: Error message (eg. water tank full, not very useful device will not cool unless tank is emptied anyway), Temperature unit swapping (Can be swapped on device and left alone thereafter) 