### PR TITLE
Create aquatech_x6_water_heater.yaml

### DIFF
--- a/custom_components/tuya_local/devices/aquatech_x6_water_heater.yaml
+++ b/custom_components/tuya_local/devices/aquatech_x6_water_heater.yaml
@@ -1,0 +1,68 @@
+name: Aquatech RAPID/X6
+primary_entity:
+  entity: water_heater
+  dps:
+    - id: 1
+      type: boolean
+      name: operation_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: work_mode
+          conditions:
+            - dps_val: ECO
+              value: eco
+              icon: "mdi:cash"
+            - dps_val: Stand
+              value: heat_pump
+              icon: "mdi:heat-pump"
+            - dps_val: HYB
+              value: high_demand
+              icon: "mdi:sun-thermometer"
+            - dps_val: HYB1
+              value: performance
+              icon: "mdi:radiator"
+            - dps_val: ELE
+              value: electric
+              icon: "mdi:heating-coil"
+    - id: 2
+      type: string
+      name: work_mode
+      hidden: true
+    - id: 4
+      type: integer
+      name: temperature
+      range:
+        min: 15
+        max: 75
+      readonly: true
+      icon: "mdi:thermometer-lines"
+    - id: 7
+      type: boolean
+      name: defrosting
+      mapping:
+        - dps_val: true
+          icon: "mdi:snowflake-melt"
+        - dps_val: false
+          icon: "mdi:checkbox-blank-off-outline"
+    - id: 15
+      type: bitfield
+      name: fault_code
+    - id: 16
+      type: integer
+      name: current_temperature
+      icon: "mdi:thermometer-water"
+secondary_entities:
+  - entity: binary_sensor
+    class: problem
+    name: Fault
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true


### PR DESCRIPTION
This matches issue #834 (Request support for Aquatech Rapid/X6 Heat Pump Water Heater).

It is correctly retrieving the temperatures, but I haven't figured out how to get 'defrost' as an attribute in HA. I presume it would need a secondary entity?

I have also excluded any DPs that are just returning zero for me. (See examples in the Issue showing values when the Heat Pump is ON and OFF.)