### PR TITLE
add Ferroli titano twin water heater

### DIFF
--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -3,35 +3,26 @@ products:
   - id: lci0ebsz7ftaruaf
     name: DT EWH
 primary_entity:
-  entity: climate
+  entity: water_heater
   dps:
     - id: 1
-      name: hvac_mode
+      name: operation_mode
       type: boolean
       mapping:
         - dps_val: false
           value: "off"
         - dps_val: true
-          constraint: preset_mode
+          constraint: work_mode
           conditions:
             - dps_val: manual
-              value: heat_cool
+              value: Electric
             - dps_val: eco
-              value: heat
+              value: eco
+              icon: "mdi:leaf"
     - id: 2
-      name: preset_mode
       type: string
-      mapping:
-        - dps_val: eco
-          value: "eco"
-    - id: 4
-      name: disinfection
-      type: boolean
-      mapping:
-        - dps_val: false
-          value: "off"
-        - dps_val: true
-          value: "on"
+      name: work_mode
+      hidden: true
     - id: 9
       type: integer
       name: temperature
@@ -41,24 +32,68 @@ primary_entity:
       mapping:
         - step: 5
       unit: C
-      step: 5
     - id: 10
       type: integer
       name: current_temperature
-    - id: 101
-      type: integer
-      name: fault_code
-    - id: 102
-      type: string
-      name: workstate
-    - id: 103
-      type: boolean
-      name: antifreeze
-      mapping:
-        - dps_val: false
-          value: "off"
-        - dps_val: true
-          value: "on"
-    - id: 104
-      type: integer
-      name: target_temperature
+secondary_entities:
+  - entity: binary_sensor
+    name: Anti-Legionella
+    category: diagnostic
+    dps:
+      - id: 4
+        name: sensor
+        type: boolean
+        mapping:
+          - dps_val: true
+            icon: "mdi:shield-cross-outline"
+          - dps_val: false
+            icon: "mdi:shield-remove-outline"
+  - entity: binary_sensor
+    class: problem
+    name: Fault
+    category: diagnostic
+    dps:
+      - id: 101
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+            icon: "mdi:water-boiler-alert"
+  - entity: sensor
+    name: Working status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 102
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "Heating"
+            icon: "mdi:water-boiler"
+          - dps_val: "Standby"
+            icon: "mdi:water-boiler-off"            
+  - entity: binary_sensor
+    name: Antifreeze
+    class: cold
+    category: diagnostic
+    dps:
+      - id: 103
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            icon: "mdi:snowflake-alert"
+          - dps_val: false
+            icon: "mdi:snowflake-off"
+  - entity: sensor
+    name: Target temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -71,7 +71,6 @@ secondary_entities:
             value: E6 clock RTC failure
   - entity: sensor
     name: Working status
-    class: enum
     category: diagnostic
     dps:
       - id: 102
@@ -105,5 +104,4 @@ secondary_entities:
         name: sensor
         unit: C
         class: measurement
-
-            
+        

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -1,0 +1,64 @@
+name: Ferroli Titano Twin
+products:
+  - id: lci0ebsz7ftaruaf
+    name: DT EWH
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: preset_mode
+          conditions:
+            - dps_val: manual
+              value: heat_cool
+            - dps_val: eco
+              value: heat
+    - id: 2
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: eco
+          value: "eco"
+    - id: 4
+      name: disinfection
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: "on"
+    - id: 9
+      type: integer
+      name: temperature
+      range:
+        min: 40
+        max: 80
+      mapping:
+        - step: 5
+      unit: C
+      step: 5
+    - id: 10
+      type: integer
+      name: current_temperature
+    - id: 101
+      type: integer
+      name: fault_code
+    - id: 102
+      type: string
+      name: workstate
+    - id: 103
+      type: boolean
+      name: antifreeze
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: "on"
+    - id: 104
+      type: integer
+      name: target_temperature

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -15,7 +15,7 @@ primary_entity:
           constraint: work_mode
           conditions:
             - dps_val: manual
-              value: Electric
+              value: electric
             - dps_val: eco
               value: eco
               icon: "mdi:leaf"

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -35,6 +35,18 @@ primary_entity:
     - id: 10
       type: integer
       name: current_temperature
