### PR TITLE
Add configuration for Argo DRY PURY EVO WF dehumidifier

### DIFF
--- a/custom_components/tuya_local/devices/dry_pury_evo_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/dry_pury_evo_dehumidifier.yaml
@@ -1,0 +1,160 @@
+name: Argo DRY PURY EVO WF dehumidifier
+products:
+  - id: oya6k3fqen43zyi7
+    name: Argo DRY PURY EVO WF 21
+primary_entity:
+  entity: humidifier
+  class: dehumidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 2
+      name: humidity
+      type: integer
+      range:
+        min: 30
+        max: 80
+      mapping:
+        - step: 5
+    - id: 5
+      name: mode
+      type: string
+      mapping:
+        - dps_val: dehumidify
+          value: comfort
+        - dps_val: drying
+          value: laundry
+          icon: "mdi:tshirt-crew-outline"
+          icon_priority: 3
+        - dps_val: sleep
+          value: sleep
+          icon: "mdi:power-sleep"
+          icon_priority: 3
+    - id: 6
+      name: current_humidity
+      type: integer
+secondary_entities:
+  - entity: fan
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 5
+        name: dehumidifier_mode
+        type: string
+        hidden: true
+      - id: 4
+        name: speed
+        type: string
+        mapping:
+          - dps_val: low
+            value: 50
+            constraint: dehumidifier_mode
+            conditions:
+              - dps_val: laundry
+                invalid: true
+          - dps_val: high
+            value: 100
+            constraint: dehumidifier_mode
+            conditions:
+              - dps_val: sleep
+                invalid: true
+  - entity: sensor
+    name: Current humidity
+    # deprecated: humidifier      # without that I see humidity values and it's history
+    # category: diagnostic        # without that I see humidity values and it's history
+    class: humidity
+    dps:
+      - id: 6
+        name: sensor
+        type: integer
+        precision: 0
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 7
+        name: sensor
+        type: integer
+        unit: C
+        class: measurement
+  - entity: switch
+    name: Ionizer
+    icon: "mdi:creation"
+    optional: true
+    dps:
+      - id: 10
+        type: boolean
+        name: switch
+  - entity: lock
+    name: Child lock
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        name: lock
+        mapping:
+          - dps_val: false
+            icon: "mdi:hand-back-right"
+          - dps_val: true
+            icon: "mdi:hand-back-right-off"
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 17
+        type: string
+        name: option
+        mapping:
+          - dps_val: "cancel"
+            value: Continuous
+          - dps_val: 1h
+            value: 1 hour
+          - dps_val: 2h
+            value: 2 hours
+          - dps_val: 3h
+            value: 3 hours
+  - entity: binary_sensor # based on API doc. I don't know how to test
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 19
+        name: fault
+        type: bitfield
+        mapping:
+          - dps_val: 0
+            value: E1
+          - dps_val: 1
+            value: CL
+          - dps_val: 2
+            value: CH
+          - dps_val: 3
+            value: LO
+          - dps_val: 4
+            value: FL
+          - dps_val: 5
+            value: Cleaning
+  - entity: button # based on API doc. Nothing happened when I run on my device
+    name: Filter reset
+    category: config
+    optional: true
+    dps:
+      - id: 20
+        type: boolean
+        name: button
+  - entity: select # based on API doc. Nothing happened when I run on my device
+    name: Temperature unit
+    category: config
+    optional: true
+    dps:
+      - id: 24
+        type: string
+        name: option
+        mapping:
+          - dps_val: "c"
+            value: Celsius
+          - dps_val: "f"
+            value: Fahrenheit


### PR DESCRIPTION
Support for Argo DRY PURY EVO WF 21 https://argoclima.com/en/prodotti/argo-dry-pury-evo-wf-21-21lt-gg-32ac80-u-r-2/

![image](https://github.com/make-all/tuya-local/assets/18677903/e16b1e9f-eaef-496a-aea7-9866d58053fb)
![image](https://github.com/make-all/tuya-local/assets/18677903/c0bf7699-437a-4e16-b697-6fe15c05b6eb)
![image](https://github.com/make-all/tuya-local/assets/18677903/58a954ff-5274-46f8-b074-82e36c6de648)

Works well but:
- no action on device when I press `Filter reset` in HA
- no action on device when I change `Temperature unit` in HA
- no action on device when I change `Timer` in HA
- I don't know what values should I use to localise the labels in HA