### PR TITLE
Add support for VIVOSUN DE0003 Dehumidifier

### DIFF
--- a/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
@@ -1,7 +1,8 @@
 name: Dehumidifier
 products:
   - id: qrjffdu2bjrd7v42
-    name: Vivosun DE0003 10L Smart Dehumidifier
+    name: DE0003 10L Smart Dehumidifier
+    manufacturer: Vivosun
 primary_entity:
   entity: humidifier
   class: dehumidifier

--- a/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
@@ -159,7 +159,21 @@ secondary_entities:
             value: 24 hours
   - entity: binary_sensor
     class: problem
+    name: Tank full
+    category: diagnostic
+    icon: "mdi:cup-water"
+    dps:
+      - id: 19
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 1
+            value: true
+          - value: false
+  - entity: binary_sensor
+    class: problem
     name: Fault
+    category: diagnostic
     dps:
       - id: 19
         type: bitfield

--- a/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
@@ -1,6 +1,7 @@
-name: Vivosun DE0003 Dehumidifier
+name: Dehumidifier
 products:
   - id: qrjffdu2bjrd7v42
+    name: Vivosun DE0003 10L Smart Dehumidifier
 primary_entity:
   entity: humidifier
   class: dehumidifier

--- a/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
@@ -79,17 +79,6 @@ secondary_entities:
           - dps_val: "high"
             value: 100
   - entity: sensor
-    name: Current humidity
-    deprecated: humidifier
-    category: diagnostic
-    class: humidity
-    dps:
-      - id: 6
-        type: integer
-        name: sensor
-        class: measurement
-        unit: "%"
-  - entity: sensor
     class: temperature
     dps:
       - id: 7

--- a/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
@@ -44,6 +44,11 @@ primary_entity:
     - id: 6
       type: integer
       name: current_humidity
+    # This doesn't actually have an ionizer, but having the dp
+    # will aid in detection
+    - id: 10
+      type: boolean
+      name: ionizer
     - id: 19
       name: error
       type: bitfield

--- a/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/vivosun_de0003_dehumidifier.yaml
@@ -1,0 +1,178 @@
+name: Vivosun DE0003 Dehumidifier
+products:
+  - id: qrjffdu2bjrd7v42
+primary_entity:
+  entity: humidifier
+  class: dehumidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+      mapping:
+        - dps_val: false
+          icon: "mdi:air-humidifier-off"
+          icon_priority: 3
+        - dps_val: true
+          icon: "mdi:air-humidifier"
+          icon_priority: 5
+    - id: 2
+      type: integer
+      name: humidity
+      range:
+        min: 30
+        max: 80
+      mapping:
+        - step: 5
+    - id: 5
+      name: mode
+      type: string
+      mapping:
+        - dps_val: Continuities
+          value: boost
+          icon: "mdi:tshirt-crew-outline"
+          icon_priority: 4
+        - dps_val: Auto
+          value: auto
+          icon: "mdi:water-outline"
+          icon_priority: 4
+        - dps_val: Sleep
+          value: sleep
+          icon: "mdi:weather-night"
+          icon_priority: 4
+    - id: 6
+      type: integer
+      name: current_humidity
+    - id: 19
+      name: error
+      type: bitfield
+      # E2 might be a compressor fault.
+      mapping:
+        - dps_val: 0
+          value: OK
+        - dps_val: 1
+          value: "Water Tank Full or Removed"
+          icon: "mdi:cup-water"
+          icon_priority: 1
+        - dps_val: 2
+          value: "E2 Compressor Fault"
+          icon: "mdi:engine-off-outline"
+          icon_priority: 1
+secondary_entities:
+  - entity: fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 4
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "low"
+            value: 50
+          - dps_val: "high"
+            value: 100
+  - entity: sensor
+    name: Current humidity
+    deprecated: humidifier
+    category: diagnostic
+    class: humidity
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        class: measurement
+        unit: "%"
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: F
+        class: measurement
+  - entity: lock
+    name: Child lock
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        name: lock
+        mapping:
+          - dps_val: true
+            icon: "mdi:hand-back-right-off"
+          - dps_val: false
+            icon: "mdi:hand-back-right"
+  - entity: select
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 17
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: "Off"
+          - dps_val: 1h
+            value: 1 hour
+          - dps_val: 2h
+            value: 2 hours
+          - dps_val: 3h
+            value: 3 hours
+          - dps_val: 4h
+            value: 4 hours
+          - dps_val: 5h
+            value: 5 hours
+          - dps_val: 6h
+            value: 6 hours
+          - dps_val: 7h
+            value: 7 hours
+          - dps_val: 8h
+            value: 8 hours
+          - dps_val: 9h
+            value: 9 hours
+          - dps_val: 10h
+            value: 10 hours
+          - dps_val: 11h
+            value: 11 hours
+          - dps_val: 12h
+            value: 12 hours
+          - dps_val: 13h
+            value: 13 hours
+          - dps_val: 14h
+            value: 14 hours
+          - dps_val: 15h
+            value: 15 hours
+          - dps_val: 16h
+            value: 16 hours
+          - dps_val: 17h
+            value: 17 hours
+          - dps_val: 18h
+            value: 18 hours
+          - dps_val: 19h
+            value: 19 hours
+          - dps_val: 20h
+            value: 20 hours
+          - dps_val: 21h
+            value: 21 hours
+          - dps_val: 22h
+            value: 22 hours
+          - dps_val: 23h
+            value: 23 hours
+          - dps_val: 24h
+            value: 24 hours
+  - entity: binary_sensor
+    class: problem
+    name: Fault
+    dps:
+      - id: 19
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 1
+            value: false
+          - dps_val: null
+            value: false
+          - value: true


