### PR TITLE
Adding support for ETOP FCU thermostat

### DIFF
--- a/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
+++ b/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
@@ -1,6 +1,7 @@
-name: ETOP-FCU(CF) thermostat
+name: FCU thermostat
 products:
   - id: psetc59fvtm5gexl
+    name: ETOP-FCU(CF)
     name: Jaga JRT-100TW
 primary_entity:
   entity: climate
@@ -25,16 +26,13 @@ primary_entity:
     - id: 3
       name: current_temperature
       type: integer
-      unit: C
       mapping:
         - scale: 10
-          step: 5
     # Available DPs for current temperature and setpoint in °F
     # if you want to control in °F, uncomment these DPs
     # and comment the DP for °C above
     # - id: 20
     #   name: temperature
-    #   hidden: true
     #   type: integer
     #   unit: F
     #   range:
@@ -45,15 +43,9 @@ primary_entity:
     #       step: 1
     # - id: 21
     #   name: current_temperature
-    #   hidden: true
     #   type: integer
-    #   unit: F
-    #   range:
-    #     min: 32
-    #     max: 122
     #   mapping:
     #     - scale: 1
-    #       step: 1
     ############################################################
     # Thermostat modes
     #
@@ -70,7 +62,7 @@ primary_entity:
         - dps_val: cold
           value: cool
         - dps_val: auto
-          value: auto
+          value: heat_cool
     - id: 5
       name: fan_mode
       type: string

--- a/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
+++ b/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
@@ -1,0 +1,143 @@
+name: ETOP-FCU(CF) thermostat
+products:
+  - id: psetc59fvtm5gexl
+    name: Jaga JRT-100TW
+primary_entity:
+  entity: climate
+  name: Thermostat
+  dps:
+    ############################################################
+    # Setpoint and current temperature
+    ############################################################
+    # Using DPs for current temperature and setpoint in °C
+    # if you want to control in °F instead, comment these DPs
+    # and uncomment the DPs for °F below
+    - id: 2
+      name: temperature
+      type: integer
+      unit: C
+      range:
+        min: 50
+        max: 350
+      mapping:
+        - scale: 10
+          step: 5
+    - id: 3
+      name: current_temperature
+      type: integer
+      unit: C
+      mapping:
+        - scale: 10
+          step: 5
+    # Available DPs for current temperature and setpoint in °F
+    # if you want to control in °F, uncomment these DPs
+    # and comment the DP for °C above
+    # - id: 20
+    #   name: temperature
+    #   hidden: true
+    #   type: integer
+    #   unit: F
+    #   range:
+    #     min: 41
+    #     max: 95
+    #   mapping:
+    #     - scale: 1
+    #       step: 1
+    # - id: 21
+    #   name: current_temperature
+    #   hidden: true
+    #   type: integer
+    #   unit: F
+    #   range:
+    #     min: 32
+    #     max: 122
+    #   mapping:
+    #     - scale: 1
+    #       step: 1
+    ############################################################
+    # Thermostat modes
+    #
+    # Depending on your actual heating/cooling installation
+    # you can disable the unnecessary entries
+    - id: 4
+      name: hvac_mode
+      type: string
+      mapping:
+        - dps_val: fan
+          value: fan_only
+        - dps_val: heat
+          value: heat
+        - dps_val: cold
+          value: cool
+          hidden: true
+        - dps_val: auto
+          value: auto
+          hidden: true
+    - id: 5
+      name: fan_mode
+      type: string
+      mapping:
+        - dps_val: low
+          value: low
+        - dps_val: middle
+          value: medium
+        - dps_val: high
+          value: high
+        - dps_val: auto
+          value: auto
+secondary_entities:
+  # Overall On/Off switch
+  - entity: switch
+    name: "On/Off"
+    category: config
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+  # Temperature display unit
+  - entity: select
+    name: "Display unit"
+    category: config
+    icon: "mdi:temperature-celsius"
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: c
+            value: Celsius
+          - dps_val: f
+            value: Fahrenheit
+  # The following DPs are available but don't seem to 
+  # actually do anything
+  # - entity: switch
+  #   name: "Child Lock"
+  #   category: config
+  #   dps:
+  #     - id: 7
+  #       name: switch
+  #       type: boolean
+  # - entity: switch
+  #   name: "Countdown"
+  #   category: config
+  #   dps:
+  #     - id: 11
+  #       name: switch
+  #       type: string
+  #       mapping:
+  #         - dps_val: Disable
+  #           value: off
+  #         - dps_val: Enable
+  #           value: on
+  # - entity: switch
+  #   name: "Work State"
+  #   category: config
+  #   dps:
+  #     - id: 14
+  #       name: switch
+  #       type: string
+  #       mapping:
+  #         - dps_val: no_working
+  #           value: off
+  #         - dps_val: working
+  #           value: on

