### PR TITLE
Fixed brightness scaling issue for CCT lightbulb + added 2 product details

### DIFF
--- a/custom_components/tuya_local/devices/cct_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/cct_lightbulb.yaml
@@ -4,6 +4,10 @@ products:
     name: A60 lightbulb
   - id: znfxaaxc89zz6m5a
     name: A65 lightbulb
+  - id: c59bbbt5xsm6fkkk
+    name: Laser 10W Smart White Bulb E27
+  - id: t6kkutyhtbbohacx
+    name: Connect 10W Smart White Bulb E27
 primary_entity:
   entity: light
   dps:


### PR DESCRIPTION
By chance I noticed that setting full brightness in HA for my 2 tuya based CCT lightbulbs from different brands is showing up as 25% brightness in the tuya app. More importantly, when I turned up the brightness in tuya app, the bulbs did get brighter accordingly. I compared the model definition returned by tuya's API with the yaml file and found them to be the same hence I figured this is a scaling issue instead. With this change, both HA and tuya app now shows the same brightness level.