### PR TITLE
Starlight heatpump: add entities for existing dps (+unit tests)

### DIFF
--- a/custom_components/tuya_local/devices/starlight_heatpump.yaml
+++ b/custom_components/tuya_local/devices/starlight_heatpump.yaml
@@ -116,13 +116,13 @@ primary_entity:
       type: string
       hidden: true
     - id: 119
-      name: unknown_119
+      name: electricity_management
       type: string
     - id: 120
       name: unknown_120
       type: string
     - id: 123
-      name: unknown_123
+      name: flags
       type: string
     - id: 126
       name: vertical_flow_position
@@ -240,3 +240,97 @@ secondary_entities:
             value: Slight Right
           - dps_val: "5"
             value: Rightmost
+  - entity: select
+    name: Sleep mode
+    category: config
+    icon: "mdi:weather-night"
+    dps:
+      - id: 105
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "Off"
+          - dps_val: "normal"
+            value: Standard
+          - dps_val: "old"
+            value: "Elderly"
+          - dps_val: "child"
+            value: "Child"
+  - entity: switch
+    name: Display
+    category: config
+    icon: "mdi:lightbulb-on-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "0008"
+  - entity: switch
+    name: Buzzer
+    category: config
+    icon: "mdi:access-point"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "0010"
+  - entity: switch
+    name: Soft wind
+    category: config
+    icon: "mdi:weather-windy"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "8000"
+  - entity: switch
+    name: Anti-mildew
+    category: config
+    icon: "mdi:water-off-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "0100"
+  - entity: switch
+    name: Health
+    category: config
+    icon: "mdi:heart-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "0020"
+  - entity: switch
+    name: Anti-freeze
+    category: config
+    icon: "mdi:radiator"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "1000"
+  - entity: switch
+    name: Eco mode
+    category: config
+    icon: "mdi:leaf"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - scale: 1
+            mask: "0001"

