### PR TITLE
Fixed asyncio.sleep() not being awaited

### DIFF
--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -294,7 +294,7 @@ class TuyaLocalDevice(object):
                         self._api.receive,
                     )
                 else:
-                    asyncio.sleep(5)
+                    await asyncio.sleep(5)
                     poll = None
 
                 if poll:


### PR DESCRIPTION
Those yellow warnings in HA logs are annoying.