### PR TITLE
Update tompd_63lw_breaker.yaml - A way to fix polling problems

### DIFF
--- a/custom_components/tuya_local/devices/tompd_63lw_breaker.yaml
+++ b/custom_components/tuya_local/devices/tompd_63lw_breaker.yaml
@@ -52,7 +52,7 @@ secondary_entities:
         name: button
         optional: true
   - entity: button
-    name: Refresh report
+    name: Refresh sensors
     class: restart
     category: config
     dps:

--- a/custom_components/tuya_local/devices/tompd_63lw_breaker.yaml
+++ b/custom_components/tuya_local/devices/tompd_63lw_breaker.yaml
@@ -51,6 +51,15 @@ secondary_entities:
         type: boolean
         name: button
         optional: true
+  - entity: button
+    name: Refresh report
+    class: restart
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: button
+        optional: true
   - entity: sensor
     name: Balance energy
     category: diagnostic

--- a/tests/devices/test_tompd63lw_breaker.py
+++ b/tests/devices/test_tompd63lw_breaker.py
@@ -61,6 +61,7 @@ class TestTOMPD63lw(MultiSensorTests, TuyaDeviceTestCase):
             [
                 "button_earth_leak_test",
                 "button_energy_reset",
+                "button_refresh_sensors",
                 "number_charge_energy",
                 "sensor_balance_energy",
                 "sensor_current_a",


### PR DESCRIPTION
My device always stopped updating in Home Assistant after about a minute or so, oddly, when I accessed the device in Tuya Smart, it would start polling data again.

I snooped around Query Properties on API Explorer and I found this:

      {
        "code": "refresh",
        "custom_name": "",
        "dp_id": 106,
        "time": 1702153606980,
        "value": false
      }

Apparently this command corresponds to the command "刷新上报" (Refresh report) which you can see on Tuya IoT Platform - *Project* - Device Debugging - Device Report under the same category with the Mandarin name. Apparently the mobile app sends this command when you access the device. I tested this myself, made an automation to press this button every 30 seconds and I haven't encountered any problems since.