### PR TITLE
Air quality sensor - Air housekeeper (6 in 1)

### DIFF
--- a/custom_components/tuya_local/devices/airquality6in1.yaml
+++ b/custom_components/tuya_local/devices/airquality6in1.yaml
@@ -1,20 +1,16 @@
-name: Air quality monitor 6 in 1
+name: Air quality monitor
 products:
   - id: ugjbnqj2mffaexp5
-    name: Air Housekeeper
+    name: Air Housekeeper 6-in-1
 primary_entity:
   entity: sensor
-  name: PM2.5
-  class: volatile_organic_compounds
-  icon: "mdi:factory"
+  class: pm25
   dps:
     - id: 2
       type: integer
       name: sensor
       unit: µg/m³
       class: measurement
-      mapping:
-        - scale: 1
 secondary_entities:
   - entity: sensor
     class: temperature
@@ -43,20 +39,16 @@ secondary_entities:
       - id: 20
         type: integer
         name: sensor
-        unit: mg/m³
+        unit: ugm3
         class: measurement
-        mapping:
-          - scale: 1000
   - entity: sensor
     class: volatile_organic_compounds
     dps:
       - id: 21
         type: integer
         name: sensor
-        unit: mg/m³
+        unit: ugm3
         class: measurement
-        mapping:
-          - scale: 1000
   - entity: sensor
     class: carbon_dioxide
     dps:
@@ -65,6 +57,3 @@ secondary_entities:
         name: sensor
         unit: ppm
         class: measurement
-
-
-

--- a/custom_components/tuya_local/devices/airquality6in1.yaml
+++ b/custom_components/tuya_local/devices/airquality6in1.yaml
@@ -1,0 +1,70 @@
+name: Air quality monitor 6 in 1
+products:
+  - id: ugjbnqj2mffaexp5
+    name: Air Housekeeper
+primary_entity:
+  entity: sensor
+  name: PM2.5
+  class: volatile_organic_compounds
+  icon: "mdi:factory"
+  dps:
+    - id: 2
+      type: integer
+      name: sensor
+      unit: µg/m³
+      class: measurement
+      mapping:
+        - scale: 1
+secondary_entities:
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 19
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Formaldehyde
+    class: volatile_organic_compounds
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: mg/m³
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: volatile_organic_compounds
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        unit: mg/m³
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: carbon_dioxide
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        unit: ppm
+        class: measurement
+
+
+


### PR DESCRIPTION
Added temperature and air quality sensor - Air housekeeper (6 in 1). 
Tuya product_id: ugjbnqj2mffaexp5

Measurement support:
1) Temperatures
2) Humidity
3) PM2.5
4) VOC
5) CH2O
6) CO2