### PR TITLE
Add Sonoff SNZB-02 ZigBee Temperature & Humidity Sensor

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -496,6 +496,7 @@ port and password.
 - Nedis ZBSC10WT temperature and humidity sensor
 - Temperature and humidity sensor with alarm feature
 - ZTH08ZTU temperature and humidity sensor
+- Sonoff SNZB-02 ZigBee temperature and humidity sensor
 
 NOTE: this project does not intend to expand the scope to support non-Tuya
 devices via Tuya hubs.  Though it may be techincally feasible to do such a

--- a/custom_components/tuya_local/devices/zigbee_sonoff_snzb-02-climate-sensor.yaml
+++ b/custom_components/tuya_local/devices/zigbee_sonoff_snzb-02-climate-sensor.yaml
@@ -1,0 +1,31 @@
+name: Climate sensor
+products:
+  - id: vtA4pDd6PLUZzXgZxxx
+    name: Sonoff SNZB-02 ZigBee temperature and humidity sensor
+primary_entity:
+  entity: sensor
+  class: humidity
+  dps:
+    - id: 101
+      type: integer
+      name: sensor
+      unit: "%"
+      class: measurement
+secondary_entities:
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement


### PR DESCRIPTION
It uses the same DPS as `MultiIR Zigbee TE100-TY`, just without scale. I'm using it for some time already, just don't have time to contribute the change back.

DPS:
```json
{"101": 51, "102": 83, "103": 7, "full_poll": true}
```