### PR TITLE
Fix the encoded length of masked datapoint values

### DIFF
--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -866,8 +866,9 @@ class TuyaDpsConfig:
                 raise ValueError(f"{self.name} ({value}) must be between {mn} and {mx}")
 
         if mask and isinstance(result, Number):
+            # mask is in hex, 2 digits/characters per byte
+            length = int(len(mask) / 2)
             # Convert to int
-            length = len(mask)
             mask = int(mask, 16)
             mask_scale = mask & (1 + ~mask)
             current_value = int.from_bytes(self.decoded_value(device), "big")


### PR DESCRIPTION
Without this fix, the encoded value is longer than the input value. For example, the input hex value `8008` with a mask of `0008` will be encoded as `00008008`. The mask value is in hex, so its length has to be halved for the `to_bytes` call because 1 byte is represented as two hexadecimal digits.

I could not find any defined device with a settable entity with masked mapping, so this change does not affect any of the currently existing devices. I have added unit tests for `device_config` to validate the expected behavior when an entity like this is set.