### PR TITLE
Add support for Cleverio AR10 / AR20 panel heaters

### DIFF
--- a/custom_components/tuya_local/devices/cleverio_ar10_ar20.yaml
+++ b/custom_components/tuya_local/devices/cleverio_ar10_ar20.yaml
@@ -1,0 +1,166 @@
+name: Cleverio AR10 / AR20
+products:
+  - id: urxauhwqufusih5h
+    name: Cleverio AR10 / AR20
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: heat
+    - id: 2
+      name: temperature
+      type: integer
+      range:
+        min: 5
+        max: 45
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: F
+              range:
+                min: 41
+                max: 113
+    - id: 3
+      name: current_temperature
+      type: integer
+    - id: 4
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: low
+          value: eco
+        - dps_val: high
+          value: boost
+    - id: 12
+      name: fault_code
+      type: bitfield
+    - id: 101
+      name: hvac_action
+      type: boolean
+      mapping:
+        - constraint: hvac_mode
+          conditions:
+            - dps_val: false
+              value: "off"
+            - dps_val: true
+              mapping:
+                - dps_val: false
+                  value: idle
+                - dps_val: true
+                  value: heating
+    - id: 103
+      name: temperature_unit
+      type: string
+      mapping:
+        - dps_val: C
+          value: TEMP_CELSIUS
+        - dps_val: F
+          value: TEMP_FAHRENHEIT
+secondary_entities:
+  - entity: lock
+    name: Child lock
+    icon: "mdi:hand-back-right-off"
+    category: config
+    dps:
+      - id: 6
+        type: boolean
+        name: lock
+  - entity: select
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: "1 hour"
+          - dps_val: "2"
+            value: "2 hours"
+          - dps_val: "3"
+            value: "3 hours"
+          - dps_val: "4"
+            value: "4 hours"
+          - dps_val: "5"
+            value: "5 hours"
+          - dps_val: "6"
+            value: "6 hours"
+          - dps_val: "7"
+            value: "7 hours"
+          - dps_val: "8"
+            value: "8 hours"
+          - dps_val: "9"
+            value: "9 hours"
+          - dps_val: "10"
+            value: "10 hours"
+          - dps_val: "11"
+            value: "11 hours"
+          - dps_val: "12"
+            value: "12 hours"
+          - dps_val: "13"
+            value: "13 hours"
+          - dps_val: "14"
+            value: "14 hours"
+          - dps_val: "15"
+            value: "15 hours"
+          - dps_val: "16"
+            value: "16 hours"
+          - dps_val: "17"
+            value: "17 hours"
+          - dps_val: "18"
+            value: "18 hours"
+          - dps_val: "19"
+            value: "19 hours"
+          - dps_val: "20"
+            value: "20 hours"
+          - dps_val: "21"
+            value: "21 hours"
+          - dps_val: "22"
+            value: "22 hours"
+          - dps_val: "23"
+            value: "23 hours"
+          - dps_val: "24"
+            value: "24 hours"
+  - entity: sensor
+    name: Time remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 11
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 12
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    name: Temperature unit
+    icon: "mdi:temperature-celsius"
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: option
+        mapping:
+          - dps_val: C
+            value: Celsius
+          - dps_val: F
+            value: Fahrenheit

--- a/custom_components/tuya_local/devices/electric_panel_heater.yaml
+++ b/custom_components/tuya_local/devices/electric_panel_heater.yaml
@@ -1,4 +1,4 @@
-name: Cleverio AR10 / AR20
+name: Electric Panel Heater
 products:
   - id: urxauhwqufusih5h
     name: Cleverio AR10 / AR20
@@ -57,11 +57,6 @@ primary_entity:
     - id: 103
       name: temperature_unit
       type: string
-      mapping:
-        - dps_val: C
-          value: TEMP_CELSIUS
-        - dps_val: F
-          value: TEMP_FAHRENHEIT
 secondary_entities:
   - entity: lock
     name: Child lock


### PR DESCRIPTION
Add support for Cleverio AR10 / AR20 panel heaters from the Swedish retailer Kjell & Co. 

Both models identify as “Cleverio AR10 / AR20” in Tuya. The only difference between them is the wattage (1000W vs 2000W) and the physical size. 

![IMG_4321](https://github.com/make-all/tuya-local/assets/14877697/48f3c1f2-52dc-4121-a04f-02d3cd363385)

AR10: https://www.kjell.com/se/produkter/smarta-hem/temperaturstyrning/smarta-element/cleverio-smart-element-1000-w-p40720

![IMG_4319](https://github.com/make-all/tuya-local/assets/14877697/43387b2c-b136-409d-bd78-915236f63cb3)

AR20: https://www.kjell.com/se/produkter/smarta-hem/temperaturstyrning/smarta-element/cleverio-smart-element-2000-w-p40721

![IMG_4320](https://github.com/make-all/tuya-local/assets/14877697/8a43c285-944e-47ec-abc9-f7ee2c950c8c)