### PR TITLE
Adding support to intelbras IFR7000 lock.

### DIFF
--- a/custom_components/tuya_local/devices/intelbras_IFR7000_lock.yaml
+++ b/custom_components/tuya_local/devices/intelbras_IFR7000_lock.yaml
@@ -1,0 +1,45 @@
+name: Intelbras IFR7000 lock
+products:
+  - id: a6nttc41
+    name: Intelbras IFR 7000
+primary_entity:
+  entity: lock
+  dps:
+    - id: 1
+      type: integer
+      name: unlock_fingerprint
+      optional: true
+    - id: 7
+      type: integer
+      name: unlock_key
+      optional: true
+    - id: 8
+      type: boolean
+      name: lock
+      optional: true
+      readonly: true
+      mapping:
+        - dps_val: true
+          value: False
+        - dps_val: false
+          value: True
+    - id: 9
+      type: string
+      name: alarm
+      optional: true
+    - id: 47
+      type: string
+      name: Lock raw
+    - id: 57
+      type: boolean
+      name: Lock Motor Status
+      optional: true
+secondary_entities:
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        unit: "%"

--- a/custom_components/tuya_local/devices/intelbras_IFR7000_lock.yaml
+++ b/custom_components/tuya_local/devices/intelbras_IFR7000_lock.yaml
@@ -1,4 +1,4 @@
-name: Intelbras IFR7000 lock
+name: Door lock
 products:
   - id: a6nttc41
     name: Intelbras IFR 7000


### PR DESCRIPTION
Adding support to [IFR7000](https://www.intelbras.com/pt-br/fechadura-smart-de-embutir-com-macaneta-ifr-7000) lock. It's possible it will work on IFR7001 too. 

This product is very popular in Brazil, but we don't have any way to add it to Home Assistant (until this PR).

The lock dp is readonly. I guess it should be this way for security purposes.

![Screenshot 2023-09-19 at 21 57 38](https://github.com/make-all/tuya-local/assets/2902946/aa3142b7-8893-4810-8e6b-0f8b027da7c1)


