### PR TITLE
add support for Nedis Ceramic PTC Fan Heater

### DIFF
--- a/custom_components/tuya_local/devices/nedis_ptc_fan_heater.yaml
+++ b/custom_components/tuya_local/devices/nedis_ptc_fan_heater.yaml
@@ -1,0 +1,89 @@
+name: Ceramic PTC Fan Heater
+products:
+  - id: gzmby6hypv4daebf
+    name: Nedis Ceramic PTC Fan Heater HTFA22WTW
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: preset_mode
+          conditions:
+            - dps_val: level_1
+              value: fan_only
+            - dps_val: level_2
+              value: heat
+            - dps_val: level_3
+              value: heat
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 10
+        max: 49
+    - id: 3
+      type: integer
+      name: current_temperature
+    - id: 5
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: "level_1"
+          value: none
+          hidden: true
+        - dps_val: "level_2"
+          value: comfort
+        - dps_val: "level_3"
+          value: boost
+    - id: 8
+      type: boolean
+      name: swing_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: "on"
+secondary_entities:
+  - entity: switch
+    name: Indicator
+    category: config
+    dps:
+      - id: 10
+        type: boolean
+        name: switch
+  - entity: select
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: "cancel"
+            value: Cancel
+          - dps_val: "1h"
+            value: "1 hour"
+          - dps_val: "2h"
+            value: "2 hours"
+          - dps_val: "2h"
+            value: "3 hours"
+          - dps_val: "3h"
+            value: "4 hours"
+          - dps_val: "4h"
+            value: "5 hours"
+          - dps_val: "5h"
+            value: "6 hours"
+  - entity: sensor
+    name: Remaining Time
+    class: duration
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: min

--- a/custom_components/tuya_local/devices/nedis_ptc_fan_heater.yaml
+++ b/custom_components/tuya_local/devices/nedis_ptc_fan_heater.yaml
@@ -1,7 +1,7 @@
-name: Ceramic PTC Fan Heater
+name: Fan heater
 products:
   - id: gzmby6hypv4daebf
-    name: Nedis Ceramic PTC Fan Heater HTFA22WTW
+    name: Nedis Ceramic PTC HTFA22WTW
 primary_entity:
   entity: climate
   dps:
@@ -49,9 +49,10 @@ primary_entity:
         - dps_val: true
           value: "on"
 secondary_entities:
-  - entity: switch
+  - entity: light
     name: Indicator
     category: config
+    icon: "mdi:led-on"
     dps:
       - id: 10
         type: boolean
@@ -80,7 +81,7 @@ secondary_entities:
           - dps_val: "5h"
             value: "6 hours"
   - entity: sensor
-    name: Remaining Time
+    name: Remaining time
     class: duration
     dps:
       - id: 20


### PR DESCRIPTION
https://nedis.com/en-us/product/household-and-living/climate/heating/550784759/smartlife-ceramic-ptc-fan-heater-wi-fi-1500-w-2-heat-settings-oscillation-display-10-49-0c-android-ios