### PR TITLE
Add support for Proscenic A9 Air Purifier

### DIFF
--- a/custom_components/tuya_local/devices/proscenic_a9_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/proscenic_a9_airpurifier.yaml
@@ -1,0 +1,149 @@
+name: Air Purifier
+products:
+  - id: giwqfeiezesbkkbe
+    name: Proscenic A9
+primary_entity:
+  entity: fan
+  icon: "mdi:air-purifier"
+  translation_key: fan_with_presets
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 4
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: "Sleep"
+          value: sleep
+        - dps_val: "1"
+          value: low
+        - dps_val: "2"
+          value: medium
+        - dps_val: "3"
+          value: high
+        - dps_val: "4"
+          value: turbo
+        - dps_val: "Auto"
+          value: auto
+    - id: 4
+      name: speed
+      type: string
+      mapping:
+        - dps_val: "Sleep"
+          value: 20
+        - dps_val: "1"
+          value: 40
+        - dps_val: "2"
+          value: 60
+        - dps_val: "3"
+          value: 80
+        - dps_val: "4"
+          value: 100
+        - dps_val: "Auto"
+          value: 0
+    - id: 102
+      name: unknown_102
+      type: string
+secondary_entities:
+  - entity: sensor 
+    class: pm25
+    dps:
+      - id: 2
+        name: sensor
+        class: measurement
+        type: integer
+        unit: ugm3
+  - entity: light # this is inverted to what actually happens (false = light on)
+    category: config
+    name: Display
+    icon: "mdi:lightbulb-night"
+    dps:
+      - id: 8
+        name: switch
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: true
+          - dps_val: true
+            value: false
+  - entity: sensor
+    name: Filter usage
+    category: diagnostic
+    icon: "mdi:shield-bug"
+    dps:
+      - id: 5
+        name: sensor
+        type: integer
+        unit: "%"
+  - entity: button
+    name: Reset Filter
+    category: config
+    icon: "mdi:air-filter"
+    dps:
+      - id: 11
+        name: button
+        type: boolean
+  - entity: sensor
+    name: Filter hours left
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 16
+        name: sensor
+        type: integer
+        unit: h
+  - entity: lock
+    name: Child lock
+    icon: "mdi:hand-back-right-off"
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+  - entity: sensor
+    name: Filtered Air
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        optional: true
+        unit: m³
+  - entity: sensor
+    name: Air quality
+    class: enum
+    icon: "mdi:air-filter"
+    dps:
+      - id: 21
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: "mild"
+            value: "Great"
+          - dps_val: "good"
+            value: "Good"
+          - dps_val: "medium"
+            value: "Medium"
+          - dps_val: "severe"
+            value: "Severe"
+  - entity: select
+    name: Timer
+    icon: "mdi:fan-clock"
+    category: config
+    dps:
+      - id: 101
+        type: integer
+        name: option
+        mapping:
+          - dps_val: 0
+            value: "Off"
+          - dps_val: 1
+            value: "1 hour"
+          - dps_val: 2
+            value: "2 hour"
+          - dps_val: 4
+            value: "4 hours" 
+          - dps_val: 8
+            value: "8 hours" 


### PR DESCRIPTION
Adds support for the prescenic Air Purifier A9.

Most sensors are normal aside:
* the display "light" which is inverted in what actually happens (true is off)
* the filter sensor is in hours and not days differently than shown in tuya IOT platform
* There is an sensor which has no meaning and just shows numbers like 100 000 001, seems a sort of bitfield in a string but couldn't figure out what it tries to expose, the A8 device description (already present) seems to have the same thing so i kept it the same way
* Finally technically the fan is a choice which has some speed settings and Auto and Sleep mode - so presets. I tried to map them to speed % in order to allow to use it more easily. only thing is a bit quirky is that i set 0 to auto making it only possible to set it as a preset as 0 would mean off usually. It works in home assistant but i didn't know how to map it to a fan speed aside that option.

![immagine](https://github.com/make-all/tuya-local/assets/1127663/62712671-855f-49df-9f91-325a66e500db)

![immagine](https://github.com/make-all/tuya-local/assets/1127663/3a57cca7-7986-4a17-89db-3c288e09e59b)