+    - id: 101
+      type: bitfield
+      name: fault_code
+      mapping:
+        - dps_val: 1
+          value: E2 Operating without water
+        - dps_val: 2
+          value: E3 NTC temperature sensor
+        - dps_val: 4
+          value: E4 Water overheating 
+        - dps_val: 16
+          value: E6 clock RTC failure
 secondary_entities:
   - entity: switch
     name: Anti-Legionella
@@ -60,40 +72,22 @@ secondary_entities:
           - dps_val: 0
             value: false
           - value: true
-            icon: "mdi:water-boiler-alert"
-          - dps_val: 1
-            value: E2 Operating without water
-          - dps_val: 2
-            value: E3 NTC temperature sensor
-          - dps_val: 4
-            value: E4 Water overheating 
-          - dps_val: 16
-            value: E6 clock RTC failure
-  - entity: sensor
+  - entity: binary_sensor
     name: Working status
+    class: running
     category: diagnostic
     dps:
       - id: 102
         type: string
         name: sensor
-        mapping:
-          - dps_val: "Heating"
-            icon: "mdi:water-boiler"
-          - dps_val: "Standby"
-            icon: "mdi:water-boiler-off"            
   - entity: binary_sensor
-    name: Antifreeze
+    name: Anti-frost
     class: cold
     category: diagnostic
     dps:
       - id: 103
         type: boolean
         name: sensor
-        mapping:
-          - dps_val: true
-            icon: "mdi:snowflake-alert"
-          - dps_val: false
-            icon: "mdi:snowflake-off"
   - entity: sensor
     name: Target temperature
     class: temperature
@@ -104,4 +98,3 @@ secondary_entities:
         name: sensor
         unit: C
         class: measurement
-        

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -36,18 +36,30 @@ primary_entity:
       type: integer
       name: current_temperature
 secondary_entities:
-  - entity: binary_sensor
+  - entity: switch
     name: Anti-Legionella
-    category: diagnostic
+    category: config
     dps:
       - id: 4
-        name: sensor
         type: boolean
+        name: switch
         mapping:
           - dps_val: true
             icon: "mdi:shield-cross-outline"
           - dps_val: false
             icon: "mdi:shield-remove-outline"
+#  - entity: binary_sensor
+#    name: Anti-Legionella
+#    category: diagnostic
+#    dps:
+#      - id: 4
+#        name: sensor
+#        type: boolean
+#        mapping:
+#          - dps_val: true
+#            icon: "mdi:shield-cross-outline"
+#          - dps_val: false
+#            icon: "mdi:shield-remove-outline"
   - entity: binary_sensor
     class: problem
     name: Fault
@@ -61,6 +73,14 @@ secondary_entities:
             value: false
           - value: true
             icon: "mdi:water-boiler-alert"
+          - dps_val: 1
+            value: E2 Operating without water
+          - dps_val: 2
+            value: E3 NTC temperature sensor
+          - dps_val: 4
+            value: E4 Water overheating 
+          - dps_val: 16
+            value: E6 clock RTC failure
   - entity: sensor
     name: Working status
     class: enum
@@ -97,3 +117,5 @@ secondary_entities:
         name: sensor
         unit: C
         class: measurement
+
+            

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -48,18 +48,6 @@ secondary_entities:
             icon: "mdi:shield-cross-outline"
           - dps_val: false
             icon: "mdi:shield-remove-outline"
-#  - entity: binary_sensor
-#    name: Anti-Legionella
-#    category: diagnostic
-#    dps:
-#      - id: 4
-#        name: sensor
-#        type: boolean
-#        mapping:
-#          - dps_val: true
-#            icon: "mdi:shield-cross-outline"
-#          - dps_val: false
-#            icon: "mdi:shield-remove-outline"
   - entity: binary_sensor
     class: problem
     name: Fault

--- a/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
+++ b/custom_components/tuya_local/devices/ferroli_titano_twin.yaml
@@ -1,7 +1,7 @@
-name: Ferroli Titano Twin
+name: Water heater
 products:
   - id: lci0ebsz7ftaruaf
-    name: DT EWH
+    name: Ferroli Titano Twin DT EWH
 primary_entity:
   entity: water_heater
   dps:
