### PR TITLE
new device hyd weair plus fan

### DIFF
--- a/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
+++ b/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
@@ -6,9 +6,18 @@ primary_entity:
   entity: climate
   dps:
     - id: 1
+      name: hvac_mode
       type: boolean
-      name: mode
-      hidden: true
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: true
+              value: "heat"
+            - dps_val: false
+              value: "fan_only"
     - id: 2
       name: fan_mode
       type: string
@@ -65,21 +74,9 @@ primary_entity:
       name: fault
       optional: true
     - id: 103
-      name: hvac_mode
       type: boolean
-      mapping:
-        - dps_val: true
-          value: "heat"
-          icon: "mdi:radiator"
-        - dps_val: false
-          value: "off"
-          icon: "mdi:radiator-disabled"
-          constraint: mode
-          conditions:
-            - dps_val: true
-              value: "cool"
-            - dps_val: false
-              value: "off"
+      name: mode
+      hidden: true
 secondary_entities:
   - entity: select
     name: Timer
@@ -88,26 +85,25 @@ secondary_entities:
       - id: 11
         type: string
         name: option
-        unit: "hour"
         mapping:
           - dps_val: "0"
             value: "Off"
           - dps_val: "1"
-            value: "1"
+            value: "1 hour"
           - dps_val: "2"
-            value: "2"
+            value: "2 hours"
           - dps_val: "3"
-            value: "3"
+            value: "3 hours"
           - dps_val: "4"
-            value: "4"
+            value: "4 hours"
           - dps_val: "5"
-            value: "5"
+            value: "5 hours"
           - dps_val: "6"
-            value: "6"
+            value: "6 hours"
           - dps_val: "7"
-            value: "7"
+            value: "7 hours"
           - dps_val: "8"
-            value: "8"
+            value: "8 hours"
   - entity: sensor
     name: Time remaining
     class: "duration"

--- a/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
+++ b/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
@@ -1,0 +1,149 @@
+name: HYD WeAir Plus Fan
+products:
+  - id: 6p7jm8rrqimnlusw
+    name: D-68
+primary_entity:
+  entity: fan
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 13
+      type: integer
+      name: fault
+      optional: true
+secondary_entities:
+  - entity: select
+    name: Wind Speed
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+          - dps_val: "6"
+            value: "6"
+          - dps_val: "7"
+            value: "7"
+          - dps_val: "8"
+            value: "8"
+          - dps_val: "9"
+            value: "9"
+  - entity: select
+    name: Wind Mode
+    category: config
+    icon: "mdi:thermometer-lines"
+    dps:
+      - id: 3
+        type: string
+        name: option
+        mapping:
+          - dps_val: "sleep"
+            value: "sleep"
+          - dps_val: "heavy"
+            value: "heavy"
+          - dps_val: "fresh"
+            value: "fresh"
+          - dps_val: "close"
+            value: "close"
+  - entity: switch
+    name: Windleftright
+    icon: "mdi:thermometer-lines"
+    dps:
+      - id: 8
+        type: boolean
+        name: switch
+  - entity: number
+    name: TempSet
+    dps:
+      - id: 9
+        type: integer
+        name: value
+        unit: "C"
+        range:
+          min: 1
+          max: 30
+  - entity: sensor
+    name: NowTemp
+    dps:
+      - id: 10
+        name: sensor
+        type: integer
+        unit: "C"
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "0"
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+          - dps_val: "6"
+            value: "6"
+          - dps_val: "7"
+            value: "7"
+          - dps_val: "8"
+            value: "8"
+  - entity: sensor
+    name: Countdown
+    dps:
+      - id: 12
+        name: sensor
+        type: integer
+        unit: min
+  - entity: switch
+    name: Beep
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Warm Switch
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: select
+    name: Warm Speed
+    category: config
+    dps:
+      - id: 106
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: 1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+  - entity: switch
+    name: UVC
+    dps:
+      - id: 107
+        type: boolean
+        name: switch

--- a/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
+++ b/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
@@ -3,83 +3,84 @@ products:
   - id: 6p7jm8rrqimnlusw
     name: D-68
 primary_entity:
-  entity: fan
+  entity: climate
   dps:
     - id: 1
       type: boolean
