### PR TITLE
Create holman_wx1_taptimer.yaml

### DIFF
--- a/custom_components/tuya_local/devices/holman_wx1_taptimer.yaml
+++ b/custom_components/tuya_local/devices/holman_wx1_taptimer.yaml
@@ -1,0 +1,428 @@
+name: Holman WX1 Tap Timer
+products:
+  - id: zrsgzc8jktsricjj
+    model: WX1
+    manufacturer: Holman
+    # DP decoding thanks to funtastix https://github.com/funtastix/localtuya/blob/dbcc6dcd8340cd3e8b7ae91cda379ab68dfcac22/HOLMAN_TAP_TIMER.md
+primary_entity:
+  entity: switch
+  icon: "mdi:watering-can"
+  dps:
+    - id: 108
+      type: boolean
+      name: switch
+      mapping:
+        - dps_val: true
+          value: false
+        - dps_val: false
+          value: true
+secondary_entities:
+  - entity: sensor
+    name: Soil Temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 101
+        name: sensor
+        type: integer
+        unit: C
+  - entity: sensor
+    name: Soil Moisture
+    class: humidity
+    category: diagnostic
+    dps:
+      - id: 102
+        name: sensor
+        type: integer
+        unit: "%"
+  - entity: sensor
+    name: Water flow
+    class: water
+    category: diagnostic
+    icon: "mdi:water"
+    dps:
+      - id: 103
+        name: sensor
+        type: integer
+        unit: L
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+        mapping:
+          - dps_val: 0
+            icon: "mdi:battery-10"
+            value: 0
+          - dps_val: 1
+            icon: "mdi:battery-60"
+            value: 50
+          - dps_val: 2
+            icon: "mdi:battery"
+            value: 100
+  - entity: sensor
+    name: Status
+    class: enum
+    icon: "mdi:list-status"
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: "Off"
+          - dps_val: 1
+            value: "Manual"
+          - dps_val: 2
+            value: "Auto"
+          - dps_val: 3
+            value: "Rain Delay"
+  - entity: number
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 107
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 60
+  - entity: number
+    name: Time Left
+    icon: "mdi:timer"
+    category: diagnostic
+    dps:
+      - id: 109
+        type: integer
+        name: value
+        unit: min
+  - entity: sensor
+    name: Start A Encoded # this DP shows the start time, duration and days for start A. Not controllable - use automation instead.
+    category: diagnostic
+    dps:
+      - id: 110
+        name: sensor
+        type: base64
+      - id: 110
+        name: days # bit string of flags for days of the week Sun-Sat, plus a bit for on/off
+        type: base64
+        mapping:
+          - mask: "FF000000"
+      - id: 110
+        name: minutes_duration
+        type: base64
+        mapping:
+          - mask: "FF00000000"
+      - id: 110
+        name: hours_duration
+        type: base64
+        mapping:
+          - mask: "FF0000000000"
+      - id: 110
+        name: minutes_start
+        type: base64
+        mapping:
+          - mask: "FF000000000000"
+      - id: 110
+        name: hours_start
+        type: base64
+        mapping:
+          - mask: "FF00000000000000"
+  - entity: sensor
+    name: Start B Encoded # this DP shows the start time, duration and days for start B. Not controllable - use automation instead.
+    category: diagnostic
+    dps:
+      - id: 111
+        name: sensor
+        type: string
+      - id: 111
+        name: days # bit string of flags for days of the week Sun-Sat, plus a bit for on/off
+        type: base64
+        mapping:
+          - mask: "FF000000"
+      - id: 111
+        name: minutes_duration
+        type: base64
+        mapping:
+          - mask: "FF00000000"
+      - id: 111
+        name: hours_duration
+        type: base64
+        mapping:
+          - mask: "FF0000000000"
+      - id: 111
+        name: minutes_start
+        type: base64
+        mapping:
+          - mask: "FF000000000000"
+      - id: 111
+        name: hours_start
+        type: base64
+        mapping:
+          - mask: "FF00000000000000"
+  - entity: sensor
+    name: Start C Encoded # this DP shows the start time, duration and days for start C. Not controllable - use automation instead.
+    category: diagnostic
+    dps:
+      - id: 112
+        name: sensor
+        type: string
+      - id: 112
+        name: days # bit string of flags for days of the week Sun-Sat, plus a bit for on/off
+        type: base64
+        mapping:
+          - mask: "FF000000"
+      - id: 112
+        name: minutes_duration
+        type: base64
+        mapping:
+          - mask: "FF00000000"
+      - id: 112
+        name: hours_duration
+        type: base64
+        mapping:
+          - mask: "FF0000000000"
+      - id: 112
+        name: minutes_start
+        type: base64
+        mapping:
+          - mask: "FF000000000000"
+      - id: 112
+        name: hours_start
+        type: base64
+        mapping:
+          - mask: "FF00000000000000"
+  - entity: select
+    name: Watering Delay
+    category: config
+    dps:
+      - id: 113
+        name: option
+        type: string
+        mapping:
+          - dps_val: 0
+            value: 0h
+          - dps_val: 24
+            value: 24h
+          - dps_val: 48
+            value: 48h
+          - dps_val: 72
+            value: 72h
+  - entity: select
+    name: 24H Time
+    category: config
+    dps:
+      - id: 114
+        name: option
+        type: string
+        mapping:
+          - dps_val: 12
+            value: 12H
+          - dps_val: 24
+            value: 24H
+  - entity: binary_sensor
+    name: Soil Sensor Present
+    category: diagnostic
+    dps:
+      - id: 115
+        name: sensor
+        type: string
+  - entity: binary_sensor
+    name: Rain Sensor Present
+    category: diagnostic
+    dps:
+      - id: 116
+        name: sensor
+        type: string
+  - entity: binary_sensor
+    name: Soil Sensor Power OK
+    category: diagnostic
+    dps:
+      - id: 117
+        name: sensor
+        type: string
+  - entity: select
+    name: Units
+    category: config
+    dps:
+      - id: 119
+        name: option
+        type: string
+        mapping:
+          - dps_val: 1
+            value: "L/C"
+          - dps_val: 2
+            value: "gal/F"
+  - entity: sensor
+    name: Alarm Status
+    category: diagnostic
+    dps:
+      - id: 120
+        name: sensor
+        type: string
+  - entity: sensor
+    name: Flow Count Encoded # shows the past 10 days of flow count history. xx_days_256 values need to be multiplied by 256 and added to xx_days value to get the total for that day.
+    category: diagnostic
+    dps:
+      - id: 121
+        name: sensor
+        type: base64
+      - id: 121
+        name: 10_days
+        type: base64
+        mapping:
+          - mask: "FF"
+      - id: 121
+        name: 10_days_256
+        type: base64
+        mapping:
+          - mask: "FF00"
+      - id: 121
+        name: 9_days
+        type: base64
+        mapping:
+          - mask: "FF0000"
+      - id: 121
+        name: 9_days_256
+        type: base64
+        mapping:
+          - mask: "FF000000"
+      - id: 121
+        name: 8_days
+        type: base64
+        mapping:
+          - mask: "FF00000000"
+      - id: 121
+        name: 8_days_256
+        type: base64
+        mapping:
+          - mask: "FF0000000000"
+      - id: 121
+        name: 7_days
+        type: base64
+        mapping:
+          - mask: "FF000000000000"
+      - id: 121
+        name: 7_days_256
+        type: base64
+        mapping:
+          - mask: "FF00000000000000"
+      - id: 121
+        name: 6_days
+        type: base64
+        mapping:
+          - mask: "FF0000000000000000"
+      - id: 121
+        name: 6_days_256
+        type: base64
+        mapping:
+          - mask: "FF000000000000000000"
+      - id: 121
+        name: 5_days
+        type: base64
+        mapping:
+          - mask: "FF00000000000000000000"
+      - id: 121
+        name: 5_days_256
+        type: base64
+        mapping:
+          - mask: "FF0000000000000000000000"
+      - id: 121
+        name: 4_days
+        type: base64
+        mapping:
+          - mask: "FF000000000000000000000000"
+      - id: 121
+        name: 4_days_256
+        type: base64
+        mapping:
+          - mask: "FF00000000000000000000000000"
+      - id: 121
+        name: 3_days
+        type: base64
+        mapping:
+          - mask: "FF0000000000000000000000000000"
+      - id: 121
+        name: 3_days_256
+        type: base64
+        mapping:
+          - mask: "FF000000000000000000000000000000"
+      - id: 121
+        name: 2_days
+        type: base64
+        mapping:
+          - mask: "FF00000000000000000000000000000000"
+      - id: 121
+        name: 2_days_256
+        type: base64
+        mapping:
+          - mask: "FF0000000000000000000000000000000000"
+      - id: 121
+        name: 1_day
+        type: base64
+        mapping:
+          - mask: "FF000000000000000000000000000000000000"
+      - id: 121
+        name: 1_day_256
+        type: base64
+        mapping:
+          - mask: "FF00000000000000000000000000000000000000"
+  - entity: sensor
+    name: Temperature Count Encoded
+    category: diagnostic
+    dps:
+      - id: 122
+        name: sensor
+        type: base64
+  - entity: sensor
+    name: Moisture Count Encoded
+    category: diagnostic
+    dps:
+      - id: 123
+        name: sensor
+        type: base64
+  - entity: binary_sensor
+    name: Postponed Due to Rain
+    category: diagnostic
+    dps:
+      - id: 125
+        name: sensor
+        type: string
+  - entity: sensor
+    name: Next Watering Encoded # shows the next scheduled watering time based on starts A, B and C
+    category: diagnostic
+    dps:
+      - id: 128
+        name: sensor
+        type: base64
+      - id: 128
+        name: minute
+        type: base64
+        mapping:
+          - mask: "FF"
+      - id: 128
+        name: hour
+        type: base64
+        mapping:
+          - mask: "FF00"
+      - id: 128
+        name: day
+        type: base64
+        mapping:
+          - mask: "FF0000"
+      - id: 128
+        name: month
+        type: base64
+        mapping:
+          - mask: "FF000000"
+      - id: 128
+        name: year
+        type: base64
+        mapping:
+          - mask: "FF00000000"


### PR DESCRIPTION
This PR adds a config file for Holman WX1 Tap Timer (https://www.holmanindustries.com.au/product/wx1-tap-timer-and-wifi-hub/), which connects through a hub.

A couple of points:

I don't have a soil sensor attached so was not able to create the decoding of the base64 fields associated with these.

The timer is designed to operate independently, with scheduling directly on the device and controllable via the app. I was unable to figure out a way to use tuya-local to write the appropriate base64 values back to DPs 110-112 in order to replicate this functionality. Any scheduling will need to be done via HA instead.

A lot of the DP info, particularly decoding the base64 values, I got from funtastix https://github.com/funtastix/localtuya/blob/dbcc6dcd8340cd3e8b7ae91cda379ab68dfcac22/HOLMAN_TAP_TIMER.md