### PR DESCRIPTION
This PR adds support for the VIVOSUN DE0003 Dehumidifier (also known as the VIVOSUN 10L Dehumidifier on Amazon). Results from the Tuya API showed that this dehumidifer was really similar to the JJPro JPD02 dehumidifier, so this config is mostly a copy of that (they even share the same name for the continuous mode: `Continuities`).

This is my first contribution to this repo and I'm not sure that I've done this right, so I'll also include the device data and Tuya API data.

JSON extracted from HA logs (closest match was `feit_dimmer` at 30%):
```json
{
  "updated_at": 1703197006.9113197,
  "1": true,
  "2": 70,
  "4": "high",
  "5": "Auto",
  "6": 38,
  "7": 78,
  "10": false,
  "16": false,
  "17": "cancel",
  "19": 0
}
```

I've shoved the next two things into details tags to reduce the amount of scrolling required.

<details><summary>Device info (with sensitive fields redacted):</summary>

```json
{
  "result": {
    "active_time": 1703194802,
    "category": "cs",
    "create_time": 1703194802,
    "custom_name": "",
    "icon": "smart/icon/bay1655275121807SBKr/1655800847d17296d2ffa.jpg",
    "id": "<redacted>",
    "ip": "<redacted>",
    "is_online": true,
    "lat": "<redacted>",
    "local_key": "<redacted>",
    "lon": "<redacted>",
    "model": "Vivosun-DE0003",
    "name": "Vivosun-DE0003",
    "product_id": "qrjffdu2bjrd7v42",
    "product_name": "Vivosun-DE0003",
    "sub": false,
    "time_zone": "<redacted>",
    "update_time": 1703194805,
    "uuid": "<redacted>"
  },
  "success": true,
  "t": 1703196715338,
  "tid": "<redacted>"
}
```

</details>

<details><summary>Model info:</summary>

