### PR TITLE
New device - Akai Heat Pump Dryer

### DIFF
--- a/custom_components/tuya_local/devices/akai_dryer.yaml
+++ b/custom_components/tuya_local/devices/akai_dryer.yaml
@@ -1,0 +1,118 @@
+name: Akai Heat Pump Dryer
+products:
+  - id: do3cbzmmdqfdpqxw
+    name: Akai Heat Pump Dryer
+primary_entity:
+  entity: sensor
+  class: enum
+  dps:
+    - id: 107
+      name: sensor # state
+      type: string
+      mapping:
+        - dps_val: "off"
+          value: "off"
+        - dps_val: "set"
+          value: "set"
+        - dps_val: "run"
+          value: "run"
+        - dps_val: "pause"
+          value: "pause"
+        - dps_val: "delay"
+          value: "delay"
+        - dps_val: "end"
+          value: "end"
+        - dps_val: "err"
+          value: "error"
+    - id: 7
+      name: error # fault
+      type: integer
+secondary_entities:
+  - entity: button
+    name: Start
+    dps:
+      - id: 105
+        name: button # start
+        type: boolean
+  - entity: select
+    class: enum
+    name: Drying Mode
+    dps:
+      - id: 5
+        name: option # drying_mode
+        type: string
+        mapping:
+          - dps_val: "OFF"
+            value: "Off"
+          - dps_val: "Standard"
+            value: "Standard"
+          - dps_val: "Cotton"
+            value: "Cotton"
+          - dps_val: "Synthetic"
+            value: "Synthetic"
+          - dps_val: "Bulky_Ttem"
+            value: "Bulky Item"
+          - dps_val: "Towel"
+            value: "Towel"
+          - dps_val: "Wool"
+            value: "Wool"
+          - dps_val: "Duvet"
+            value: "Duvet"
+          - dps_val: "Baby_Care"
+            value: "Baby Care"
+          - dps_val: "Warm_Air"
+            value: "Warm Air"
+          - dps_val: "Refresh"
+            value: "Refresh"
+          - dps_val: "Time"
+            value: "Time"
+          - dps_val: "Underwear"
+            value: "Underwear"
+          - dps_val: "Denim"
+            value: "Denim"
+          - dps_val: "Shirts"
+            value: "Shirts"
+          - dps_val: "Sportswear"
+            value: "Sportswear"
+  - entity: select
+    class: enum
+    name: Drying Level
+    dps:
+      - id: 101
+        name: option # drying_level
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: "Auto"
+          - dps_val: 1
+            value: "Low"
+          - dps_val: 2
+            value: "Medium"
+          - dps_val: 3
+            value: "High"
+  - entity: switch
+    name: Anti Crease
+    dps:
+      - id: 103
+        name: switch # anti_crease
+        type: boolean
+  - entity: switch
+    name: Lock
+    dps:
+      - id: 106
+        name: switch # lock
+        type: boolean
+  - entity: sensor
+    name: Drying Time
+    dps:
+      - id: 3
+        name: sensor # drying_time
+        type: integer
+        unit: min
+  - entity: sensor
+    name: Drying Time Left
+    dps:
+      - id: 4
+        name: sensor # drying_time_left
+        type: integer
+        unit: min

--- a/custom_components/tuya_local/devices/akai_dryer.yaml
+++ b/custom_components/tuya_local/devices/akai_dryer.yaml
@@ -1,10 +1,11 @@
-name: Akai Heat Pump Dryer
+name: Dryer
 products:
   - id: do3cbzmmdqfdpqxw
-    name: Akai Heat Pump Dryer
+    name: Akai heat pump dryer
 primary_entity:
   entity: sensor
   class: enum
+  icon: "mdi:tumble-dryer"
   dps:
     - id: 107
       name: sensor # state
@@ -25,18 +26,19 @@ primary_entity:
         - dps_val: "err"
           value: "error"
     - id: 7
-      name: error # fault
+      name: fault_code
       type: integer
 secondary_entities:
   - entity: button
     name: Start
+    icon: "mdi:play"
     dps:
       - id: 105
         name: button # start
         type: boolean
   - entity: select
-    class: enum
-    name: Drying Mode
+    name: Drying mode
+    icon: "mdi:tumble-dryer"
     dps:
       - id: 5
         name: option # drying_mode
@@ -75,8 +77,8 @@ secondary_entities:
           - dps_val: "Sportswear"
             value: "Sportswear"
   - entity: select
-    class: enum
-    name: Drying Level
+    name: Drying level
+    icon: "mdi:signal"
     dps:
       - id: 101
         name: option # drying_level
@@ -91,26 +93,29 @@ secondary_entities:
           - dps_val: 3
             value: "High"
   - entity: switch
-    name: Anti Crease
+    name: Anti crease
+    icon: "mdi:iron"
     dps:
       - id: 103
-        name: switch # anti_crease
+        name: switch
         type: boolean
-  - entity: switch
+  - entity: lock
     name: Lock
     dps:
       - id: 106
-        name: switch # lock
+        name: lock
         type: boolean
   - entity: sensor
-    name: Drying Time
+    name: Drying time
+    class: duration
     dps:
       - id: 3
-        name: sensor # drying_time
+        name: sensor
         type: integer
         unit: min
   - entity: sensor
-    name: Drying Time Left
+    name: Drying time remaining
+    class: duration
     dps:
       - id: 4
         name: sensor # drying_time_left


### PR DESCRIPTION
I can't find an example of a Dryer entity anywhere (neither in HASS or this project), so hopefully the way I've set this device up makes sense.

The modes can be selected and the device can be started.

UX doesn't feel quite right - i feel like selecting a drying mode should fire off the 'start' DP (unless the selected mode is 'off').

![image](https://github.com/make-all/tuya-local/assets/365349/e9a787a7-e443-4e67-a433-900ecf734dd9)

Fixes #1265
