### PR TITLE
Update klarstein_dryfy_pro_connect_dehumidifier.yaml

### DIFF
--- a/custom_components/tuya_local/devices/klarstein_dryfy_pro_connect_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/klarstein_dryfy_pro_connect_dehumidifier.yaml
@@ -119,9 +119,9 @@ secondary_entities:
         optional: true
         mapping:
           - dps_val: false
-            value: true
+            value: false
           - dps_val: true
-            value: false  
+            value: true  
   - entity: switch
     name: "Humidity indicator"
     category: config

--- a/custom_components/tuya_local/devices/klarstein_dryfy_pro_connect_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/klarstein_dryfy_pro_connect_dehumidifier.yaml
@@ -117,11 +117,6 @@ secondary_entities:
         name: switch 
         type: boolean
         optional: true
-        mapping:
-          - dps_val: false
-            value: false
-          - dps_val: true
-            value: true  
   - entity: switch
     name: "Humidity indicator"
     category: config


### PR DESCRIPTION
Thanks for adding the Morris dehumidifier after all. 
The ionizer changes are inverted though.. 
I don't know if in the klarstein one they are supposed to be like this, or if it is a bug. 
With the Morris dehumidifier and the original values, though, in HA, when Ionizer is off, it shows as on and vise versa