### PR TITLE
fix dps_val mapping for CBI Astute Smart Controller's initial state setting

### DIFF
--- a/custom_components/tuya_local/devices/cbi_astute_outdoor_smartswitch.yaml
+++ b/custom_components/tuya_local/devices/cbi_astute_outdoor_smartswitch.yaml
@@ -34,11 +34,11 @@ secondary_entities:
         type: string
         name: option
         mapping:
-          - dps_val: "power_on"
+          - dps_val: "on"
             value: "On"
-          - dps_val: "power_off"
+          - dps_val: "off"
             value: "Off"
-          - dps_val: last
+          - dps_val: "memory"
             value: "Last State"
   - entity: sensor
     category: diagnostic


### PR DESCRIPTION
The Initial State "relay_status" entity (representing the default state to be in upon loss and regain of power), was not being correctly fetched nor set by Home Assistant.

I've confirmed that my device is the same one as this config.
At `https://iot.tuya.com/cloud/explorer -> IoT Core -> Device Management -> Query Device Details`
I entered my device's id, and received the same product_id back: "xzgtyrqbab8lm2zo"

I then tried `https://iot.tuya.com/cloud/explorer -> IoT Core -> Device Control(Standard Instruction Set) -> Get the specifications and properties of the device`
Which returned the following response:
<details>
  <summary>Expand Response</summary>

```json
{
  "result": {
    "category": "kg",
    "functions": [
      {
        "code": "switch_1",
        "desc": "{}",
        "name": "开关1",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "countdown_1",
        "desc": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}",
        "name": "开关1倒计时",
        "type": "Integer",
        "values": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
      },
      {
        "code": "relay_status",
        "desc": "{\"range\":[\"power_off\",\"power_on\",\"last\"]}",
        "name": "上电状态",
        "type": "Enum",
        "values": "{\"range\":[\"power_off\",\"power_on\",\"last\"]}"
      }
    ],
    "status": [
      {
        "code": "switch_1",
        "name": "开关1",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "countdown_1",
        "name": "开关1倒计时",
        "type": "Integer",
        "values": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}"
      },
      {
        "code": "relay_status",
        "name": "上电状态",
        "type": "Enum",
        "values": "{\"range\":[\"power_off\",\"power_on\",\"last\"]}"
      },
      {
        "code": "add_ele",
        "name": "增加电量",
        "type": "Integer",
        "values": "{\"unit\":\"kwh\",\"min\":0,\"max\":50000,\"scale\":3,\"step\":100}"
      },
      {
        "code": "cur_current",
        "name": "当前电流",
        "type": "Integer",
        "values": "{\"unit\":\"A\",\"min\":0,\"max\":30000,\"scale\":3,\"step\":100}"
      },
      {
        "code": "cur_voltage",
        "name": "当前电压",
        "type": "Integer",
        "values": "{\"unit\":\"V\",\"min\":0,\"max\":5000,\"scale\":1,\"step\":1}"
      },
      {
        "code": "cur_power",
        "name": "当前功率",
        "type": "Integer",
        "values": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":1,\"step\":1}"
      }
    ]
  },
  "success": true,
  "t": "<REDACTED>",
  "tid": "<REDACTED>"
}
```
</details>

However, those Enum values for "relay_status" (which were the same as the current config) were not working.

I then tried `https://iot.tuya.com/cloud/explorer -> IoT Core -> Device Control -> Query Things Data Model`
Which returned a JSON response containing the stringified JSON for the model.
After cleaning up the JSON, the model details looked like this:
<details>
  <summary>Expand Response</summary>

```json
{
  "model": {
    "modelId": "000002k39n",
    "services": [
      {
        "actions": [],
        "code": "",
        "description": "",
        "events": [],
        "name": "默认服务",
        "properties": [
          {
            "abilityId": 1,
            "accessMode": "rw",
            "code": "switch_1",
            "description": "",
            "extensions": {
              "iconName": "icon-power",
              "attribute": "1"
            },
            "name": "开关",
            "typeSpec": {
              "type": "bool",
              "typeDefaultValue": false
            }
          },
          {
            "abilityId": 7,
            "accessMode": "rw",
            "code": "countdown_1",
            "description": "",
            "extensions": {
              "iconName": "icon-dp_time2"
            },
            "name": "Countdown",
            "typeSpec": {
              "max": 86400,
              "min": 0,
              "scale": 0,
              "step": 1,
              "type": "value",
              "typeDefaultValue": 0,
              "unit": "s"
            }
          },
          {
            "abilityId": 14,
            "accessMode": "rw",
            "code": "relay_status",
            "description": "",
            "extensions": {
              "iconName": "icon-dp_circle"
            },
            "name": "上电状态设置",
            "typeSpec": {
              "range": [
                "off",
                "on",
                "memory"
              ],
              "type": "enum",
              "typeDefaultValue": "off"
            }
          },
          {
            "abilityId": 20,
            "accessMode": "rw",
            "code": "add_ele",
            "description": "",
            "extensions": {
              "iconName": "icon-dianliang"
            },
            "name": "增加电量",
            "typeSpec": {
              "max": 50000,
              "min": 0,
              "scale": 3,
              "step": 100,
              "type": "value",
              "typeDefaultValue": 0,
              "unit": "kwh"
            }
          },
          {
            "abilityId": 21,
            "accessMode": "ro",
            "code": "cur_current",
            "description": "",
            "extensions": {
              "iconName": "icon-Ele"
            },
            "name": "Current current",
            "typeSpec": {
              "max": 30000,
              "min": 0,
              "scale": 3,
              "step": 100,
              "type": "value",
              "typeDefaultValue": 0,
              "unit": "A"
            }
          },
          {
            "abilityId": 22,
            "accessMode": "ro",
            "code": "cur_voltage",
            "description": "",
            "extensions": {
              "iconName": "icon-dianliang"
            },
            "name": "当前电压",
            "typeSpec": {
              "max": 5000,
              "min": 0,
              "scale": 1,
              "step": 1,
              "type": "value",
              "typeDefaultValue": 0,
              "unit": "V"
            }
          },
          {
            "abilityId": 23,
            "accessMode": "ro",
            "code": "cur_power",
            "description": "",
            "extensions": {
              "iconName": "icon-gaodiyin"
            },
            "name": "当前功率",
            "typeSpec": {
              "max": 50000,
              "min": 0,
              "scale": 1,
              "step": 1,
              "type": "value",
              "typeDefaultValue": 0,
              "unit": "W"
            }
          }
        ]
      }
    ]
  }
}
```
</details>

I suspect that these Enum values ("off","on","memory") are for local control, whereas the other Enum values ("power_off","power_on","last") are for the standardized instruction set when controlling via the cloud API.

After changing my config locally, the Initial State (relay_status) setting was working perfectly within Home Assistant.

I'm unsure if this is an isolated quirk for this device, or if it may be recommended for other devices to get their DPs settings using this API request for the device's Data Model. Is it mentioned somewhere in the README about how to get these DPs settings?