--- a/tests/devices/test_starlight_heatpump.py
+++ b/tests/devices/test_starlight_heatpump.py
@@ -1,0 +1,162 @@
+from homeassistant.components.climate.const import (
+    ClimateEntityFeature,
+)
+
+from ..const import STARLIGHT_HEATPUMP_PAYLOAD
+from ..helpers import assert_device_properties_set
+from ..mixins.climate import TargetTemperatureTests
+from .base_device_tests import TuyaDeviceTestCase
+
+TEMPERATURE_DPS = "2"
+FLAGS_DPS = "123"
+
+
+class TestStarLightHeatpump(
+    TargetTemperatureTests,
+    TuyaDeviceTestCase,
+):
+    __test__ = True
+
+    def setUp(self):
+        self.setUpForConfig("starlight_heatpump.yaml", STARLIGHT_HEATPUMP_PAYLOAD)
+        self.subject = self.entities["climate"]
+        self.display_switch = self.entities.get("switch_display")
+        self.buzzer_switch = self.entities.get("switch_buzzer")
+        self.soft_wind_switch = self.entities.get("switch_soft_wind")
+        self.setUpTargetTemperature(
+            TEMPERATURE_DPS,
+            self.subject,
+            min=16.0,
+            max=31.0,
+            scale=10,
+            step=5,
+        )
+        self.mark_secondary(
+            [
+                "sensor_current_humidity",
+                "select_vertical_swing",
+                "select_vertical_position",
+                "select_horizontal_swing",
+                "select_horizontal_position",
+                "select_sleep_mode",
+                "switch_display",
+                "switch_buzzer",
+                "switch_soft_wind",
+                "switch_anti_mildew",
+                "switch_health",
+                "switch_anti_freeze",
+                "switch_eco_mode",
+            ]
+        )
+
+    def test_supported_features(self):
+        self.assertEqual(
+            self.subject.supported_features,
+            (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.FAN_MODE
+                | ClimateEntityFeature.SWING_MODE
+            ),
+        )
+
+    def test_display_is_on(self):
+        self.dps[FLAGS_DPS] = "0000"
+        self.assertFalse(self.display_switch.is_on)
+        self.dps[FLAGS_DPS] = "0008"
+        self.assertTrue(self.display_switch.is_on)
+        self.dps[FLAGS_DPS] = "8001"
+        self.assertFalse(self.display_switch.is_on)
+        self.dps[FLAGS_DPS] = "8009"
+        self.assertTrue(self.display_switch.is_on)
+
+    def test_buzzer_is_on(self):
+        self.dps[FLAGS_DPS] = "0008"
+        self.assertFalse(self.buzzer_switch.is_on)
+        self.dps[FLAGS_DPS] = "0018"
+        self.assertTrue(self.buzzer_switch.is_on)
+        self.dps[FLAGS_DPS] = "8000"
+        self.assertFalse(self.buzzer_switch.is_on)
+        self.dps[FLAGS_DPS] = "8010"
+        self.assertTrue(self.buzzer_switch.is_on)
+
+    def test_soft_wind_is_on(self):
+        self.dps[FLAGS_DPS] = "0000"
+        self.assertFalse(self.soft_wind_switch.is_on)
+        self.dps[FLAGS_DPS] = "0008"
+        self.assertFalse(self.soft_wind_switch.is_on)
+        self.dps[FLAGS_DPS] = "8002"
+        self.assertTrue(self.soft_wind_switch.is_on)
+        self.dps[FLAGS_DPS] = "8008"
+        self.assertTrue(self.soft_wind_switch.is_on)
+
+    async def test_turn_on_display(self):
+        self.dps[FLAGS_DPS] = "0000"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "0008"}
+        ):
+            await self.display_switch.async_turn_on()
+        self.dps[FLAGS_DPS] = "8001"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "8009"}
+        ):
+            await self.display_switch.async_turn_on()
+
+    async def test_turn_off_display(self):
+        self.dps[FLAGS_DPS] = "0018"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "0010"}
+        ):
+            await self.display_switch.async_turn_off()
+        self.dps[FLAGS_DPS] = "8009"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "8001"}
+        ):
+            await self.display_switch.async_turn_off()
+
+    async def test_turn_on_buzzer(self):
+        self.dps[FLAGS_DPS] = "8008"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "8018"}
+        ):
+            await self.buzzer_switch.async_turn_on()
+        self.dps[FLAGS_DPS] = "0009"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "0019"}
+        ):
+            await self.buzzer_switch.async_turn_on()
+
+    async def test_turn_off_buzzer(self):
+        self.dps[FLAGS_DPS] = "8018"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "8008"}
+        ):
+            await self.buzzer_switch.async_turn_off()
+        self.dps[FLAGS_DPS] = "0019"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "0009"}
+        ):
+            await self.buzzer_switch.async_turn_off()
+
+    async def test_turn_on_soft_wind(self):
+        self.dps[FLAGS_DPS] = "0008"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "8008"}
+        ):
+            await self.soft_wind_switch.async_turn_on()
+        self.dps[FLAGS_DPS] = "0010"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "8010"}
+        ):
+            await self.soft_wind_switch.async_turn_on()
+
+    async def test_turn_off_soft_wind(self):
+        self.dps[FLAGS_DPS] = "8008"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "0008"}
+        ):
+            await self.soft_wind_switch.async_turn_off()
+        self.dps[FLAGS_DPS] = "8011"
+        async with assert_device_properties_set(
+            self.subject._device, {FLAGS_DPS: "0011"}
+        ):
+            await self.soft_wind_switch.async_turn_off()


### PR DESCRIPTION
These datapoints were already defined in the yaml file, but I have reverse-engineered their values and added entities to control them. Now these switches work exactly like they do in the official Tuya Android application.

I have also added a unit test file for the device, which includes tests for the previously defined climate entity and the newly introduced entities as well.

The `flags` datapoint is a 2 bytes length hex encoded bitset. To send its updated value correctly to the device, this pull request depends on my other one which fixes a bug related to this case: #877.