### PR TITLE
added support for Alutherm 2000 v2

### DIFF
--- a/custom_components/tuya_local/devices/eurom_alutherm_heater_v2.yaml
+++ b/custom_components/tuya_local/devices/eurom_alutherm_heater_v2.yaml
@@ -1,0 +1,71 @@
+name: Heater
+products:
+  - id: kotlg4xiajpds72u
+    name: Eurom Alutherm 2000 v2
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: true
+          icon: "mdi:radiator"
+          constraint: mode
+          conditions:
+            - dps_val: manual
+              value: heat
+            - dps_val: auto
+              value: auto
+        - dps_val: false
+          value: "off"
+          icon: "mdi:radiator-disabled"
+    - id: 2
+      name: temperature
+      type: integer
+      range:
+        min: 0
+        max: 37
+    - id: 3
+      name: current_temperature
+      type: integer
+    - id: 4
+      name: mode
+      type: string
+      hidden: true
+    - id: 5
+      name: fan_mode
+      type: string
+      mapping:
+        - dps_val: "off"
+          value: "off"
+        - dps_val: low
+          value: low
+        - dps_val: mid
+          value: medium
+        - dps_val: high
+          value: high
+    - id: 6
+      name: preset_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: comfort
+        - dps_val: true
+          value: eco
+    - id: 21
+      name: fault_code
+      type: bitfield
+secondary_entities:
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true


### PR DESCRIPTION
Last week I bought an Eurom Alutherm 2000. The existing integration doesn't seem to work with my version. I also noticed in the shop they were selling the same product in two different boxes. I took the "newest" model but the spec seemed to have changed. I took a copy of the existing eurom integration and tweaked it to work with the model I have.