### PR TITLE
Fix Kogan LX10 Vacuum 'start' command no longer working after 2023.6.1

### DIFF
--- a/custom_components/tuya_local/devices/kogan_lx10_vacuum.yaml
+++ b/custom_components/tuya_local/devices/kogan_lx10_vacuum.yaml
@@ -16,8 +16,10 @@ primary_entity:
       type: string
       mapping:
         - value: start
+          dps_val: true
           value_redirect: start
         - value: pause
+          dps_val: true
           value_redirect: pause
         - dps_val: smart
           value: smart


### PR DESCRIPTION
Bug introduced by 3488430 in #759 / [2023.6.1](https://github.com/make-all/tuya-local/releases/tag/2023.6.1) - `value_redirect` mappings need a non-null `dps_val`.

If there's a preferred `dps_val` other than `true` I'll happily change this. I think you may have commented on the original PR something to the effect that a `dps_val` would be necessary but at the time it worked without.

