### PR TITLE
Update monzana_air_conditioner to add heat function

### DIFF
--- a/custom_components/tuya_local/devices/monzana_klimaanlage_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/monzana_klimaanlage_air_conditioner.yaml
@@ -20,6 +20,8 @@ primary_entity:
               value: dry
             - dps_val: Fan
               value: fan_only
+            - dps_val: Heat
+              value: heat
     - id: 2
       type: integer
       name: temperature


### PR DESCRIPTION
I have been using this integration for a while for this AC and wondered why it didn't have the heat function, so changed the files locally to add it in and everything worked so thought I would put a PR in for it. 

Simple 2-line addition, if making a new device with my specific AC model number is better then I will happily modify this PR but it would seem that all Monzana ACs that have multi-function also can act as a heater. 