### PR TITLE
Add support for Graywind shades/blinds

### DIFF
--- a/custom_components/tuya_local/devices/graywind_shades.yaml
+++ b/custom_components/tuya_local/devices/graywind_shades.yaml
@@ -1,9 +1,10 @@
-name: Graywind Shades
+name: Window shade
 products:
   - id: hldq12vsaqalcfer
+    name: Graywind hardwired blackout
 primary_entity:
   entity: cover
-  class: curtain
+  class: shade
   dps:
     - id: 1
       name: control
@@ -18,13 +19,12 @@ primary_entity:
     - id: 2
       name: position
       type: integer
-      unit: "%"
       range:
         min: 0
         max: 100
 secondary_entities:
   - entity: select
-    name: Motor reverse mode
+    name: Motor direction
     category: config
     icon: "mdi:sign-direction"
     dps:

--- a/custom_components/tuya_local/devices/graywind_shades.yaml
+++ b/custom_components/tuya_local/devices/graywind_shades.yaml
@@ -1,0 +1,38 @@
+name: Graywind Shades
+products:
+  - id: hldq12vsaqalcfer
+primary_entity:
+  entity: cover
+  class: curtain
+  dps:
+    - id: 1
+      name: control
+      type: string
+      mapping:
+        - dps_val: open
+          value: open
+        - dps_val: close
+          value: close
+        - dps_val: stop
+          value: stop
+    - id: 2
+      name: position
+      type: integer
+      unit: "%"
+      range:
+        min: 0
+        max: 100
+secondary_entities:
+  - entity: select
+    name: Motor reverse mode
+    category: config
+    icon: "mdi:sign-direction"
+    dps:
+      - id: 5
+        name: option
+        type: string
+        mapping:
+          - dps_val: forward
+            value: Forward
+          - dps_val: back
+            value: Back


### PR DESCRIPTION
https://www.amazon.com/gp/product/B07Z95FTVW/?ie=UTF8

Mine have the opening/closing status flipped, but I believe that's because I have reverse enabled - probably not worth trying to fix that.

When I deployed to my local Hass instance the shades were correctly recognised and function otherwise as expected.