### PR TITLE
Add support for Reiga 52 Ceiling fan with Light

### DIFF
--- a/custom_components/tuya_local/devices/reiga_52_fan_light.yaml
+++ b/custom_components/tuya_local/devices/reiga_52_fan_light.yaml
@@ -1,7 +1,7 @@
-name: Reiga Ceiling Fan
+name: Ceiling fan with light
 products:
   - id: g0ewlb1vmwqljzji
-    name: Reiga 52 Ceiling Fan with Light
+    name: Reiga 52 ceiling fan with light
 primary_entity:
   entity: fan
   translation_key: fan_with_presets
@@ -61,14 +61,15 @@ secondary_entities:
       - id: 16
         type: integer
         name: brightness
-
+        range:
+          min: 0
+          max: 255
         mapping:
           - scale: 0.392156862745098
       - id: 17
         type: integer
         name: color_temp
         mapping:
-          - step: 1
           - target_range:
               min: 2700
               max: 6500

--- a/custom_components/tuya_local/devices/reiga_52_fan_light.yaml
+++ b/custom_components/tuya_local/devices/reiga_52_fan_light.yaml
@@ -40,12 +40,14 @@ secondary_entities:
         type: string
         name: option
         mapping:
-          - dps_val: cancel
+          - dps_val: "off"
             value: "Off"
           - dps_val: "1hour"
             value: "1 hour"
-          - dps_val: "3hour"
-            value: "3 hours"
+          - dps_val: "2hour"
+            value: "2 hours"
+          - dps_val: "4hour"
+            value: "4 hours"
           - dps_val: "8hour"
             value: "8 hours"
   - entity: light
@@ -66,7 +68,7 @@ secondary_entities:
         type: integer
         name: color_temp
         mapping:
-          - step: 50
+          - step: 1
           - target_range:
               min: 2700
               max: 6500

--- a/custom_components/tuya_local/devices/reiga_52_fan_light.yaml
+++ b/custom_components/tuya_local/devices/reiga_52_fan_light.yaml
@@ -1,0 +1,75 @@
+name: Reiga Ceiling Fan
+products:
+  - id: g0ewlb1vmwqljzji
+    name: Reiga 52 Ceiling Fan with Light
+primary_entity:
+  entity: fan
+  translation_key: fan_with_presets
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: normal
+          value: normal
+        - dps_val: nature
+          value: nature
+        - dps_val: sleep
+          value: sleep
+    - id: 3
+      type: integer
+      name: speed
+      range:
+        min: 1
+        max: 6
+      mapping:
+        - scale: 0.06
+    - id: 8
+      type: string
+      name: direction
+secondary_entities:
+  - entity: select
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: "Off"
+          - dps_val: "1hour"
+            value: "1 hour"
+          - dps_val: "3hour"
+            value: "3 hours"
+          - dps_val: "8hour"
+            value: "8 hours"
+  - entity: light
+    name: Light
+    icon: "mdi:lightbulb"
+    category: config
+    dps:
+      - id: 15
+        type: boolean
+        name: switch
+      - id: 16
+        type: integer
+        name: brightness
+
+        mapping:
+          - scale: 0.392156862745098
+      - id: 17
+        type: integer
+        name: color_temp
+        mapping:
+          - step: 50
+          - target_range:
+              min: 2700
+              max: 6500
+        range:
+          min: 0
+          max: 100


### PR DESCRIPTION
Tested each setting myself. 

DP Status from tinytuya:
{'dps': {'1': True, '2': 'normal', '3': 2, '8': 'reverse', '15': False, '16': 60, '17': 32, '22': 'off'}}

DP Configuration:
I had to piece this together manually because my api trial ended. I got these from debugging the normal Tuya integration and from using tinytuya. 

I manually tested each of the values for each of the settings

```
code='mode',
  type='Enum',
  values='{"range":["normal", "sleep", "nature"]}'

# This is actually wrong. They are numeric values, not strings.
code='fan_speed',
 type='Enum',
 values='{"range":["1", "2", "3", "4", "5", "6"]}

code='fan_direction',
  type='Enum',
   values='{"range":["forward", "reverse"]}'

code='light',
 type='Boolean',
 values='{}'

# also wrong. the minimum it goes to is 2
code='bright_value',
 type='Integer',
 values='{"min":0, "max":100, "scale":0, "step":1}

code='temp_value',
 type='Integer',
 values='{"min":0, "max":100, "scale":0, "step":1}')

# wrong again. these values don't work, but values like '1hour' work. 'cancel' is wrong. the actual value I get from tinytuya is 'off'.
code='countdown_set',
 type='Enum',
 values='{"range":["cancel", "1h", "2h", "4h", "8h"]

code='mode',
 type='Enum',
 values='{"range":["normal", "sleep", "nature"
```