### PR TITLE
ZY-M201 fix service call error for detection distance slider

### DIFF
--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -55,10 +55,10 @@ secondary_entities:
         unit: m
         range:
           min: 150
-          max: 600
+          max: 550
         mapping:
           - scale: 100
-            step: 100
+#            step: 100
   - entity: sensor
     name: Target distance
     class: distance

--- a/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym201_presence_sensor.yaml
@@ -55,7 +55,7 @@ secondary_entities:
         unit: m
         range:
           min: 150
-          max: 550
+          max: 600
         mapping:
           - scale: 100
             step: 100


### PR DESCRIPTION
fixes service call error that pops up when slider is set to 5.5

![image](https://github.com/make-all/tuya-local/assets/5904370/37f82f65-9cea-4f3d-bbe2-eab54ae759ea)
