### PR TITLE
expand ZG205W configuration

### DIFF
--- a/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
@@ -2,6 +2,9 @@ name: mmWave presence sensor
 products:
   - id: qbapy7r4deyp6zbx
     name: ZG-205W
+  - id: uykwakpl6rbxvjdd
+    name: ZG-205W/A
+
 primary_entity:
   entity: binary_sensor
   class: occupancy
@@ -14,42 +17,15 @@ primary_entity:
           value: true
         - dps_val: none
           value: false
+    # - id: 111
+    #   name: breathingselftest
 secondary_entities:
-  - entity: light
-    name: Led indicator
-    category: config
-    dps:
-      - id: 103
-        type: boolean
-        name: switch
   - entity: number
     name: Motion sensitivity
     category: config
     icon: mdi:motion-sensor
     dps:
       - id: 2
-        type: integer
-        name: value
-        range:
-          min: 0
-          max: 10
-  - entity: number
-    name: Stationary sensitivity
-    category: config
-    icon: mdi:motion-sensor
-    dps:
-      - id: 102
-        type: integer
-        name: value
-        range:
-          min: 0
-          max: 10
-  - entity: number
-    name: Small motion sensitivity
-    category: config
-    icon: mdi:motion-sensor
-    dps:
-      - id: 106
         type: integer
         name: value
         range:
@@ -85,6 +61,48 @@ secondary_entities:
         mapping:
           - scale: 100
             step: 10
+  - entity: sensor
+    class: illuminance
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: lx
+        class: measurement
+  - entity: number
+    name: Stationary sensitivity
+    category: config
+    icon: mdi:motion-sensor
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
+  - entity: light
+    name: Led indicator
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: select
+    name: Alarm mode
+    class: enum
+    icon: mdi:shield-home
+    category: config
+    dps:
+      - id: 104
+        type: string
+        name: option
+        mapping:
+          - dps_val: armed
+            value: Armed
+          - dps_val: disarm
+            value: Disarm
+          - dps_val: sos
+            value: Alarm
   - entity: number
     name: Small motion detection distance
     category: config
@@ -100,6 +118,17 @@ secondary_entities:
         mapping:
           - scale: 100
             step: 10
+  - entity: number
+    name: Small motion sensitivity
+    category: config
+    icon: mdi:motion-sensor
+    dps:
+      - id: 106
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
   - entity: select
     name: Alarm volume
     class: enum
@@ -118,39 +147,6 @@ secondary_entities:
             value: Low
           - dps_val: mute
             value: Mute
-  - entity: select
-    name: Alarm mode
-    class: enum
-    icon: mdi:shield-home
-    category: config
-    dps:
-      - id: 104
-        type: string
-        name: option
-        mapping:
-          - dps_val: armed
-            value: Armed
-          - dps_val: disarm
-            value: Disarm
-          - dps_val: sos
-            value: Alarm
-  - entity: sensor
-    name: Detection state
-    class: enum
-    icon: mdi:cursor-move
-    dps:
-      - id: 116
-        type: string
-        name: sensor
-        mapping:
-          - dps_val: large_move
-            value: Large move
-          - dps_val: small_move
-            value: Small move
-          - dps_val: breathe
-            value: Breathe
-          - dps_val: none
-            value: None
   - entity: number
     name: Exit delay
     category: config
@@ -161,10 +157,8 @@ secondary_entities:
         name: value
         unit: s
         range:
-          min: 1
-          max: 100
-        mapping:
-          - scale: 10
+          min: 0
+          max: 28800
   - entity: number
     name: Alarm duration
     category: config
@@ -177,11 +171,133 @@ secondary_entities:
         range:
           min: 1
           max: 30
-  - entity: sensor
-    class: illuminance
+  - entity: number
+    name: Motion minimum detection distance
+    category: config
+    icon: mdi:signal-distance-variant
+    hidden: true
     dps:
-      - id: 101
+      - id: 110
         type: integer