--- a/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
+++ b/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
@@ -1,18 +1,18 @@
 name: FCU thermostat
 products:
   - id: psetc59fvtm5gexl
-    name: ETOP-FCU(CF)
-    name: Jaga JRT-100TW
+    name: ETOP-FCU(CF) | Jaga JRT-100TW
 primary_entity:
   entity: climate
   name: Thermostat
   dps:
     ############################################################
     # Setpoint and current temperature
-    ############################################################
+    #
     # Using DPs for current temperature and setpoint in °C
     # if you want to control in °F instead, comment these DPs
     # and uncomment the DPs for °F below
+    ############################################################
     - id: 2
       name: temperature
       type: integer
@@ -33,6 +33,7 @@ primary_entity:
     # and comment the DP for °C above
     # - id: 20
     #   name: temperature
+    #   hidden: true
     #   type: integer
     #   unit: F
     #   range:
@@ -43,26 +44,45 @@ primary_entity:
     #       step: 1
     # - id: 21
     #   name: current_temperature
+    #   hidden: true
     #   type: integer
+    #   unit: F
+    #   range:
+    #     min: 32
+    #     max: 122
     #   mapping:
     #     - scale: 1
+    #       step: 1
     ############################################################
     # Thermostat modes
     #
     # Depending on your actual heating/cooling installation
-    # you can hide the unnecessary entries
-    - id: 4
+    # you can disable the unnecessary entries
+    ############################################################
+    - id: 1
       name: hvac_mode
-      type: string
+      type: boolean
       mapping:
-        - dps_val: fan
-          value: fan_only
-        - dps_val: heat
-          value: heat
-        - dps_val: cold
-          value: cool
-        - dps_val: auto
-          value: heat_cool
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: work_mode
+          conditions:
+            - dps_val: fan
+              value: fan_only
+            - dps_val: heat
+              value: heat
+            - dps_val: cold
+              value: cool
+            - dps_val: auto
+              value: heat_cool
+    - id: 4
+      name: work_mode
+      type: string
+      hidden: true
+    ############################################################
+    # Fan speed
+    ############################################################
     - id: 5
       name: fan_mode
       type: string
@@ -76,15 +96,9 @@ primary_entity:
         - dps_val: auto
           value: auto
 secondary_entities:
-  # Overall On/Off switch
-  - entity: switch
-    name: "On/Off"
-    category: config
-    dps:
-      - id: 1
-        name: switch
-        type: boolean
+  ############################################################
   # Temperature display unit
+  ############################################################
   - entity: select
     name: "Display unit"
     category: config
@@ -98,36 +112,47 @@ secondary_entities:
             value: Celsius
           - dps_val: f
             value: Fahrenheit
+  ############################################################
+  # Programming mode
+  #
+  # Enable/disable the weekly program
+  ############################################################
+  - entity: select
+    name: "Programming mode"
+    category: config
+    icon: "mdi:clock-outline"
+    dps:
+      - id: 11
+        name: option
+        type: string
+        mapping:
+          - dps_val: Disable
+            value: Manual
+          - dps_val: Enable
+            value: Automatic
+  ############################################################
   # The following DPs are available but don't seem to 
   # actually do anything
