### PR TITLE
Fix smart_watering_device.yaml

### DIFF
--- a/custom_components/tuya_local/devices/smart_watering_device.yaml
+++ b/custom_components/tuya_local/devices/smart_watering_device.yaml
@@ -11,10 +11,8 @@ primary_entity:
       mapping:
         - dps_val: true
           icon: mdi:water-pump
-          value: ON
         - dps_val: false
           icon: mdi:water-pump-off
-          value: OFF
     - id: 48
       type: string
       optional: true

--- a/custom_components/tuya_local/devices/smart_watering_device.yaml
+++ b/custom_components/tuya_local/devices/smart_watering_device.yaml
@@ -8,6 +8,13 @@ primary_entity:
     - id: 1
       name: switch
       type: boolean
+      mapping:
+        - dps_val: true
+          icon: mdi:water-pump
+          value: ON
+        - dps_val: false
+          icon: mdi:water-pump-off
+          value: OFF
     - id: 48
       type: string
       optional: true
@@ -33,7 +40,7 @@ secondary_entities:
       - id: 56
         type: integer
         name: value
-        unit: min
+        unit: s
         range:
           min: 0
           max: 360
@@ -65,12 +72,18 @@ secondary_entities:
           min: 0
           max: 60
   - entity: sensor
-    name: Runtime
-    class: duration
-    category: diagnostic
+    name: "Run time remaining"
+    icon: "mdi:timer-sand"
     dps:
-      - id: 10
+      - id: 102
         type: integer
         name: sensor
-        unit: min
+        unit: s
+        range:
+          min: 0
+          max: 360
+      - id: 10
+        type: integer
+        name: runtime
+        unit: s
         optional: true


### PR DESCRIPTION
Apologies, I didn't see your code reviews on my PR (holidays probably).

This implements those revisions and I'll provide some context here where necessary:
1. The device is a small water pump for your plants. The runtime is in seconds because this is ample time to supply water to your house plants.
2. Implemented DPS 10 as an attribute of DPS 102 (which was missing). Again DPS 10 seems to do nothing (but perhaps the data will be useful to someone else in the future).