### PR TITLE
Position of DPS ID4 (Poolex Q7) moved upwards

### DIFF
--- a/custom_components/tuya_local/devices/poolex_q7_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolex_q7_heatpump.yaml
@@ -43,6 +43,22 @@ primary_entity:
                 min: 68
                 max: 104
               value_redirect: temp_set_f
+    - id: 4
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: Boost_Heat
+          value: quick_heat
+        - dps_val: Silent_Heat
+          value: quiet_heat
+        - dps_val: ECO_Heat
+          value: smart_heat
+        - dps_val: ECO_Cool
+          value: smart_cool
+        - dps_val: Silent_Cool
+          value: quiet_cool
+        - dps_val: Boost_Cool
+          value: quick_cool
     - id: 3
       type: integer
       name: current_temperature
@@ -86,22 +102,6 @@ primary_entity:
       name: temp_current_f
       hidden: true
       optional: true
-    - id: 4
-      type: string
-      name: preset_mode
-      mapping:
-        - dps_val: Boost_Heat
-          value: quick_heat
-        - dps_val: Silent_Heat
-          value: quiet_heat
-        - dps_val: ECO_Heat
-          value: smart_heat
-        - dps_val: ECO_Cool
-          value: smart_cool
-        - dps_val: Silent_Cool
-          value: quiet_cool
-        - dps_val: Boost_Cool
-          value: quick_cool
     - id: 21
       type: integer
       name: unknown_21


### PR DESCRIPTION
Hi
I don't understand why the position of the entry is important. But with this change, the heat pump can be controlled correctly. Without this adjustment, the pump can neither be deactivated nor can the mode be changed.

Except the problem is that I have the `Q-Line 9` and not `Q-Line 7`
https://www.poolstar.fr/de/produit/warmepumpe-pool-poolex-q-line-7

![image](https://github.com/make-all/tuya-local/assets/24251966/355a7222-d12f-42d7-8c0b-8bace3d28a2a)

![image](https://github.com/make-all/tuya-local/assets/24251966/b71d0e24-f8eb-4509-9ef7-4b11e0c79908)
