### PR TITLE
Fixes #379 Nedis Pet Feeder

### DIFF
--- a/custom_components/tuya_local/devices/nedis_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/nedis_pet_feeder.yaml
@@ -34,6 +34,7 @@ secondary_entities:
         type: integer
         name: value
         unit: portions
+        optional: true
         range:
           min: 0
           max: 12
@@ -95,6 +96,7 @@ secondary_entities:
     icon: "mdi:clock-fast"
     dps:
       - id: 107
+        optional: true
         type: integer
         name: sensor
         unit: portions


### PR DESCRIPTION
Like @make-all guessed in #379 there were a couple of dps that needed to be optional.
After making them so I can add the device without any problem