### PR TITLE
Create morris_premier_plus_dehumidifier.yaml

### DIFF
--- a/custom_components/tuya_local/devices/morris_premier_plus_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/morris_premier_plus_dehumidifier.yaml
@@ -1,0 +1,133 @@
+name: Morris MDP-xx400IW series
+# {'updated_at': 1674605185.2896934, '1': True, '2': 'auto', '3': 57, '4': 55, '10': True, '101': True, '102': '0_90', '103': 24}
+products:
+  - id: 6cguug02fnygou5c
+primary_entity:
+  entity: humidifier
+  class: dehumidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 2
+      name: mode
+      type: string
+      optional: true
+      mapping:
+        - dps_val: auto
+          value: auto
+          icon: "mdi:fan-auto"
+        - dps_val: high
+          value: High
+          icon: "mdi:fan-speed-3"
+        - dps_val: low
+          value: Low
+          icon: "mdi:fan-speed-1"
+        - dps_val: fan
+          value: Fan
+          icon: "mdi:fan"
+    - id: 3
+      type: integer
+      name: current_humidity
+    - id: 4
+      type: integer
+      name: humidity
+      range:
+        min: 35
+        max: 80
+      mapping:
+        - step: 5          
+secondary_entities:
+  - entity: fan
+    deprecated: humidifier mode
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 2
+        name: preset_mode
+        type: string
+        optional: true
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: high
+            value: high
+          - dps_val: low
+            value: low
+          - dps_val: fan
+            value: Fan
+      - id: 102
+        name: oscillate
+        type: string
+        optional: true
+        mapping:
+          - dps_val: "0_90"
+            value: true
+          - dps_val: "45"
+            value: false
+          - dps_val: "90"
+            value: false
+  - entity: select
+    name: Direction
+    category: config
+    icon: "mdi:sprinkler-variant"
+    dps:
+      - id: 102
+        name: option
+        type: string
+        optional: true
+        mapping:
+          - dps_val: "0_90"
+            value:  "45°-90°"
+          - dps_val: "45"
+            value: "45°"
+          - dps_val: "90"
+            value: "90°"
+  - entity: sensor
+    name: Current humidity
+    deprecated: humidifier
+    category: diagnostic
+    class: humidity
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        class: measurement
+        unit: "%"
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: switch
+    name: UV sterilization
+    icon: "mdi:shield-half-full"
+    dps:
+      - id: 10
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Ionizer
+    icon: "mdi:creation"
+    dps:
+      - id: 5
+        name: switch 
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: false
+            value: true
+          - dps_val: true
+            value: false  
+  - entity: switch
+    name: "Humidity indicator"
+    category: config
+    icon: "mdi:dots-circle"
+    dps:
+      - id: 101
+        name: switch
+        type: boolean 


### PR DESCRIPTION
Hello! This is just a clone of the klarstein_dryfy_pro_connect_dehumidifier.yaml file with minor changes for the Morris MDP-24400IW dehumidifier. From Tuya API there are no more DPs returned, so they are basically identical. The only difference is that while the Klarstein one has the following modes: Auto/Boost/Eco/Purify, the Morris one has Auto/High/Low/Fan respectively. So I just changed the relative values to the ones the Morris one uses. What I cannot find is where the Boost/Eco icons were coming from. So I simply added icons to the relevant section but I doubt they display. This pull request is not actually created with the intention to be commited (unless you believe it is OK ) but rather in order to let you know that the Morris dehumidifier is working fine with the klarstein yaml file, except from those minor differences, so that you can perhaps add a "proper" version yourself if you like.

P.S.: Thanks for your great work !
P.P.S.: The Boost icon (mdi: rocket-launch) is nowhere to be found in the component. How is it displayed?