-  # - entity: switch
-  #   name: "Child Lock"
-  #   category: config
-  #   dps:
-  #     - id: 7
-  #       name: switch
-  #       type: boolean
-  # - entity: switch
-  #   name: "Countdown"
-  #   category: config
-  #   dps:
-  #     - id: 11
-  #       name: switch
-  #       type: string
-  #       mapping:
-  #         - dps_val: Disable
-  #           value: off
-  #         - dps_val: Enable
-  #           value: on
-  # - entity: switch
-  #   name: "Work State"
-  #   category: config
-  #   dps:
-  #     - id: 14
-  #       name: switch
-  #       type: string
-  #       mapping:
-  #         - dps_val: no_working
-  #           value: off
-  #         - dps_val: working
-  #           value: on
+  ############################################################
+  - entity: switch
+    name: "Child Lock"
+    category: config
+    icon: "mdi:lock"
+    dps:
+      - id: 7
+        name: switch
+        type: boolean
+  - entity: binary_sensor
+    name: "Work State"
+    category: config
+    dps:
+      - id: 14
+        name: sensor
+        type: string
+        readonly: true
+        mapping:
+          - dps_val: no_working
+            value: false
+          - dps_val: working
+            value: true
+

--- a/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
+++ b/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
@@ -58,7 +58,7 @@ primary_entity:
     # Thermostat modes
     #
     # Depending on your actual heating/cooling installation
-    # you can disable the unnecessary entries
+    # you can hide the unnecessary entries
     - id: 4
       name: hvac_mode
       type: string
@@ -69,10 +69,8 @@ primary_entity:
           value: heat
         - dps_val: cold
           value: cool
-          hidden: true
         - dps_val: auto
           value: auto
-          hidden: true
     - id: 5
       name: fan_mode
       type: string

--- a/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
+++ b/custom_components/tuya_local/devices/etop_fcu_thermostat.yaml
@@ -1,4 +1,4 @@
-name: FCU thermostat
+name: Thermostat
 products:
   - id: psetc59fvtm5gexl
     name: ETOP-FCU(CF) | Jaga JRT-100TW
@@ -39,9 +39,6 @@ primary_entity:
     #   range:
     #     min: 41
     #     max: 95
-    #   mapping:
-    #     - scale: 1
-    #       step: 1
     # - id: 21
     #   name: current_temperature
     #   hidden: true
@@ -50,9 +47,6 @@ primary_entity:
     #   range:
     #     min: 32
     #     max: 122
-    #   mapping:
-    #     - scale: 1
-    #       step: 1
     ############################################################
     # Thermostat modes
     #
@@ -95,6 +89,11 @@ primary_entity:
           value: high
         - dps_val: auto
           value: auto
+    - id: 14
+      name: work_state
+      type: string
+      # has values no_working and working defined in docs, and appears to be useful for hvac_action,
+      # but in practice does not seem to change.
 secondary_entities:
   ############################################################
   # Temperature display unit
@@ -142,17 +141,3 @@ secondary_entities:
       - id: 7
         name: switch
         type: boolean
-  - entity: binary_sensor
-    name: "Work State"
-    category: config
-    dps:
-      - id: 14
-        name: sensor
-        type: string
-        readonly: true
-        mapping:
-          - dps_val: no_working
-            value: false
-          - dps_val: working
-            value: true
-


### PR DESCRIPTION
Hi,

Here's a config file for an [ETOP FCU thermostat](https://www.etopcontrols.com/digital-programmable-heating-and-cooling-fcu-thermostat), also sold by Java as the [JRT-100TW](https://jaga.com/ex/options/jaga-clock-thermostat-for-recessed-panel-mounting-jrt-100tw/)