### PR TITLE
Updated support for Tellur WiFi Aroma Diffuser

### DIFF
--- a/custom_components/tuya_local/devices/yym_805SW_aroma_nightlight.yaml
+++ b/custom_components/tuya_local/devices/yym_805SW_aroma_nightlight.yaml
@@ -5,6 +5,8 @@ products:
     name: YYM-805SW
   - id: 4870500398f4abbfbae4
     name: GX
+  - id: 58107061e868e7c462da
+    name: Tellur WiFi Aroma Diffuser
 primary_entity:
   entity: fan
   dps:
@@ -12,12 +14,27 @@ primary_entity:
       name: switch
       type: boolean
       mapping:
-        - dps_val: true
-          icon: mdi:scent
-          value: ON
-        - dps_val: false
-          icon: mdi:scent-off
-          value: OFF
+        - conditions:
+            - dps_val:
+                - true
+                - false
+              mapping:
+                - dps_val: true
+                  icon: mdi:scent
+                  value: ON
+                - dps_val: false
+                  icon: mdi:scent-off
+                  value: OFF
+            - dps_val:
+                - on
+                - off
+              mapping:
+                - dps_val: on
+                  icon: mdi:scent
+                  value: ON
+                - dps_val: off
+                  icon: mdi:scent-off
+                  value: OFF
     - id: 2
       name: speed
       type: string


### PR DESCRIPTION
Added support for device 58107061e868e7c462da - Tellur WiFi Aroma Diffuser.
It already works great, with one caveat - when setting fan to OFF, or setting spray level when it's already OFF, nothing happens. I hope these changes will help with that.

DP code `1` log:
```
            {
                "devId": "58107061e868e7c462da",
                "eventType": "Report",
                "sourceDetail": "",
                "eventTime": 1690485440832,
                "eventName": "Spray",
                "eventTimeStr": "2023-07-27 19:17:20:832",
                "eventDetail": "ON",
                "requestFrom": "device itself"
            },
```

DP code `2` log:

```
            {
                "devId": "58107061e868e7c462da",
                "eventType": "Report",
                "sourceDetail": "",
                "eventTime": 1690486518944,
                "eventName": "Mode",
                "eventTimeStr": "2023-07-27 19:35:18:944",
                "eventDetail": "Small",
                "requestFrom": "device itself"
            }
```

<img width="546" alt="image" src="https://github.com/make-all/tuya-local/assets/43441428/93a2867b-9675-483d-9372-1a2cbb867a2c">
