### PR TITLE
Add support for a generic valve

### DIFF
--- a/custom_components/tuya_local/devices/generic_valve.yaml
+++ b/custom_components/tuya_local/devices/generic_valve.yaml
@@ -1,16 +1,17 @@
-name: Generic Valve
+name: Valve controller
 products:
   - id: nguto5atyd2xxnap
-    name: ARD-100+ Smart valve controller
+    name: ARD-100+ smart valve controller
 primary_entity:
   entity: switch
+  icon: "mdi:valve"
   dps:
     - id: 1
       type: boolean
       name: switch
 secondary_entities:
   - entity: number
-    name: Countdown
+    name: Timer
     icon: "mdi:timer"
     category: config
     dps:
@@ -25,7 +26,7 @@ secondary_entities:
           - scale: 1
           - dps_val: null
   - entity: select
-    name: Restart status
+    name: Initial state
     category: config
     icon: "mdi:toggle-switch"
     dps:

--- a/custom_components/tuya_local/devices/generic_valve.yaml
+++ b/custom_components/tuya_local/devices/generic_valve.yaml
@@ -25,7 +25,7 @@ secondary_entities:
           - scale: 1
           - dps_val: null
   - entity: select
-    name: Relay status
+    name: Restart status
     category: config
     icon: "mdi:toggle-switch"
     dps:

--- a/custom_components/tuya_local/devices/generic_valve.yaml
+++ b/custom_components/tuya_local/devices/generic_valve.yaml
@@ -1,0 +1,41 @@
+name: Generic Valve
+products:
+  - id: nguto5atyd2xxnap
+    name: ARD-100+ Smart valve controller
+primary_entity:
+  entity: switch
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+secondary_entities:
+  - entity: number
+    name: Countdown
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 7
+        name: value
+        type: integer
+        range:
+          min: 0
+          max: 86400
+        unit: sec
+        mapping:
+          - scale: 1
+          - dps_val: null
+  - entity: select
+    name: Relay status
+    category: config
+    icon: "mdi:toggle-switch"
+    dps:
+      - id: 14
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "Off"
+          - dps_val: "on"
+            value: "On"
+          - dps_val: "memory"
+            value: "Last state"


### PR DESCRIPTION
This adds support for a generic valve (wifi/ble). I've got one without box so not sure about the model, but it looks exactly like [this one](https://botland.store/tuya-home-automation/17447-water-gas-ball-valve-actuator-wifi-tuya-rtx-wvw1-5904422327576.html).
It identifies itself as Smart valve controller (model ARD-100+). It's very basic, the only features available in Tuya app are:
- on/off switch (where "on" means "valve open")
- timer
- "restart status" selection (off/on/last state)

The reported firmware versions are 1.1.5 (main) and 1.1.5 (MCU). 