### PR TITLE
Updated binary value polarity for Holman Bit Flags for battery entities.

### DIFF
--- a/custom_components/tuya_local/devices/holman_wx8_irrigation_controller.yaml
+++ b/custom_components/tuya_local/devices/holman_wx8_irrigation_controller.yaml
@@ -139,8 +139,8 @@ secondary_entities:
         type: bitfield
         mapping:
           - dps_val: 1
-            value: true
-          - value: false
+            value: false
+          - value: true
   - entity: binary_sensor
     name: Power supply
     class: problem
@@ -151,8 +151,8 @@ secondary_entities:
         type: bitfield
         mapping:
           - dps_val: 2
-            value: true
-          - value: false
+            value: false
+          - value: true
   - entity: binary_sensor
     name: Watering
     dps:
@@ -175,6 +175,17 @@ secondary_entities:
             value: true
           - value: false
   - entity: binary_sensor
+    name: reserved
+    category: diagnostic
+    dps:
+      - id: 120
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 16
+            value: true
+          - value: false          
+  - entity: binary_sensor
     name: Evie
     category: diagnostic
     class: connectivity
@@ -196,8 +207,8 @@ secondary_entities:
         type: bitfield
         mapping:
           - dps_val: 64
-            value: true
-          - value: false
+            value: false
+          - value: true
   - entity: binary_sensor
     name: Evie sensor
     class: moisture

--- a/custom_components/tuya_local/devices/holman_wx8_irrigation_controller.yaml
+++ b/custom_components/tuya_local/devices/holman_wx8_irrigation_controller.yaml
@@ -173,7 +173,7 @@ secondary_entities:
         mapping:
           - dps_val: 8
             value: true
-          - value: false      
+          - value: false
   - entity: binary_sensor
     name: Evie
     category: diagnostic

--- a/custom_components/tuya_local/devices/holman_wx8_irrigation_controller.yaml
+++ b/custom_components/tuya_local/devices/holman_wx8_irrigation_controller.yaml
@@ -173,18 +173,7 @@ secondary_entities:
         mapping:
           - dps_val: 8
             value: true
-          - value: false
-  - entity: binary_sensor
-    name: reserved
-    category: diagnostic
-    dps:
-      - id: 120
-        name: sensor
-        type: bitfield
-        mapping:
-          - dps_val: 16
-            value: true
-          - value: false          
+          - value: false      
   - entity: binary_sensor
     name: Evie
     category: diagnostic


### PR DESCRIPTION
reversed bitfield flag order. Although I see you made that change on the main branch. Agree this is correct based on my latest testing.