### PR TITLE
Fix detection of NAC AP470 Air Purifier

### DIFF
--- a/custom_components/tuya_local/devices/nac_ap470_purifier.yaml
+++ b/custom_components/tuya_local/devices/nac_ap470_purifier.yaml
@@ -113,6 +113,7 @@ secondary_entities:
       - id: 19
         name: option
         type: string
+        optional: true
         mapping:
           - dps_val: cancle
             value: "Off"
@@ -133,3 +134,4 @@ secondary_entities:
         type: integer
         name: sensor
         unit: "min"
+        optional: true


### PR DESCRIPTION
It wasn't properly detected. It looks like tuya is not sending DPS 19 all the time.