### PR TITLE
Revert changes causing device  integration issues

### DIFF
--- a/custom_components/tuya_local/devices/jiahong_et72w_thermostat.yaml
+++ b/custom_components/tuya_local/devices/jiahong_et72w_thermostat.yaml
@@ -37,23 +37,23 @@ primary_entity:
               value: auto
             - dps_val: false
               value_redirect: power
-            - dps_val: "Manual"
-              icon: "mdi:fire"
-              constraint: power
-              conditions:
-                - dps_val: true
-                  value: heat
-                - dps_val: false
-                  value_redirect: power
-                  value: "off"
-            - dps_val: "Anti_frozen"
-              icon: "mdi:snowflake"
-              constraint: power
-              conditions:
-                - dps_val: true
-                  value: cool
-                - dps_val: false
-                  value_redirect: power
+        - dps_val: "Manual"
+          icon: "mdi:fire"
+          constraint: power
+          conditions:
+            - dps_val: true
+              value: heat
+            - dps_val: false
+              value_redirect: power
+              value: "off"
+        - dps_val: "Anti_frozen"
+          icon: "mdi:snowflake"
+          constraint: power
+          conditions:
+            - dps_val: true
+              value: cool
+            - dps_val: false
+              value_redirect: power
     - id: 105
       type: integer
       name: current_temperature
@@ -94,6 +94,7 @@ primary_entity:
             - dps_val: true
               value: heating
             - dps_val: false
+              value_redirect: power
               value: "off"
         - dps_val: false
           constraint: power

--- a/custom_components/tuya_local/devices/jiahong_et72w_thermostat.yaml
+++ b/custom_components/tuya_local/devices/jiahong_et72w_thermostat.yaml
@@ -4,22 +4,11 @@ primary_entity:
   dps:
     - id: 101
       type: boolean
-      name: hvac_mode
+      name: power
       mapping:
         - dps_val: false
           value: "off"
-        - dps_val: true
-          constraint: mode
-          conditions:
-            - dps_val: "Smart"
-              icon: "mdi:calendar-sync"
-              value: auto
-            - dps_val: "Manual"
-              icon: "mdi:fire"
-              value: heat
-            - dps_val: "Anti_frozen"
-              icon: "mdi:snowflake"
-              value: cool
+      hidden: true
     - id: 102
       type: integer
       name: temperature
@@ -38,8 +27,33 @@ primary_entity:
                 max: 750
     - id: 103
       type: string
-      name: mode
-      hidden: true
+      name: hvac_mode
+      mapping:
+        - dps_val: "Smart"
+          icon: "mdi:calendar-sync"
+          constraint: power
+          conditions:
+            - dps_val: true
+              value: auto
+            - dps_val: false
+              value_redirect: power
+            - dps_val: "Manual"
+              icon: "mdi:fire"
+              constraint: power
+              conditions:
+                - dps_val: true
+                  value: heat
+                - dps_val: false
+                  value_redirect: power
+                  value: "off"
+            - dps_val: "Anti_frozen"
+              icon: "mdi:snowflake"
+              constraint: power
+              conditions:
+                - dps_val: true
+                  value: cool
+                - dps_val: false
+                  value_redirect: power
     - id: 105
       type: integer
       name: current_temperature
@@ -75,18 +89,19 @@ primary_entity:
       name: hvac_action
       mapping:
         - dps_val: true
-          constraint: hvac_mode
+          constraint: power
           conditions:
             - dps_val: true
               value: heating
             - dps_val: false
               value: "off"
         - dps_val: false
-          constraint: hvac_mode
+          constraint: power
           conditions:
             - dps_val: true
               value: idle
             - dps_val: false
+              value_redirect: power
               value: "off"
     - id: 104
       type: integer


### PR DESCRIPTION
Revert changes from https://github.com/craibo/tuya-local/commit/370ddcfcb6aa580b4e5bff7c3c1936de5e1dc646 to Jiahong ET-72W thermostate.

These changes break the climate details reflecting  in Home Assistant.

Issues noticed:
1. If the device is manually updated these updates do not reflect on home assistant. eg. Device is on but HA shows it is off
2. Modifying the lock screen turns on the device incorrectly.