-      name: switch
+      name: mode
+      hidden: true
+    - id: 2
+      name: fan_mode
+      type: string
+      mapping:
+        - dps_val: "1"
+          value: "1"
+        - dps_val: "2"
+          value: "2"
+        - dps_val: "3"
+          value: "3"
+        - dps_val: "4"
+          value: "4"
+        - dps_val: "5"
+          value: "5"
+        - dps_val: "6"
+          value: "6"
+        - dps_val: "7"
+          value: "7"
+        - dps_val: "8"
+          value: "8"
+        - dps_val: "9"
+          value: "9"
+    - id: 3
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: "sleep"
+          value: "sleep"
+        - dps_val: "heavy"
+          value: "boost"
+        - dps_val: "fresh"
+          value: "comfort"
+        - dps_val: "close"
+          value: "none"
+    - id: 8
+      name: swing_mode
+      type: boolean
+      mapping:
+        - dps_val: true
+          value: "horizontal"
+        - dps_val: false
+          value: "off"
+    - id: 9
+      name: temperature
+      type: integer
+      range:
+        min: 1
+        max: 30
+    - id: 10
+      type: integer
+      name: current_temperature
     - id: 13
       type: integer
       name: fault
       optional: true
+    - id: 103
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: true
+          value: "heat"
+          icon: "mdi:radiator"
+        - dps_val: false
+          value: "off"
+          icon: "mdi:radiator-disabled"
+          constraint: mode
+          conditions:
+            - dps_val: true
+              value: "cool"
+            - dps_val: false
+              value: "off"
 secondary_entities:
-  - entity: select
-    name: Wind Speed
-    category: config
-    dps:
-      - id: 2
-        type: string
-        name: option
-        mapping:
-          - dps_val: "1"
-            value: "1"
-          - dps_val: "2"
-            value: "2"
-          - dps_val: "3"
-            value: "3"
-          - dps_val: "4"
-            value: "4"
-          - dps_val: "5"
-            value: "5"
-          - dps_val: "6"
-            value: "6"
-          - dps_val: "7"
-            value: "7"
-          - dps_val: "8"
-            value: "8"
-          - dps_val: "9"
-            value: "9"
-  - entity: select
-    name: Wind Mode
-    category: config
-    icon: "mdi:thermometer-lines"
-    dps:
-      - id: 3
-        type: string
-        name: option
-        mapping:
-          - dps_val: "sleep"
-            value: "sleep"
-          - dps_val: "heavy"
-            value: "heavy"
-          - dps_val: "fresh"
-            value: "fresh"
-          - dps_val: "close"
-            value: "close"
-  - entity: switch
-    name: Windleftright
-    icon: "mdi:thermometer-lines"
-    dps:
-      - id: 8
-        type: boolean
-        name: switch
-  - entity: number
-    name: TempSet
-    dps:
-      - id: 9
-        type: integer
-        name: value
-        unit: "C"
-        range:
-          min: 1
-          max: 30
-  - entity: sensor
-    name: NowTemp
-    dps:
-      - id: 10
-        name: sensor
-        type: integer
-        unit: "C"
   - entity: select
     name: Timer
     category: config
@@ -87,9 +88,10 @@ secondary_entities:
       - id: 11
         type: string
         name: option
+        unit: "hour"
         mapping:
           - dps_val: "0"
-            value: "0"
+            value: "Off"
           - dps_val: "1"
             value: "1"
           - dps_val: "2"
@@ -107,7 +109,8 @@ secondary_entities:
           - dps_val: "8"
             value: "8"
   - entity: sensor
-    name: Countdown
+    name: Time remaining
+    class: "duration"
     dps:
       - id: 12
         name: sensor
@@ -119,14 +122,8 @@ secondary_entities:
       - id: 102
         type: boolean
         name: switch
-  - entity: switch
-    name: Warm Switch
-    dps:
-      - id: 103
-        type: boolean
-        name: switch
   - entity: select
-    name: Warm Speed
+    name: Warm level
     category: config
     dps:
       - id: 106
@@ -142,7 +139,7 @@ secondary_entities:
           - dps_val: "4"
             value: "4"
   - entity: switch
-    name: UVC
+    name: UV sterilization
     dps:
       - id: 107
         type: boolean

--- a/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
+++ b/custom_components/tuya_local/devices/hyd_weair_plus_fan.yaml
@@ -1,7 +1,7 @@
-name: HYD WeAir Plus Fan
+name: Fan
 products:
   - id: 6p7jm8rrqimnlusw
-    name: D-68
+    name: HYD WeAir Plus D-68
 primary_entity:
   entity: climate
   dps:


### PR DESCRIPTION
Add support for hyd weair plus fan (D-68)
https://www.hyd.com.tw/products/weair-plus-iot%E9%81%A0%E7%AB%AF%E6%99%BA%E8%83%BD%E6%B6%BC%E6%9A%96%E9%A2%A8%E7%A9%BA%E6%B0%A3%E6%B8%85%E6%B7%A8%E6%A9%9F-d-68

Unfortunately, this product does not come with an English user manual.
In simple terms, this is a bladeless electric fan with both cooling and heating functions, as well as UV disinfection capability.
![78cc61a6bc-Gd-9819477](https://github.com/make-all/tuya-local/assets/4236169/ed4b8958-d9cd-422c-8aa6-5776d18d4acb)
