### PR TITLE
Added Garza Wi-Fi water timer

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -315,4 +315,5 @@ Further device support has been made with the assistance of users.  Please consi
 - [kondi](https://github.com/kondi) for contributing improvements to masked values and Starlight heatpumps.
 - [scotttimmins](https://github.com/scotttimmins) for contributing support for 4 outlet + USB smart powerstrip.
 - [madchuska](https://github.com/madchuska) for contributing support for Kogan air purifiers.
-^ [bskjon](https://github.com/bskjon) for contributing support for Woods Milan air conditioner and Norwegian translations.
+- [bskjon](https://github.com/bskjon) for contributing support for Woods Milan air conditioner and Norwegian translations.
+- [jamarju](https://github.com/jamarju) for contributing support for Garza Wi-Fi garden irrigation systems.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -429,6 +429,7 @@ of device.
 - ZN-2C09 9-in-1 air quality monitor
 - ZX-GS21 gas leak alarm monitor
 - ZY-M100-WiFi mmWave human presence sensor
+- Garza Wi-Fi garden irrigation system model: ITV103W, ref: 401303. Connects to Wi-Fi hub via 433 MHz RF.
 
 ### Devices supported via Bluetooth hubs
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Using this integration does not stop your devices from sending status
 to the Tuya cloud, so this should not be seen as a security measure,
 rather it improves speed and reliability by using local connections,
 and may unlock some features of your device, or even unlock whole
-devices, that are not supported by the Tuya cloud API. 
+devices, that are not supported by the Tuya cloud API.
 
 A similar but unrelated integration is
 [rospogrigio/localtuya](https://github.com/rospogrigio/localtuya/), if
@@ -35,14 +35,14 @@ easier to set up using that as an alternative.
 
 ## Device support
 
-Note that devices sometimes get firmware upgrades, or incompatible versions are sold under the same model name, so it is possible that the device will not work despite being listed. 
+Note that devices sometimes get firmware upgrades, or incompatible versions are sold under the same model name, so it is possible that the device will not work despite being listed.
 
 Battery powered devices such as door and window sensors, smoke alarms etc which do not use a hub will be impossible to support locally, due to the power management that they need to do to get acceptable battery
 life.  Currently hubs are also unsupported, but this is being worked on.
 
 A list of currently supported devices can be found in the [DEVICES.md](https://github.com/make-all/tuya-local/blob/main/DEVICES.md) file.
 
-Documentation on building a device configuration file is in [/custom_components/tuya_local/devices/README.md](https://github.com/make-all/tuya-local/blob/main/custom_components/tuya_local/devices/README.md) 
+Documentation on building a device configuration file is in [/custom_components/tuya_local/devices/README.md](https://github.com/make-all/tuya-local/blob/main/custom_components/tuya_local/devices/README.md)
 
 If your device is not listed, you can find the information required to add a configuration for it in the following locations:
 
@@ -68,7 +68,7 @@ If you submit a pull request, please understand that the config file naming and 
 
 Installation is easiest via the [Home Assistant Community Store
 (HACS)](https://hacs.xyz/), which is the best place to get third-party
-integrations for Home Assistant. Once you have HACS set up, simply click the button below (requires My Homeassistant configured) or 
+integrations for Home Assistant. Once you have HACS set up, simply click the button below (requires My Homeassistant configured) or
 follow the [instructions for adding a custom
 repository](https://hacs.xyz/docs/faq/custom_repositories) and then
 the integration will be available to install like any other.
@@ -307,7 +307,7 @@ mode they are in, but are set to readonly so that you cannot accidentally
 switch the thermostat to the wrong mode from HA.
 
 
-## Finding your device ID and local key
+## Finding your device ID and local key at the Tuya Developer Portal
 
 The easiest way to find your local key is with the Tuya Developer portal.
 If you have previously configured the built in Tuya cloud integration, or
@@ -334,6 +334,50 @@ command line Tuya client like tuyaapi/cli or
 [tinytuya](https://github.com/jasonacox/tinytuya) you may also be able
 to scan your network for Tuya devices to find the IP address and also automate
 the above process of connecting to the portal and getting the local key.
+
+## Connecting to devices via hubs
+
+If your device connects via a hub (eg. battery powered water timers) you have to provide the following info when adding a new device:
+
+- Device id (uuid): this is the **hub's** device id
+- IP address or hostname: the **hub's** IP address or hostname
+- Local key: the **hub's** local key
+- Sub device id: the **acual device you want to control's** `node_id`. Note this `node_id` differs from the device id, you can find it with tinytuya as described below.
+
+## Finding device ids and local keys with tinytuya
+
+You can use this component's underlying library [tinytuya](https://github.com/jasonacox/tinytuya) to scan for devices in your network and find the required information about them. In particular, you need to use this procedure to obtain the `node_id` value required to connect to hub-dependent devices.
+
+Before running tinytuya's wizard you need to gather your API credentials so head to [Tuya's Developer Portal](https://iot.tuya.com) -> Cloud -> Development -> Open project and make a note of:
+
+- Access ID/Client ID
+- Access Secret/Client Secret
+
+Next, go to the "Devices" tab and note your device id (any of them will work). Also note your region (eg. "Central Europe Data Center") in the combobox at the top right of the page.
+
+Then, open a terminal in your HA machine and run:
+
+```sh
+python -m tinytuya wizard
+```
+
+Answer the following:
+
+- Enter API Key from tuya.com: your "Access ID/Client ID"
+- Enter API Secret from tuya.com: your "Access Secret/Client Secret"
+- Enter any Device ID currently registered in Tuya App (used to pull full list) or 'scan' to scan for one: your device id
+- Enter Your Region: your datacenter's region
+- Download DP Name mappings? (Y/n): Y
+- Poll local devices? (Y/n): Y
+
+If your device supports local connections and is in the same network as your HA instance this should find it and report its IP address.
+
+In the `devices.json` file you will everything you need to add your device:
+
+- "id": the device id
+- "key": the local key
+- "node_id": the sub-device id. You need this for hub-dependent devices
+- "mapping": in the unfortunate case your device is not [yet supported](DEVICES.md), this key contains a description of all the datapoints reported by the device, type and expected values. You are more than welcome to create a new device specification following [the guidelines](custom_components/tuya_local/devices/README.md) and submitting a PR.
 
 ## Next steps
 

--- a/custom_components/tuya_local/devices/garza_irrigation_system.yaml
+++ b/custom_components/tuya_local/devices/garza_irrigation_system.yaml
@@ -1,0 +1,87 @@
+name: Garza WiFi garden irrigation system
+product:
+  - id: xnajzurgqo1ugohn
+    model: ITV103W
+primary_entity:
+  entity: switch
+  icon: "mdi:watering-can"
+  name: Switch
+  dps:
+    - id: 108
+      type: boolean
+      name: switch
+      mapping:
+        - dps_val: true
+          value: false
+        - dps_val: false
+          value: true
+secondary_entities:
+  - entity: sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+        mapping:
+          - dps_val: 0
+            icon: "mdi:battery-10"
+            value: 0
+          - dps_val: 1
+            icon: "mdi:battery-60"
+            value: 50
+          - dps_val: 2
+            icon: "mdi:battery"
+            value: 100
+  - entity: sensor
+    name: Water flow
+    class: water
+    category: diagnostic
+    icon: "mdi:water"
+    dps:
+      - id: 103
+        name: sensor
+        type: integer
+        unit: L
+  - entity: number
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 107
+        type: integer
+        name: value
+        unit: m
+        range:
+          min: 0
+          max: 60
+  - entity: sensor
+    name: Work status
+    class: enum
+    icon: "mdi:list-status"
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: "Off"
+          - dps_val: 1
+            value: "Manual"
+          - dps_val: 2
+            value: "Auto"
+  - entity: binary_sensor
+    name: Alarm status
+    category: diagnostic
+    class: problem
+    dps:
+      - id: 120
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true

--- a/custom_components/tuya_local/devices/garza_irrigation_system.yaml
+++ b/custom_components/tuya_local/devices/garza_irrigation_system.yaml
@@ -1,11 +1,11 @@
-name: Garza WiFi garden irrigation system
+name: Garden irrigation system
 product:
   - id: xnajzurgqo1ugohn
     model: ITV103W
+    manufacturer: Garza
 primary_entity:
   entity: switch
   icon: "mdi:watering-can"
-  name: Switch
   dps:
     - id: 108
       type: boolean
@@ -53,12 +53,12 @@ secondary_entities:
       - id: 107
         type: integer
         name: value
-        unit: m
+        unit: min
         range:
           min: 0
           max: 60
   - entity: sensor
-    name: Work status
+    name: Status
     class: enum
     icon: "mdi:list-status"
     category: diagnostic
@@ -74,7 +74,7 @@ secondary_entities:
           - dps_val: 2
             value: "Auto"
   - entity: binary_sensor
-    name: Alarm status
+    name: Alarm
     category: diagnostic
     class: problem
     dps:


### PR DESCRIPTION
This is a water timer commonly found in Leroy Merlin shops.

It consists of a hub that doubles as a smart switch and controls the actual water timer via a 433 MHz custom protocol. 

Added basic support:

- Switch on/off
- Manual irrigation timer
- Battery report (0/50/100%)
- Current working mode (Off/Manual/Auto)
- Current alarm status (untested, actually)

Not supported:

- Timer scheduling: just use HA automations instead! this uses a binary protocol that should not be hard to reverse using Tuya cloud's "debug device" feature if anyone cares.

Also included directions to get the `node_id` AKA the "sub device id" using tinytuya as I couldn't find it anywhere in the developer portal.