### PR TITLE
Add support for Arlec PA1123BKHA portable air conditioner

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -2,13 +2,13 @@
 
 None of this would have been possible without some foundational discovery work to get me started:
 
-- [nicole-ashley](https://github.com/nicole-ashley)'s [homeassistant-goldair-climate](https://github.com/nicole-ashley/homeassistant-goldair-climate) was the starting point for this project to expand to non-Goldair devices as well.  Initial support for GPPH heaters, GPDH420 dehumidifiers and GCPF315 fans is based on the upstream Goldair integration. Nicole also contributed GPDH340 dehumidifier support.
+- [nicole-ashley](https://github.com/nicole-ashley)'s [homeassistant-goldair-climate](https://github.com/nicole-ashley/homeassistant-goldair-climate) was the starting point for this project to expand to non-Goldair devices as well. Initial support for GPPH heaters, GPDH420 dehumidifiers and GCPF315 fans is based on the upstream Goldair integration. Nicole also contributed GPDH340 dehumidifier support.
 - [TarxBoy](https://github.com/TarxBoy)'s [investigation using codetheweb/tuyapi](https://github.com/codetheweb/tuyapi/issues/31) to figure out the correlation of the cryptic DPS states .
 - [sean6541](https://github.com/sean6541)'s [tuya-homeassistant](https://github.com/sean6541/tuya-homeassistant) library giving an example of integrating Tuya devices with Home Assistant.
 - [clach04](https://github.com/clach04)'s [python-tuya](https://github.com/clach04/python-tuya) library.
 - [jasonacox](https://github.com/jasonacox)'s [tinytuya](https://github.com/jasonacox/tinytuya) library which improves on the original.
 
-Further device support has been made with the assistance of users.  Please consider contributing if you find a device that is not supported by gathering some information about the device's DPS ids and their values.
+Further device support has been made with the assistance of users. Please consider contributing if you find a device that is not supported by gathering some information about the device's DPS ids and their values.
 
 - [etamtlosz](https://github.com/etamtlosz) and [KiLLeRRaT](https://github.com/KiLLeRRaT) for their support and dev work towards GECO and GPCV heaters.
 - [botts7](https://github.com/botts7) for support towards widening Kogan SmartPlug support.
@@ -17,65 +17,65 @@ Further device support has been made with the assistance of users.  Please consi
 - [Xeovar](https://github.com/Xeovar) for assistance in supporting Purline M100 heaters, Garden PAC pool heatpumps and Qoto sprinklers.
 - [paulmfclark](https://github.com/paulmfclark) for assistance in supporting Remora Inverter pool heatpumps
 - [cartman10](https://github.com/cartman10) for assistance with BWT FI 45 pool heater.
- - [superman110](https://github.com/superman110) for assistance in supporting Eanons/purenjoy humidifier and SD123 human presence radar.
- - [woolmonkey](https://github.com/woolmonkey) for assistance in supporting Inkbird ITC306A Thermostat.
- - [hazell20](https://github.com/hazell20) for assistance in supporting Anko fans.
- - [meremortals70](https://github.com/meremortals70) for assistance in supporting Deta fan controllers.
- - [mvnixon](https://github.com/mvnixon) for assistance in supporting Madimack pool heaters.
- - [Lapy](https://github.com/Lapy) for contributing support for Electriq CD25PRO dehumidifiers.
- - [thomas-fr](https://github.com/thomas-fr) for contributing support for Poolex Silverline heatpumps.
- - [lperez31](https://github.com/lperez31) for contributing support for Poolex Vertigo heatpumps.
- - [b3nnyk22](https://github.com/b3nnyk22) for assistance in supporting Kogan Dehumidifiers.
- - [rodrigoGA](https://github.com/rodrigoGA) for assistance in supporting Greenwind dehumidifiers.
- - [jorgenDK](https://github.com/jorgenDK) for assistance in supporting TroniTechnik Air Conditioner, and thanks for the coffee!
- - [Fannangir](https://github.com/Fannangir) for assistance in supporting Tadiran Wind Air Conditioner, Zemismart curtain rail and Somgam 1, 2, 3 and 4 gang switches.
- - [marrold](https://github.com/marrold) for contributing support for ElectriQ CD20PRO dehumidifiers.
- - [Uaeguy](https://github.com/Uaeguy) for assistance in supporting Beca BHP-6000, Saswell T29UTK, Owon PCT513 and E-TOP CH7100 thermostats, and thanks for the coffee!
- - [Johnnybyzhang](https://github.com/Johnnybyzhang) for assistance in supporting Lexy F501 fans.
- - [domgrimm](https://github.com/domgrimm) for assistance in supporting newer models of Kogan heater.
- - [EKCJ](https://github.com/EKCJ) for contributing support for ElectriQ DESD9LW dehumidifiers.
- - [ed-holland](https://github.com/ed-holland) for contributing support for Awow TH213 thermostats
- - [Vikedlol](https://github.com/Vikedlol) for assistance in supporting Wetair WCH-750 heaters.
- - [wwalczyszyn](https://github.com/wwalczyszyn) for contributing support for Fersk Vind 2 heatpumps.
- - [xbmcnut](https://github.com/xbmcnut) for assistance in supporting Kogan Smart Kettles and the new type of Kogan heater.
- - [ThomasADavis](https://github.com/ThomasADavis) for contributing support for Renpho RP-AP001S air purifiers.
- - [darek-margas](https://github.com/darek-margas) for contributing support for Arlec fans, Carson portable air conditioners, Grid Connect double outlets with and without USB and power monitoring, Mirabella Genio smartplugs.
- - [SamJongenelen](https://github.com/SamJongenelen) for assistance in supporting Saswell C16 Thermostats
- - [antoweb](https://github.com/antoweb) for assistance in supporting Beca BHT-6000 thermostats.
- - [klausahrenberg](https://github.com/klausahrenberg) for figuring out the BHT-6000 and other thermostats' internal MCU protocol for his alternate MQQT firmware, which helped with finding some of the details.
- - [Swiftnesses](https://github.com/Swiftnesses) for contributing support for Electriq CD12PW dehumidifiers
- - [MrDeon](https://github.com/MrDeon) for assistance in supporting Kogan KAWFPAC09YA air conditioners.
- - [SatarisGIT](https://github.com/SatarisGIT) for assistance in supporting Eberg Qubo Q40HD portable heatpump.
- - [lucaxxaa](https://github.com/lucaxxaa) for assistance in supporting Beca BHT-002 thermostat.
- - [nickdos](https://github.com/nickdos) for assistance in supporting Stirling FS1-40DC fan.
- - [Skro11-ru](https://github.com/Skro11-ru) for assistance in supporting Moes BHT-002 variant without external temperature sensor.
- - [novisys](https://github.com/novisys) for clarifications about BHT-6000 thermostat functionality.
- - [nzcodarnoc](https://github.com/nzcodarnoc) for contributing support for Kogan KASHMFP heaters.
- - [pascaltippelt](https://github.com/pascaltippelt) for assistance in supporting Minco MH-1823 thermostat.
- - [voed](https://github.com/voed) for assistance in supporting Advanced Energy monitoring smart switch, based on CBE smart switch but seeming to follow a Tuya Standard Template, so probably applicable to others.
- - [myevit](https://github.com/myevit) for assistance in supporting simple garage doors.
- - [maartendamen](https://github.com/maartendamen) for assistance in supporting Eurom Mon Soleil 601 heaters.
- - [TeddyLafrite](https://github.com/TeddyLafrite) for assistance in supporting Nedis HTPL20F heaters.
- - [mvroosmalen1970](https://github.com/mvroosmalen1970) for assistance in supporting Eurom SaniWall 2000 heaters.
- - [petrkotek](https://github.com/petrkotek) for contributing support for Madimack Elite V3 pool heatpumps.
- - [irakhlin](https://github.com/irakhlin) for contributing support for Aspen ASP200 fans.
- - [vampywiz17](https://github.com/vampywiz17) for contributing support for TMWF02 fan controllers, Digoo, Woox and MoesHouse smartplugs and powerstrips and simple switches with timers. Also sasistance with figuring out the formats used by Tuya for RGBW lighting.
- - [awaldram](https://github.com/awaldram) for confirming BHT-3000 support.
- - [bob-tm](https://github.com/bob-tm) for contributing support from Wetair WAW-H1210LW humidifiers.
- - [shakin89](https://github.com/shakin89) for assistance in supporting Beca BAC-002 thermostats.
- - [PaulJoosten](https://github.com/PaulJoosten) for assistance in figuring out the similarities and capabilities of different Eurom heaters.
- - [jdavidr17](https://github.com/jdavidr17) for assistance with discovering timer parameters for switches.
- - [miannelli516](https://github.com/miannelli516) for assistance with TR9B thermostats.
- - [edwinyoo44](https://github.com/edwinyoo44) for contributing support for JJPro JPD01 and JPD02 dehumidifiers and assistance with Poiema One purifiers.
- - [mpetcuRO](https://github.com/mpetcuRO) for assistance with Hysen HT08WE-2 thermostats.
- - [Paul-C-S](https://github.com/Paul-C-S) for assistance with Ecostrad Accent iQ heaters and contributing support for iQ Ceramic radiators and INOW heating elements.
- - [WildeRNS](https://github.com/WildeRNS) for assistance with Nashone MTS-700-WB thermostat smartplugs, SmartMCB Energy meter, BlitzWolf BW-IS6 alarm panels.
- - [ishioni](https://github.com/ishioni) for contributing support for Eberg Cooly C32HD air conditioner.
- - [Gekko47](https://github.com/Gekko47) for contributing support for ElectriQ CD12v2 dehumidifiers.
- - [andreq](https://github.com/andreq) for assistance with Inkbird ITC-308 thermostats.
- - [dlosito](https://github.com/dlosito) for assistance with a second variant of Awow TH213 thermostat.
- - [UrZdcw9](https://github.com/UrZdcw9) for assistance with Arlec ceiling fan with light.
- - [dlosito](https://github.com/dlosito) for assistance with Lefant M213 vacuum cleaners.
+- [superman110](https://github.com/superman110) for assistance in supporting Eanons/purenjoy humidifier and SD123 human presence radar.
+- [woolmonkey](https://github.com/woolmonkey) for assistance in supporting Inkbird ITC306A Thermostat.
+- [hazell20](https://github.com/hazell20) for assistance in supporting Anko fans.
+- [meremortals70](https://github.com/meremortals70) for assistance in supporting Deta fan controllers.
+- [mvnixon](https://github.com/mvnixon) for assistance in supporting Madimack pool heaters.
+- [Lapy](https://github.com/Lapy) for contributing support for Electriq CD25PRO dehumidifiers.
+- [thomas-fr](https://github.com/thomas-fr) for contributing support for Poolex Silverline heatpumps.
+- [lperez31](https://github.com/lperez31) for contributing support for Poolex Vertigo heatpumps.
+- [b3nnyk22](https://github.com/b3nnyk22) for assistance in supporting Kogan Dehumidifiers.
+- [rodrigoGA](https://github.com/rodrigoGA) for assistance in supporting Greenwind dehumidifiers.
+- [jorgenDK](https://github.com/jorgenDK) for assistance in supporting TroniTechnik Air Conditioner, and thanks for the coffee!
+- [Fannangir](https://github.com/Fannangir) for assistance in supporting Tadiran Wind Air Conditioner, Zemismart curtain rail and Somgam 1, 2, 3 and 4 gang switches.
+- [marrold](https://github.com/marrold) for contributing support for ElectriQ CD20PRO dehumidifiers.
+- [Uaeguy](https://github.com/Uaeguy) for assistance in supporting Beca BHP-6000, Saswell T29UTK, Owon PCT513 and E-TOP CH7100 thermostats, and thanks for the coffee!
+- [Johnnybyzhang](https://github.com/Johnnybyzhang) for assistance in supporting Lexy F501 fans.
+- [domgrimm](https://github.com/domgrimm) for assistance in supporting newer models of Kogan heater.
+- [EKCJ](https://github.com/EKCJ) for contributing support for ElectriQ DESD9LW dehumidifiers.
+- [ed-holland](https://github.com/ed-holland) for contributing support for Awow TH213 thermostats
+- [Vikedlol](https://github.com/Vikedlol) for assistance in supporting Wetair WCH-750 heaters.
+- [wwalczyszyn](https://github.com/wwalczyszyn) for contributing support for Fersk Vind 2 heatpumps.
+- [xbmcnut](https://github.com/xbmcnut) for assistance in supporting Kogan Smart Kettles and the new type of Kogan heater.
+- [ThomasADavis](https://github.com/ThomasADavis) for contributing support for Renpho RP-AP001S air purifiers.
+- [darek-margas](https://github.com/darek-margas) for contributing support for Arlec fans, Carson portable air conditioners, Grid Connect double outlets with and without USB and power monitoring, Mirabella Genio smartplugs.
+- [SamJongenelen](https://github.com/SamJongenelen) for assistance in supporting Saswell C16 Thermostats
+- [antoweb](https://github.com/antoweb) for assistance in supporting Beca BHT-6000 thermostats.
+- [klausahrenberg](https://github.com/klausahrenberg) for figuring out the BHT-6000 and other thermostats' internal MCU protocol for his alternate MQQT firmware, which helped with finding some of the details.
+- [Swiftnesses](https://github.com/Swiftnesses) for contributing support for Electriq CD12PW dehumidifiers
+- [MrDeon](https://github.com/MrDeon) for assistance in supporting Kogan KAWFPAC09YA air conditioners.
+- [SatarisGIT](https://github.com/SatarisGIT) for assistance in supporting Eberg Qubo Q40HD portable heatpump.
+- [lucaxxaa](https://github.com/lucaxxaa) for assistance in supporting Beca BHT-002 thermostat.
+- [nickdos](https://github.com/nickdos) for assistance in supporting Stirling FS1-40DC fan.
+- [Skro11-ru](https://github.com/Skro11-ru) for assistance in supporting Moes BHT-002 variant without external temperature sensor.
+- [novisys](https://github.com/novisys) for clarifications about BHT-6000 thermostat functionality.
+- [nzcodarnoc](https://github.com/nzcodarnoc) for contributing support for Kogan KASHMFP heaters.
+- [pascaltippelt](https://github.com/pascaltippelt) for assistance in supporting Minco MH-1823 thermostat.
+- [voed](https://github.com/voed) for assistance in supporting Advanced Energy monitoring smart switch, based on CBE smart switch but seeming to follow a Tuya Standard Template, so probably applicable to others.
+- [myevit](https://github.com/myevit) for assistance in supporting simple garage doors.
+- [maartendamen](https://github.com/maartendamen) for assistance in supporting Eurom Mon Soleil 601 heaters.
+- [TeddyLafrite](https://github.com/TeddyLafrite) for assistance in supporting Nedis HTPL20F heaters.
+- [mvroosmalen1970](https://github.com/mvroosmalen1970) for assistance in supporting Eurom SaniWall 2000 heaters.
+- [petrkotek](https://github.com/petrkotek) for contributing support for Madimack Elite V3 pool heatpumps.
+- [irakhlin](https://github.com/irakhlin) for contributing support for Aspen ASP200 fans.
+- [vampywiz17](https://github.com/vampywiz17) for contributing support for TMWF02 fan controllers, Digoo, Woox and MoesHouse smartplugs and powerstrips and simple switches with timers. Also sasistance with figuring out the formats used by Tuya for RGBW lighting.
+- [awaldram](https://github.com/awaldram) for confirming BHT-3000 support.
+- [bob-tm](https://github.com/bob-tm) for contributing support from Wetair WAW-H1210LW humidifiers.
+- [shakin89](https://github.com/shakin89) for assistance in supporting Beca BAC-002 thermostats.
+- [PaulJoosten](https://github.com/PaulJoosten) for assistance in figuring out the similarities and capabilities of different Eurom heaters.
+- [jdavidr17](https://github.com/jdavidr17) for assistance with discovering timer parameters for switches.
+- [miannelli516](https://github.com/miannelli516) for assistance with TR9B thermostats.
+- [edwinyoo44](https://github.com/edwinyoo44) for contributing support for JJPro JPD01 and JPD02 dehumidifiers and assistance with Poiema One purifiers.
+- [mpetcuRO](https://github.com/mpetcuRO) for assistance with Hysen HT08WE-2 thermostats.
+- [Paul-C-S](https://github.com/Paul-C-S) for assistance with Ecostrad Accent iQ heaters and contributing support for iQ Ceramic radiators and INOW heating elements.
+- [WildeRNS](https://github.com/WildeRNS) for assistance with Nashone MTS-700-WB thermostat smartplugs, SmartMCB Energy meter, BlitzWolf BW-IS6 alarm panels.
+- [ishioni](https://github.com/ishioni) for contributing support for Eberg Cooly C32HD air conditioner.
+- [Gekko47](https://github.com/Gekko47) for contributing support for ElectriQ CD12v2 dehumidifiers.
+- [andreq](https://github.com/andreq) for assistance with Inkbird ITC-308 thermostats.
+- [dlosito](https://github.com/dlosito) for assistance with a second variant of Awow TH213 thermostat.
+- [UrZdcw9](https://github.com/UrZdcw9) for assistance with Arlec ceiling fan with light.
+- [dlosito](https://github.com/dlosito) for assistance with Lefant M213 vacuum cleaners.
 - [kramttocs](https://github.com/kramttocs) for assistance with Kyvol E30 vacuum cleaners.
 - [dieantu](https://github.com/dieantu) for contributing support for Himox H06 purifiers.
 - [pgistrand](https://github.com/pgistrand) for contributing support for Vork VK6067AW purifiers, and assistance with Parkside smart charger.
@@ -430,3 +430,4 @@ Further device support has been made with the assistance of users.  Please consi
 - [sayaivan](https://github.com/sayaivan) for contributing Indonesian translations.
 - [mhackdo18](https://github.com/mhackdo18) for assisting with support for YP Pet feeder.
 - [magomao](https://github.com/magomao) for assisting with support for Vivion air conditioners.
+- [tataihono](https://github.com/tataihono) for contributing support for Arlec Portable Air Conditioner.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -42,6 +42,7 @@
 
 ### Air Conditioners / Heatpumps
 
+- Arlec PA1123BKHA portable air conditioner
 - Be Cool BC14KL2101F
 - Carson CB PA280
 - Cooper&Hunter Nordic Evo Ng
@@ -380,7 +381,7 @@ of device.
 - Simple triple switch - three switches in a single device, tested with Somgam 3 gang wall switches.
 - Simple quad switch - four switches in a single device, tested with Somgam 4 gang wall switches.
 - Simple 6-way switch - six switches in a single device
-- Simple 8 switch - eight switches in a single device 
+- Simple 8 switch - eight switches in a single device
 - RGB Nightlight outlet - one smartplug with a small built-in RGB light.
 
 ### Lights

--- a/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
@@ -9,10 +9,10 @@ primary_entity:
       name: hvac_mode
       type: boolean
       mapping:
-        - dps_val: false
+        - dps_val: False
           value: "off"
           icon: "mdi:hvac-off"
-        - dps_val: true
+        - dps_val: True
           constraint: mode
           conditions:
             - dps_val: 1
@@ -36,7 +36,7 @@ primary_entity:
       mapping:
         - constraint: temperature_unit
           conditions:
-            - dps_val: true
+            - dps_val: True
               value_redirect: temp_set_f
               range:
                 min: 62
@@ -48,7 +48,7 @@ primary_entity:
       mapping:
         - constraint: temperature_unit
           conditions:
-            - dps_val: true
+            - dps_val: True
               value_redirect: temp_current_f
     - id: 20
       name: error
@@ -64,9 +64,9 @@ primary_entity:
       name: preset_mode
       type: boolean
       mapping:
-        - dps_val: false
+        - dps_val: False
           value: none
-        - dps_val: true
+        - dps_val: True
           value: sleep
     - id: 104
       type: string
@@ -82,15 +82,15 @@ primary_entity:
       name: swing_mode
       type: boolean
       mapping:
-        - dps_val: false
+        - dps_val: False
           value: "off"
-        - dps_val: true
+        - dps_val: True
           value: vertical
     - id: 109
       type: boolean
       name: temperature_unit
       mapping:
-        - dps_val: true
+        - dps_val: True
           value: F
         - value: C
     - id: 110
@@ -128,7 +128,7 @@ secondary_entities:
         type: boolean
         name: option
         mapping:
-          - dps_val: false
+          - dps_val: False
             value: Celsius
-          - dps_val: true
+          - dps_val: True
             value: Fahrenheit

--- a/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
@@ -9,22 +9,22 @@ primary_entity:
       name: hvac_mode
       type: boolean
       mapping:
-        - dps_val: False
+        - dps_val: false
           value: "off"
           icon: "mdi:hvac-off"
-        - dps_val: True
+        - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: 1
+            - dps_val: "1"
               icon: "mdi:snowflake"
               value: cool
-            - dps_val: 2
+            - dps_val: "2"
               icon: "mdi:fire"
               value: heat
-            - dps_val: 3
+            - dps_val: "3"
               icon: "mdi:water"
               value: dry
-            - dps_val: 4
+            - dps_val: "4"
               icon: "mdi:fan"
               value: fan_only
     - id: 2
@@ -36,7 +36,7 @@ primary_entity:
       mapping:
         - constraint: temperature_unit
           conditions:
-            - dps_val: True
+            - dps_val: true
               value_redirect: temp_set_f
               range:
                 min: 62
@@ -48,7 +48,7 @@ primary_entity:
       mapping:
         - constraint: temperature_unit
           conditions:
-            - dps_val: True
+            - dps_val: true
               value_redirect: temp_current_f
     - id: 20
       name: error
@@ -64,9 +64,9 @@ primary_entity:
       name: preset_mode
       type: boolean
       mapping:
-        - dps_val: False
+        - dps_val: false
           value: none
-        - dps_val: True
+        - dps_val: true
           value: sleep
     - id: 104
       type: string
@@ -82,15 +82,15 @@ primary_entity:
       name: swing_mode
       type: boolean
       mapping:
-        - dps_val: False
+        - dps_val: false
           value: "off"
-        - dps_val: True
+        - dps_val: true
           value: vertical
     - id: 109
       type: boolean
       name: temperature_unit
       mapping:
-        - dps_val: True
+        - dps_val: true
           value: F
         - value: C
     - id: 110
@@ -128,7 +128,7 @@ secondary_entities:
         type: boolean
         name: option
         mapping:
-          - dps_val: False
+          - dps_val: false
             value: Celsius
-          - dps_val: True
+          - dps_val: true
             value: Fahrenheit

--- a/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
@@ -11,17 +11,22 @@ primary_entity:
       mapping:
         - dps_val: false
           value: "off"
+          icon: "mdi:hvac-off"
         - dps_val: true
           constraint: mode
           conditions:
             - dps_val: 1
-              value: "cool"
+              icon: "mdi:snowflake"
+              value: cool
             - dps_val: 2
-              value: "heat"
+              icon: "mdi:fire"
+              value: heat
             - dps_val: 3
-              value: "dry"
+              icon: "mdi:water"
+              value: dry
             - dps_val: 4
-              value: "fan_only"
+              icon: "mdi:fan"
+              value: fan_only
     - id: 2
       type: integer
       name: temperature
@@ -54,6 +59,7 @@ primary_entity:
     - id: 101
       name: mode
       type: string
+      hidden: true
     - id: 103
       name: preset_mode
       type: boolean

--- a/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
@@ -1,4 +1,4 @@
-name: Arlec PA1123BKHA portable air conditioner
+name: Portable air conditioner
 products:
   - id: fxy4qkdh62geizbw
     name: Arlec PA1123BKHA portable air conditioner

--- a/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/arlec_pa1123bkha_portable_air_conditioner.yaml
@@ -1,0 +1,128 @@
+name: Arlec PA1123BKHA portable air conditioner
+products:
+  - id: fxy4qkdh62geizbw
+    name: Arlec PA1123BKHA portable air conditioner
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: 1
+              value: "cool"
+            - dps_val: 2
+              value: "heat"
+            - dps_val: 3
+              value: "dry"
+            - dps_val: 4
+              value: "fan_only"
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 16
+        max: 31
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: true
+              value_redirect: temp_set_f
+              range:
+                min: 62
+                max: 90
+    - id: 3
+      type: integer
+      name: current_temperature
+      readonly: true
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: true
+              value_redirect: temp_current_f
+    - id: 20
+      name: error
+      type: bitfield
+      mapping:
+        - dps_val: 0
+          value: "OK"
+    - id: 101
+      name: mode
+      type: string
+    - id: 103
+      name: preset_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: none
+        - dps_val: true
+          value: sleep
+    - id: 104
+      type: string
+      name: fan_mode
+      mapping:
+        - dps_val: "1"
+          value: high
+        - dps_val: "2"
+          value: medium
+        - dps_val: "3"
+          value: low
+    - id: 106
+      name: swing_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: vertical
+    - id: 109
+      type: boolean
+      name: temperature_unit
+      mapping:
+        - dps_val: true
+          value: F
+        - value: C
+    - id: 110
+      type: integer
+      name: temp_set_f
+      range:
+        min: 62
+        max: 90
+      hidden: true
+      optional: true
+    - id: 111
+      type: integer
+      name: temp_current_f
+      hidden: true
+      optional: true
+secondary_entities:
+  - entity: number
+    name: Timer
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: hour
+        range:
+          min: 0
+          max: 24
+  - entity: select
+    name: Temperature unit
+    icon: "mdi:temperature-celsius"
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: option
+        mapping:
+          - dps_val: false
+            value: Celsius
+          - dps_val: true
+            value: Fahrenheit


### PR DESCRIPTION
![portable ac](https://images.tuyaus.com/smart/icon/ay1536534747810ekKBj/888ce957bda81b4f2d7d0167d84507fd.png)
[Add support for Arlec PA1123BKHA portable air conditioner](https://www.bunnings.co.nz/arlec-3-3kw-smart-portable-aircon_p0453765)

- Mobile Wifi control Heating & Cooling reverse switch
- Touch control panel with LED display
- 3 fan speed with Remote control
- 3.3kW cooling & 2.6kW Heating Power