```json
{
  "modelId": "000004ijsc",
  "services": [
    {
      "actions": [],
      "code": "",
      "description": "",
      "events": [],
      "name": "默认服务",
      "properties": [
        {
          "abilityId": 1,
          "accessMode": "rw",
          "code": "switch",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_power",
            "attribute": "5"
          },
          "name": "开关",
          "typeSpec": {
            "type": "bool",
            "typeDefaultValue": false
          }
        },
        {
          "abilityId": 2,
          "accessMode": "rw",
          "code": "dehumidify_set_value",
          "description": "",
          "extensions": {
            "iconName": "icon-shidu",
            "attribute": "4"
          },
          "name": "湿度设置",
          "typeSpec": {
            "max": 80,
            "min": 30,
            "scale": 0,
            "step": 5,
            "type": "value",
            "typeDefaultValue": 30,
            "unit": "%"
          }
        },
        {
          "abilityId": 4,
          "accessMode": "rw",
          "code": "fan_speed_enum",
          "description": "",
          "extensions": {
            "iconName": "icon-a_fan_med",
            "attribute": "4"
          },
          "name": "风速",
          "typeSpec": {
            "range": [
              "low",
              "high"
            ],
            "type": "enum",
            "typeDefaultValue": "low"
          }
        },
        {
          "abilityId": 5,
          "accessMode": "rw",
          "code": "mode",
          "description": "连续，自动，睡眠",
          "extensions": {
            "iconName": "icon-dp_mode",
            "attribute": "4"
          },
          "name": "工作模式",
          "typeSpec": {
            "range": [
              "Continuities",
              "Auto",
              "Sleep"
            ],
            "type": "enum",
            "typeDefaultValue": "Continuities"
          }
        },
        {
          "abilityId": 6,
          "accessMode": "ro",
          "code": "humidity_indoor",
          "description": "",
          "name": "室内湿度",
          "typeSpec": {
            "max": 90,
            "min": 20,
            "scale": 0,
            "step": 1,
            "type": "value",
            "typeDefaultValue": 20,
            "unit": "%"
          }
        },
        {
          "abilityId": 7,
          "accessMode": "ro",
          "code": "temp_indoor",
          "description": "",
          "name": "室内温度",
          "typeSpec": {
            "max": 122,
            "min": 0,
            "scale": 0,
            "step": 1,
            "type": "value",
            "typeDefaultValue": 0,
            "unit": ""
          }
        },
        {
          "abilityId": 10,
          "accessMode": "rw",
          "code": "anion",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_power2"
          },
          "name": "负离子",
          "typeSpec": {
            "type": "bool",
            "typeDefaultValue": false
          }
        },
        {
          "abilityId": 16,
          "accessMode": "rw",
          "code": "child_lock",
          "description": "",
          "name": "童锁",
          "typeSpec": {
            "type": "bool",
            "typeDefaultValue": false
          }
        },
        {
          "abilityId": 17,
          "accessMode": "rw",
          "code": "countdown_set",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_time2"
          },
          "name": "倒计时",
          "typeSpec": {
            "range": [
              "cancel",
              "1h",
              "2h",
              "3h",
              "4h",
              "5h",
              "6h",
              "7h",
              "8h",
              "9h",
              "10h",
              "11h",
              "12h",
              "13h",
              "14h",
              "15h",
              "16h",
              "17h",
              "18h",
              "19h",
              "20h",
              "21h",
              "22h",
              "23h",
              "24h"
            ],
            "type": "enum",
            "typeDefaultValue": "cancel"
          }
        },
        {
          "abilityId": 19,
          "accessMode": "ro",
          "code": "fault",
          "description": "",
          "extensions": {
            "scope": "fault"
          },
          "name": "故障告警",
          "typeSpec": {
            "label": [
              "FULL",
              "E2"
            ],
            "maxlen": 2,
            "type": "bitmap",
            "typeDefaultValue": 0
          }
        },
        {
          "abilityId": 24,
          "accessMode": "rw",
          "code": "temp_unit_convert",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_mode",
            "attribute": "128"
          },
          "name": "温标",
          "typeSpec": {
            "range": [
              "c",
              "f"
            ],
            "type": "enum",
            "typeDefaultValue": "c"
          }
        },
        {
          "abilityId": 101,
          "accessMode": "ro",
          "code": "type",
          "description": "0=无负离子；1=有负离子",
          "name": "机型",
          "typeSpec": {
            "max": 10,
            "min": 0,
            "scale": 0,
            "step": 1,
            "type": "value",
            "typeDefaultValue": 0,
            "unit": ""
          }
        }
      ]
    }
  ]
}
```

</details>

I intentionally didn't include dps 10 or 101 since AFAICT, this device doesn't have any form of ionic air purifier built in. There's no mention of it in the manual, so the safest option (imo) is to not include it. Please let me know if you feel differently and would like me to add it in and I'd be happy to.