### PR TITLE
docs: update Tuya's "Devices Management" path

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,9 +357,9 @@ If you don't see them, check your server is set correctly at the top
 of the page.  Make a note of the Device IDs for all your devices, then
 select Cloud on the side bar again and go to the API Explorer.
 
-Under "Devices Management", select the "Query Device Details in Bulk"
+Under "Cloud" -> "API Explorer" -> "Devices Management", select the "Query Device Details in Bulk"
 function, and enter your Device IDs, separated by commas.
-In the results you should see your local_key.
+In the results you should see your `local_key`.
 
 The IP address you should be able to get from your router.  Using a
 command line Tuya client like tuyaapi/cli or


### PR DESCRIPTION
the "device management" is located under the "API Explorer" which is not maintained in the guide so I fixed it.
![image](https://github.com/make-all/tuya-local/assets/19731161/cdf99ee2-cf3c-407e-9575-3117aed8cd68)

![image](https://github.com/make-all/tuya-local/assets/19731161/7eced288-df1e-45ee-8412-0c8b0f792426)
