### PR TITLE
Fixed fan levels for wilfa_haze_hu400bc_humidifier

### DIFF
--- a/custom_components/tuya_local/devices/wilfa_haze_hu400bc_humidifier.yaml
+++ b/custom_components/tuya_local/devices/wilfa_haze_hu400bc_humidifier.yaml
@@ -58,14 +58,16 @@ secondary_entities:
         name: speed
         mapping:
           - dps_val: level_0
-            value: 20
+            value: 0
           - dps_val: level_1
-            value: 40
+            value: 20
           - dps_val: level_2
-            value: 60
+            value: 40
           - dps_val: level_3
-            value: 80
+            value: 60
           - dps_val: level_4
+            value: 80
+          - dps_val: level_5
             value: 100
   - entity: light
     name: Mood


### PR DESCRIPTION
The humidifier supports 5 levels, but the current config only supports up to level 4. I added "level_5" and adjusted the percentages accordingly.

I tested this with my local installation and it seems to work well.