### PR TITLE
New device: Madimack Inverflow Pro variable speed pool water pump

### DIFF
--- a/custom_components/tuya_local/devices/madimack_inverflow_pro.yaml
+++ b/custom_components/tuya_local/devices/madimack_inverflow_pro.yaml
@@ -1,0 +1,177 @@
+name: Pool pump
+products:
+  - id: ircs2n82vgrozoew
+    name: Madimack Inverflow Pro P300i
+primary_entity:
+  entity: fan
+  dps:
+    - id: 105
+      type: boolean
+      name: switch
+    - id: 102
+      type: integer
+      name: speed
+      range:
+        min: 30
+        max: 120
+      readonly: true
+    - id: 116
+      name: unknown_116
+      type: string
+    - id: 117
+      name: unknown_117
+      type: string
+    - id: 115
+      name: unknown_115
+      type: boolean
+secondary_entities:
+  - entity: select
+    name: Pump mode
+    translation_key: mode
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: option
+        mapping:
+          - dps_val: "MI"
+            value: "Manual"
+          - dps_val: "AI"
+            value: "AI Flow set"
+          - dps_val: "backwash"
+            value: "Boost"
+  - entity: select
+    name: Pump flow units
+    translation_key: units
+    category: config
+    dps:
+      - id: 110
+        type: string
+        name: option
+        mapping:
+          - dps_val: "m3_h"
+            value: "m³/h"
+          - dps_val: "l_min"
+            value: "L/min"
+          - dps_val: "us_gpm"
+            value: "US gpm"
+          - dps_val: "ipm_gpm"
+            value: "International gpm"
+  - entity: number
+    name: Boost timer set
+    category: config
+    mode: box
+    dps:
+      - id: 104
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 1500
+        unit: sec
+  - entity: number
+    name: AI flow rate set
+    category: config
+    mode: slider
+    dps:
+      - id: 106
+        type: integer
+        name: value
+      - id: 101
+        type: integer
+        name: maximum
+      - id: 107
+        type: integer
+        name: minimum
+      - id: 113
+        type: integer
+        name: step
+      - id: 110
+        type: string
+        name: unit
+        mapping:
+          - dps_val: "m3_h"
+            value: "m³/h"
+          - dps_val: "l_min"
+            value: "L/min"
+          - dps_val: "us_gpm"
+            value: "gal/min"
+          - dps_val: "ipm_gpm"
+            value: "gal/min"
+  - entity: number
+    name: Manual percentage power set
+    category: config
+    mode: slider
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        range:
+          min: 30
+          max: 120
+        step: 5
+        unit: "%"
+  - entity: sensor
+    name: Boost time remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        unit: sec
+  - entity: sensor
+    name: Current power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Flow rate
+    class: volume_flow_rate
+    category: diagnostic
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+      - id: 110
+        type: string
+        name: unit
+        mapping:
+          - dps_val: "m3_h"
+            value: "m³/h"
+          - dps_val: "l_min"
+            value: "L/min"
+          - dps_val: "us_gpm"
+            value: "gal/min"
+          - dps_val: "ipm_gpm"
+            value: "gal/min"
+  - entity: sensor
+    name: Hourly energy usage
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        class: measurement
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Fault code
+    category: diagnostic
+    dps:
+      - id: 2
+        type: bitfield
+        name: sensor
+  - entity: sensor
+    name: Flow pressure warning
+    category: diagnostic
+    dps:
+      - id: 114
+        type: boolean
+        name: sensor


### PR DESCRIPTION
This device is a variable speed pool water pump. The specific model I have is Madimack Inverflow Pro P300i. There are another two pumps in the range with more capacity. The manufacturer also makes a Inverflow Ultra pump which may be compatible. The Inverflow Eco does not have wifi/Tuya control. These water pumps are often used with Madimack heatpumps.

There is an obscure control mechanism which may need review:
The primary entity is set as a fan (closest matching entity available). The only controllable aspect is on/off. For the speed setting, I have added a read-only DP from Tuya that reports the pump actual speed, on a range of 30-120. This DP is always updated, regardless of the pump mode.

I have added several secondary config entities enabling full control of the pump. Firstly, there are three control modes:
1. "Boost" mode - which sets the motor at 100% and runs on a settable timer. This is the default mode on startup, and the default timer is 180s.
2. Manual control - this allows the pump to be set to a % operating capacity, with a range of 30-120%
3. AI flow mode - this allows the pump to be set to a flow rate with 4 different options of flow units.
Of note - the controls for all 3 of the above modes work independently. Mapping the control DP's of these modes to the primary entity "speed" control can result in odd behaviour. (e.g. if primary entity "speed" reads off the Manual control DP, but a flow rate is set in "AI" mode, the primary entity "speed" is not updated - it can only be updated by using the read-only "real-speed" DP.

There is also a selectable flow rate units option in the pump. This interestingly does not work on my unit, despite it being "R/W" in Tuya - I cannot change from the L/min default.

There are also several useful diagnostic DP's. These include a measurement of real flow rates, current power, diagnostic fault codes and an hourly energy usage DP (this DP I have set as "measurement" type, not "total-increasing" as it would not be compatible with HA's energy panel - I'd recommend end users setup an Integration helper).

I'd like feedback on this setup - there are a few other possible options if I activate some constraints that may be less confusing?