### PR TITLE
Add Elesion Outdoor Siren

### DIFF
--- a/custom_components/tuya_local/devices/elesion_outdoor_siren.yaml
+++ b/custom_components/tuya_local/devices/elesion_outdoor_siren.yaml
@@ -1,0 +1,65 @@
+name: Elesion outdoor siren
+product:
+  - id: likuc5ld1ap3apcm
+    model: NX-4980
+primary_entity:
+  entity: siren
+  dps:
+    - id: 1
+      name: tone
+      type: string
+      mapping:
+        - dps_val: alarm_sound
+          value: sound
+        - dps_val: alarm_light
+          value: light
+        - dps_val: alarm_sound_light
+          value: soundlight
+          default: true
+        - dps_val: normal
+          value: "off"
+    - id: 5
+      name: volume_level
+      type: string
+      mapping:
+        - dps_val: mute
+          value: 0.0
+        - dps_val: low
+          value: 0.33
+        - dps_val: middle
+          value: 0.67
+        - dps_val: high
+          value: 1.0
+    - id: 7
+      name: duration
+      type: integer
+      range:
+        min: 1
+        max: 10
+      unit: min
+secondary_entities:
+  - entity: binary_sensor
+    name: Charging
+    category: diagnostic
+    class: battery_charging
+    dps:
+      - id: 6
+        name: sensor
+        type: boolean
+  - entity: sensor
+    name: Battery
+    category: diagnostic
+    class: battery
+    dps:
+      - id: 15
+        name: sensor
+        type: integer
+        unit: "%"
+  - entity: binary_sensor
+    name: Tamper detect
+    category: diagnostic
+    class: tamper
+    dps:
+      - id: 20
+        name: sensor
+        type: boolean


### PR DESCRIPTION
Adding outdoor siren sold by Pearl and controlled by Elesion App. More information about device:

Model Name: NX-4980
Distributor: Pearl
Creator: VisorTech
https://www.pearl.de/a-ZX5035-3110.shtml

Siren is working with this configuration perfectly for myself.

Code has been copied from orion_outdoor_siren.yaml file and id adjusted.