### PR TITLE
Adding support for SWS-001 weather station (sensors only)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -386,7 +386,8 @@ of device.
 - Dongguan garage door
 - Dooya curtain motor
 - Etersky curtain switch with backlight and timing control
-- FS-03W curtain switch with backlight control
+- FS-03W curtain switch with backlight control
+
 - Kogan garage door with tilt sensor
 - Loonas smart curtain
 - LoraTap GDC100W garage door opener
@@ -495,6 +496,7 @@ port and password.
 - ZN-2C09 9-in-1 air quality monitor
 - ZX-GS21 gas leak alarm monitor
 - ZY-M100-WiFi mmWave human presence sensor
+- SWS-001 smart weather station
 
 ### Devices supported via Bluetooth hubs
 

--- a/custom_components/tuya_local/devices/smart_weather_station.yaml
+++ b/custom_components/tuya_local/devices/smart_weather_station.yaml
@@ -1,0 +1,93 @@
+name: Smart Weather Station
+products:
+  - id: 000001bbfd
+    name: Smart Weather Station
+primary_entity:
+  entity: sensor
+  name: local temperature
+  class: temperature
+  dps:
+    - id: 131
+      name: sensor
+      type: integer
+      unit: C
+      mapping:
+        - scale: 10
+      class: measurement
+secondary_entities:
+  - entity: sensor
+    name: local humidity
+    class: humidity
+    dps:
+      - id: 132
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        
+  - entity: sensor
+    name: sensor 1 temperature
+    class: temperature
+    dps:
+      - id: 133
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+        
+  - entity: sensor
+    name: sensor 1 humidity
+    class: humidity
+    dps:
+      - id: 134
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        
+  - entity: sensor
+    name: sensor 2 temperature
+    class: temperature
+    dps:
+      - id: 135
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+        
+  - entity: sensor
+    name: sensor 2 humidity
+    class: humidity
+    dps:
+      - id: 136
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        
+  - entity: sensor
+    name: sensor 3 temperature
+    class: temperature
+    dps:
+      - id: 137
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+  - entity: sensor
+  
+    name: sensor 3 humidity
+    class: humidity
+    dps:
+      - id: 138
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        

--- a/custom_components/tuya_local/devices/smart_weather_station.yaml
+++ b/custom_components/tuya_local/devices/smart_weather_station.yaml
@@ -1,10 +1,10 @@
-name: Smart Weather Station
+name: Weather station
 products:
-  - id: 000001bbfd
+  - id: fpgistthfiweyaqr
     name: Smart Weather Station
 primary_entity:
   entity: sensor
-  name: local temperature
+  name: Internal temperature
   class: temperature
   dps:
     - id: 131
@@ -16,7 +16,7 @@ primary_entity:
       class: measurement
 secondary_entities:
   - entity: sensor
-    name: local humidity
+    name: Internal humidity
     class: humidity
     dps:
       - id: 132
@@ -26,7 +26,7 @@ secondary_entities:
         class: measurement
         
   - entity: sensor
-    name: sensor 1 temperature
+    name: Temperature 1
     class: temperature
     dps:
       - id: 133
@@ -38,7 +38,7 @@ secondary_entities:
         class: measurement
         
   - entity: sensor
-    name: sensor 1 humidity
+    name: Humidity 1
     class: humidity
     dps:
       - id: 134
@@ -48,7 +48,7 @@ secondary_entities:
         class: measurement
         
   - entity: sensor
-    name: sensor 2 temperature
+    name: Temperature 2
     class: temperature
     dps:
       - id: 135
@@ -60,7 +60,7 @@ secondary_entities:
         class: measurement
         
   - entity: sensor
-    name: sensor 2 humidity
+    name: Humidity 2
     class: humidity
     dps:
       - id: 136
@@ -70,7 +70,7 @@ secondary_entities:
         class: measurement
         
   - entity: sensor
-    name: sensor 3 temperature
+    name: Temperature 3
     class: temperature
     dps:
       - id: 137
@@ -82,7 +82,7 @@ secondary_entities:
         class: measurement
   - entity: sensor
   
-    name: sensor 3 humidity
+    name: Humidity 3
     class: humidity
     dps:
       - id: 138
@@ -90,4 +90,3 @@ secondary_entities:
         name: sensor
         unit: "%"
         class: measurement
-        


### PR DESCRIPTION
Weather station supports also outside climate, but since it is taken from internet, based on location, there is no need to integrate that.