### PR TITLE
Update th16_temp_humidity_sensor.yaml

### DIFF
--- a/custom_components/tuya_local/devices/th16_temp_humidity_sensor.yaml
+++ b/custom_components/tuya_local/devices/th16_temp_humidity_sensor.yaml
@@ -33,6 +33,7 @@ secondary_entities:
             value: Fahrenheit
           - dps_val: "c"
             value: Celsius
+        optional: true
   - entity: light
     name: Display
     icon: "mdi:television-ambient-light"


### PR DESCRIPTION
I have device that don't have dp9, that why I change it to optional