### PR TITLE
8in1 air sensor - add missing names to sensor entities

### DIFF
--- a/custom_components/tuya_local/devices/pv28-cw_airquality_monitor.yaml
+++ b/custom_components/tuya_local/devices/pv28-cw_airquality_monitor.yaml
@@ -105,6 +105,7 @@ secondary_entities:
           - dps_val: charge
             value: charging
   - entity: sensor
+    name: Battery
     class: battery
     category: diagnostic
     dps:
@@ -127,6 +128,7 @@ secondary_entities:
   #       mapping:
   #         - step: 1
   - entity: sensor
+    name: Temperature
     class: temperature
     dps:
       - id: 18
@@ -135,6 +137,7 @@ secondary_entities:
         unit: C
         class: measurement
   - entity: sensor
+    name: Humidity
     class: humidity
     dps:
       - id: 19


### PR DESCRIPTION
Added names to entities since with latest 2023.9dev sensors without name: fields inherited only the device name as entity name. 

Not sure what's actually correct with all the new naming changes