+        name: value
+        unit: m
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - scale: 100
+            step: 10
+  - entity: number
+    name: Small motion minimum detection distance
+    category: config
+    icon: mdi:signal-distance-variant
+    hidden: true
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        unit: m
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - scale: 100
+            step: 10
+  - entity: number
+    name: Breathing minimum detection distance
+    category: config
+    icon: mdi:signal-distance-variant
+    hidden: true
+    dps:
+      - id: 112
+        type: integer
+        name: value
+        unit: m
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - scale: 100
+            step: 10
+  - entity: number
+    name: Adaptive testing time
+    category: diagnostic
+    icon: mdi:timer
+    hidden: true
+    dps:
+      - id: 113
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 300
+  - entity: switch
+    name: Adaptive test duration
+    category: diagnostic
+    icon: mdi:test-tube
+    dps:
+      - id: 114
+        name: switch
+        type: boolean
+  - entity: button
+    name: Factory reset
+    category: diagnostic
+    icon: mdi:restore-alert
+    dps:
+      - id: 115
+        type: boolean
+        name: button
+        optional: true
+  - entity: sensor
+    name: Movement state
+    class: enum
+    icon: mdi:cursor-move
+    dps:
+      - id: 116
+        type: string
         name: sensor
-        unit: lx
-        class: measurement
+        mapping:
+          - dps_val: large_move
+            value: Large
+          - dps_val: small_move
+            value: Small
+          - dps_val: breathe
+            value: Breathe
+          - dps_val: none
+            value: None
+  - entity: switch
+    name: Small motion self-test
+    category: diagnostic
+    icon: "mdi:test-tube"
+    dps:
+      - id: 117
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Breathing self-test
+    category: diagnostic
+    icon: "mdi:test-tube"
+    dps:
+      - id: 118
+        name: switch
+        type: boolean
+  - entity: number
+    name: Motion false detection
+    category: config
+    icon: mdi:alpha-x-circle
+    dps:
+      - id: 119
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
+  - entity: switch
+    name: Breathing false detection
+    category: config
+    icon: mdi:lungs
+    dps:
+      - id: 120
+        name: switch
+        type: boolean

--- a/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
@@ -233,7 +233,7 @@ secondary_entities:
           min: 0
           max: 300
   - entity: switch
-    name: Adaptive test duration
+    name: Adaptive test
     category: diagnostic
     icon: mdi:test-tube
     dps:

--- a/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
@@ -221,7 +221,7 @@ secondary_entities:
             step: 10
   - entity: number
     name: Adaptive testing time
-    category: diagnostic
+    category: config
     icon: mdi:timer
     hidden: true
     dps:
@@ -234,7 +234,7 @@ secondary_entities:
           max: 300
   - entity: switch
     name: Adaptive test
-    category: diagnostic
+    category: config
     icon: mdi:test-tube
     dps:
       - id: 114
@@ -242,7 +242,7 @@ secondary_entities:
         type: boolean
   - entity: button
     name: Factory reset
-    category: diagnostic
+    category: config
     icon: mdi:restore-alert
     dps:
       - id: 115
@@ -268,7 +268,7 @@ secondary_entities:
             value: None
   - entity: switch
     name: Small motion self-test
-    category: diagnostic
+    category: config
     icon: "mdi:test-tube"
     dps:
       - id: 117
@@ -276,7 +276,7 @@ secondary_entities:
         type: boolean
   - entity: switch
     name: Breathing self-test
-    category: diagnostic
+    category: config
     icon: "mdi:test-tube"
     dps:
       - id: 118


### PR DESCRIPTION
I have a ZG/205W/A model of the sensor which uses the same model and dp's as the existing configuration despite not having any alarm/siren capabilities.

 <img src="https://github.com/make-all/tuya-local/assets/5904370/fae845cc-a7ce-472f-99a9-3a51ad259330" width="200" height="200">


```
2023-10-07 15:59:28.905 DEBUG (MainThread) [custom_components.tuya_local.device] ZG205 received {"1": "none", "2": 8, "3": 1000, "4": 600, "101": 989, "102": 8, "103": true, "104": "disarm", "105": 600, "106": 2, "107": "high", "108": 7, "109": 2, "110": 0, "111": 0, "112": 0, "113": 0, "114": false, "115": true, "116": "none", "117": false, "118": false, "119": 1, "120": false, "full_poll": true}
```

I discovered a few new dp's so I included all of them for completeness and changes the "Detection state" sensor name and values to better reflect their function.

The dp's marked diagnostic are all undocumented by the manufacturer, my assumption is that it does some sort of self test to adapt to room conditions but its all just speculation.