### PR TITLE
Add support for ZY-M201 aka ZY-M100-24G

### DIFF
--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -4,7 +4,7 @@ products:
     name: ZY-M201-WIFI24G
 primary_entity:
   entity: binary_sensor
-  class: occupancy
+  class: presence
   dps:
     - id: 101
       type: string

--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -26,14 +26,17 @@ secondary_entities:
         mapping:
           - dps_val: none
             value: "None"
+            icon: "mdi:motion-sensor-off"
           - dps_val: presence
-            value: "Presence"
+            value: "Still"
+            icon: "mdi:human-handsdown"
           - dps_val: move
-            value: "Move"
+            value: "Moving"
+            icon: "mdi:walk"
   - entity: number
     name: Sensitivity
     category: config
-    icon: "mdi:motion-sensor"
+    icon: "mdi:human-greeting-proximity"
     dps:
       - id: 2
         type: integer
@@ -94,7 +97,7 @@ secondary_entities:
   - entity: number
     name: Static sensitivity
     category: config
-    icon: "mdi:motion-sensor"
+    icon: "mdi:human-greeting-proximity"
     dps:
       - id: 111
         type: integer

--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -55,7 +55,7 @@ secondary_entities:
           max: 550
         mapping:
           - scale: 100
-            step: 10
+            step: 100
   - entity: sensor
     name: Target distance
     class: distance

--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -4,7 +4,7 @@ products:
     name: ZY-M201-WIFI24G
 primary_entity:
   entity: binary_sensor
-  class: presence
+  class: occupancy
   dps:
     - id: 101
       type: string

--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -1,0 +1,104 @@
+name: mmWave presence sensor
+products:
+  - id: n3bow00a2vpwgtvx
+    name: ZY-M201-WIFI24G
+primary_entity:
+  entity: binary_sensor
+  class: occupancy
+  dps:
+    - id: 101
+      type: string
+      name: sensor
+      mapping:
+        - dps_val: exist
+          value: true
+        - dps_val: nobody
+          value: false
+secondary_entities:
+  - entity: sensor
+    name: Presence state
+    class: enum
+    icon: mdi:cursor-move
+    dps:
+      - id: 1
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: none
+            value: "None"
+          - dps_val: presence
+            value: "Presence"
+          - dps_val: move
+            value: "Move"
+  - entity: number
+    name: Sensitivity
+    category: config
+    icon: "mdi:motion-sensor"
+    dps:
+      - id: 2
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 10
+  - entity: number
+    name: Maximum detection distance
+    category: config
+    icon: "mdi:arrow-collapse-right"
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: m
+        range:
+          min: 150
+          max: 550
+        mapping:
+          - scale: 100
+            step: 10
+  - entity: sensor
+    name: Target distance
+    class: distance
+    icon: "mdi:tape-measure"
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: m
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Fading time
+    category: config
+    icon: "mdi:timer-sand-complete"
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 5
+          max: 1500
+        mapping:
+          - scale: 10
+            step: 5
+  - entity: sensor
+    class: illuminance
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: lx
+        class: measurement
+  - entity: number
+    name: Static sensitivity
+    category: config
+    icon: "mdi:motion-sensor"
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 10


### PR DESCRIPTION
Adds support for new version of ZY-M100 with 24Ghz radar. Box labelled as M100, Tuya shows device as "ZY-M201-WIFI24G存在感应器"

![LMC_12 8 4 pq20231019_112850_PQ F3-LMCR13-5 F](https://github.com/make-all/tuya-local/assets/5904370/3a3a30d2-83e6-4ba7-a48f-c06db21e125f)
