### PR TITLE
added support for Alutherm 2500, made Schedule optional

### DIFF
--- a/custom_components/tuya_local/devices/eurom_alutherm_heater.yaml
+++ b/custom_components/tuya_local/devices/eurom_alutherm_heater.yaml
@@ -1,7 +1,9 @@
-name: Heater
+name: Eurom Alutherm Heater
 products:
   - id: 20qAGCEd0AxowwTA
-    name: Eurom Alutherm heater
+    name: Alutherm 2000
+  - id: awnds45afwineiul
+    name: Alutherm 2500
 primary_entity:
   entity: climate
   dps:
@@ -75,6 +77,7 @@ secondary_entities:
     category: config
     dps:
       - id: 104
+        optional: true
         type: string
         name: option
         mapping:
@@ -83,5 +86,6 @@ secondary_entities:
           - dps_val: program
             value: Program
       - id: 103
+        optional: true
         type: string
         name: schedule_data


### PR DESCRIPTION
Fixed Alutherm config by making Schedule DPS optional, added support for 2500 device variant. Tested with the Alutherm 2000.

Closes #1315