### PR TITLE
Add support for 2 more Zigbee devices working through Tuya hub (Cover switch and Door/Window sensor)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -432,6 +432,7 @@ of device.
 - LoraTap GDC100W garage door opener
 - LoraTap QCSC420W double curtain switch
 - LoraTap SC500W-V1 curtain switch (supports many other simple curtain/blind controllers)
+- LoraTap QCSC400ZB-V2 curtain switch
 - M027 curtain module (sold under several brands, including zemismart, meterk and others)
 - Moes SCS80 Touch curtain swich with backlight and timing control
 - QS-WIFI-C01(BK) curtain module

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -588,6 +588,7 @@ port and password.
 - Nedis ZBSC10WT temperature and humidity sensor
 - Temperature and humidity sensor with alarm feature
 - ZTH08ZTU temperature and humidity sensor
+- Tuya Smart Zigbee Door Sensor
 
 NOTE: this project does not intend to expand the scope to support non-Tuya
 devices via Tuya hubs. Though it may be techincally feasible to do such a

--- a/custom_components/tuya_local/devices/loratap_curtain_switch_QCSC400ZB-V2.yaml
+++ b/custom_components/tuya_local/devices/loratap_curtain_switch_QCSC400ZB-V2.yaml
@@ -1,0 +1,26 @@
+name: ZigBee Curtain Switch
+products:
+  - id: qa8s8vca
+    name: LoraTap QCSC400ZB-V2
+primary_entity:
+  entity: cover
+  class: blind
+  dps:
+    - id: 1
+      name: control
+      type: string
+      mapping:
+        - dps_val: open
+          value: open
+        - dps_val: close
+          value: close
+        - dps_val: stop
+          value: stop
+    - id: 8
+      name: control_back_mode
+      type: string
+      mapping:
+        - dps_val: forward
+          value: forward
+        - dps_val: backward
+          value: backward

--- a/custom_components/tuya_local/devices/tuya_smart_zigbee_door_sensor.yaml
+++ b/custom_components/tuya_local/devices/tuya_smart_zigbee_door_sensor.yaml
@@ -1,0 +1,26 @@
+name: Tuya Smart Zigbee Door Sensor
+products:
+  - id: 7jIGJAymiH8OsFFb
+    name: Tuya Smart Zigbee Door Sensor
+primary_entity:
+  entity: binary_sensor
+  class: door
+  dps:
+    - id: 101
+      type: boolean
+      name: sensor
+secondary_entities:
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        optional: true
+        unit: ""
+        mapping:
+          - dps_val: low
+            value: 0
+          - dps_val: high
+            value: 500

--- a/custom_components/tuya_local/devices/tuya_smart_zigbee_door_sensor.yaml
+++ b/custom_components/tuya_local/devices/tuya_smart_zigbee_door_sensor.yaml
@@ -18,9 +18,10 @@ secondary_entities:
         type: integer
         name: sensor
         optional: true
-        unit: ""
+        unit: "%"
+        class: measurement
         mapping:
           - dps_val: low
             value: 0
           - dps_val: high
-            value: 500
+            value: 100

--- a/custom_components/tuya_local/devices/tuya_smart_zigbee_door_sensor.yaml
+++ b/custom_components/tuya_local/devices/tuya_smart_zigbee_door_sensor.yaml
@@ -20,8 +20,3 @@ secondary_entities:
         optional: true
         unit: "%"
         class: measurement
-        mapping:
-          - dps_val: low
-            value: 0
-          - dps_val: high
-            value: 100


### PR DESCRIPTION
1. Added Tuya Smart Zigbee Door Sensor support via hub
2. Added support for Loratap QCSC400ZB-V2 covers switch