### PR TITLE
Don't remove the shutdown handler while running it

### DIFF
--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -161,9 +161,6 @@ class TuyaLocalDevice(object):
     async def async_stop(self, event=None):
         _LOGGER.debug("Stopping monitor loop for %s", self.name)
         self._running = False
-        if self._shutdown_listener:
-            self._shutdown_listener()
-            self._shutdown_listener = None
         self._children.clear()
         self._force_dps.clear()
         if self._refresh_task:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -459,9 +459,8 @@ class TestDevice(IsolatedAsyncioTestCase):
         # Call the function under test
         await self.subject.async_stop()
 
-        # Was the shutdown listener cancelled?
-        listener.assert_called_once()
-        self.assertIsNone(self.subject._shutdown_listener)
+        # Shutdown listener doesn't get cancelled as HA does that
+        listener.assert_not_called()
         # Were the child entities cleared?
         self.assertEqual(self.subject._children, [])
         # Did it wait for the refresh task to finish then clear it?


### PR DESCRIPTION
When I restart HA, I get the following
```
2023-09-17 14:12:25.596 ERROR (MainThread) [homeassistant.core] Unable to remove unknown job listener (<Job onetime listen homeassistant_stop <bound method TuyaLocalDevice.async_stop of <custom_components.tuya_local.device.TuyaLocalDevice object at 0x7ff15634fdd0>> HassJobType.Callback <function TuyaLocalDevice.async_stop at 0x7ff14e834220>>, None, False)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/core.py", line 1206, in _async_remove_listener
    self._listeners[event_type].remove(filterable_job)
ValueError: list.remove(x): x not in list
```

This is because the `EVENT_HOMEASSISTANT_STOP` handler calls `async_stop` and then in the middle of that code we call the callback to remove the hander, and so HA gets confused when it's expecting to be able to cleanup the call-once handler afterwards! This PR removes that code.
