### PR TITLE
Fix scale of max and min distance for zigbee dv7vcs presence sensor

### DIFF
--- a/custom_components/tuya_local/devices/zigbee_dv7vcs_human_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zigbee_dv7vcs_human_presence_sensor.yaml
@@ -39,7 +39,7 @@ secondary_entities:
           min: 0
           max: 950
         mapping:
-          - scale: 10
+          - scale: 100
             step: 10
   - entity: number
     name: Maximum distance
@@ -54,7 +54,7 @@ secondary_entities:
           min: 0
           max: 950
         mapping:
-          - scale: 10
+          - scale: 100
             step: 10
   - entity: sensor
     class: distance


### PR DESCRIPTION
Fix scale used in zb dv7vcs presence sensor. Without this change there's a mismatch between homeassistant UI and Smart Life