### PR TITLE
Create makegood_double_power_point_with_energy.yaml

### DIFF
--- a/custom_components/tuya_local/devices/makegood_double_power_point_with_energy.yaml
+++ b/custom_components/tuya_local/devices/makegood_double_power_point_with_energy.yaml
@@ -1,4 +1,4 @@
-name: Makegood double power point
+name: Double power point
 primary_entity:
   entity: switch
   class: outlet

--- a/custom_components/tuya_local/devices/makegood_double_power_point_with_energy.yaml
+++ b/custom_components/tuya_local/devices/makegood_double_power_point_with_energy.yaml
@@ -1,0 +1,84 @@
+name: Makegood double power point
+primary_entity:
+  entity: switch
+  class: outlet
+  name: Outlet 1
+  dps:
+    - id: 12
+      type: boolean
+      name: switch
+secondary_entities:
+  - entity: switch
+    name: Outlet 2
+    class: outlet
+    dps:
+      - id: 13
+        type: boolean
+        name: switch
+  - entity: sensor
+    category: diagnostic
+    class: voltage
+    name: Voltage
+    dps:
+      - id: 6
+        name: sensor
+        type: integer
+        class: measurement
+        unit: V
+        force: true
+        mapping:
+          - scale: 10
+  - entity: sensor
+    category: diagnostic
+    class: current
+    name: Current
+    dps:
+      - id: 4
+        name: sensor
+        type: integer
+        class: measurement
+        force: true
+        unit: mA
+  - entity: sensor
+    category: diagnostic
+    class: power
+    name: Power
+    dps:
+      - id: 5
+        name: sensor
+        type: integer
+        class: measurement
+        force: true
+        unit: W
+        mapping:
+          - scale: 10
+  - entity: number
+    category: config
+    name: Timer 1
+    icon: "mdi:timer"
+    dps:
+      - id: 2
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    name: Timer 2
+    icon: "mdi:timer"
+    dps:
+      - id: 14
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60


### PR DESCRIPTION
Added configuration for Makegood Double Power Points MG-AUWF01 sold as Kogan, Oz Smart Things, Aus Electronics Direct, Witron, Qubino. 

I got mine for Oz Smart Things who have got them certified for Australia with RCM. 
https://equipment.erac.gov.au/Registration/RSDetails.aspx?atn=public&uid=a6738ea3-1ebb-4650-a4bd-67bf93ee41a4&bk=false