### PR TITLE
Add new product ID for PC321-TY

### DIFF
--- a/custom_components/tuya_local/devices/pc321ty_energy_meter.yaml
+++ b/custom_components/tuya_local/devices/pc321ty_energy_meter.yaml
@@ -1,6 +1,7 @@
 name: PC321-TY power clamp
 products:
   - id: r64livttuufctble
+  - id: 9rjjf6rdkca9woju
 primary_entity:
   entity: sensor
   class: energy


### PR DESCRIPTION
Add new product ID for the PC321-TY device. This was sold under the "PC321-TY 80A" product name via aliexpress. There appears to be no difference between the exposed data compared with the prior "r64livttuufctble" device.

This was tested with the updated firmware that noted many fixes: Main module: v2.0.2 & MCU Module: v1.1.3

https://www.aliexpress.com/item/1005004895850599.html