@@ -49,7 +49,7 @@ primary_entity:
           value: E6 clock RTC failure
 secondary_entities:
   - entity: switch
-    name: Anti-Legionella
+    name: Anti-legionella
     category: config
     dps:
       - id: 4
@@ -73,13 +73,17 @@ secondary_entities:
             value: false
           - value: true
   - entity: binary_sensor
-    name: Working status
+    name: Heating status
     class: running
     category: diagnostic
     dps:
       - id: 102
         type: string
         name: sensor
+        mapping:
+          - dps_val: Heating
+            value: true
+          - value: false
   - entity: binary_sensor
     name: Anti-frost
     class: cold
@@ -97,4 +101,3 @@ secondary_entities:
         type: integer
         name: sensor
         unit: C
-        class: measurement

--- a/custom_components/tuya_local/devices/momcozy_white_noise_machine_v2.yaml
+++ b/custom_components/tuya_local/devices/momcozy_white_noise_machine_v2.yaml
@@ -172,18 +172,6 @@ secondary_entities:
             value: Scene 8
           - dps_val: null
             value: None
-  - entity: number
-    name: Volume
-    category: config
-    icon: "mdi:volume-source"
-    dps:
-      - id: 9
-        type: integer
-        name: value
-        unit: "%"
-        range:
-          min: 10
-          max: 100
   - entity: lock
     name: Child Lock
     category: config


### PR DESCRIPTION
Added ferroli titano twin water heater

Log from tuya cloud to add this device:
---------------------------
{ 
"result": { 
"active_time": 1699199144, 
"category": "rs", 
"create_time": 1662056486, 
"custom_name": "", 
"icon": "smart/icon/ay1559825824224fhsJk/d5341937f24e6c66cf211b17e0b918aa.png", 
"id": "xxxxxxxxxxxxxxxxx", 
"ip": "xxx.xxx.xxx.xxx", 
"is_online": true, 
"lat": "xx..xxxx", 
"local_key": "local_key", 
"lon": "x.xxxx", 
"model": "", 
"name": "DT EWH", 
"product_id": "lci0ebsz7ftaruaf", 
"product_name": "DT EWH", 
"sub": false, 
"time_zone": "+00:00", 
"update_time": 1699199510, 
"uuid": "uuid" 
}, 
"success": true, 
"t": 1699200652871, 
"tid": "e49f8b057bf511ee95454a52bad04d54" 
}  
----------------------------------------

***** Parameters ************

{ 
"result": { 
"properties": [ 
{ 
"code": "switch", 
"custom_name": "", 
"dp_id": 1, 
"time": 1699201081794, 
"value": true 
}, 
{ 
"code": "mode", 
"custom_name": "", 
"dp_id": 2, 
"time": 1699199150010, 
"value": "manual" 
}, 
{ 
"code": "disinfection", 
"custom_name": "", 
"dp_id": 4, 
"time": 1699199150010, 
"value": true 
}, 
{ 
"code": "temp_set", 
"custom_name": "", 
"dp_id": 9, 
"time": 1699199150010, 
"value": 70 
}, 
{ 
"code": "temp_current", 
"custom_name": "", 
"dp_id": 10, 
"time": 1699201294437, 
"value": 37 
}, 
{ 
"code": "Fault", 
"custom_name": "", 
"dp_id": 101, 
"time": 1699199150010, 
"value": 0 
}, 
{ 
"code": "WorkState", 
"custom_name": "", "
dp_id": 102, 
"time": 1699201081952, 
"value": "Heating" 
}, 
{ 
"code": "AntifreezeState", 
"custom_name": "", "
dp_id": 103, 
"time": 1699199150010, 
"value": false 
}, 
{ 
"code": "t_tar", 
"custom_name": "", 
"dp_id": 104, 
"time": 1699199150010, 
"value": 70 
} 
] 
}, 
"success": true, "t": 1699201297475, 
"tid": "64daa6247bf711eea27736b6a8027804" 
}  

work like the tuya cloud card

manual: ttps://www.ferroli.com/media/Manual_TITANO%20TWIN_Rev%2005_0922_EN%20ES%20PT%20RO%20IT%20FR_A5.pdf
