### PR TITLE
New device: Moes IR Thermostat (AC Controller)

### DIFF
--- a/custom_components/tuya_local/devices/moes_ir_thermostat.yaml
+++ b/custom_components/tuya_local/devices/moes_ir_thermostat.yaml
@@ -1,4 +1,4 @@
-name: Thermostat
+name: IR Thermostat
 products:
   - id: aqlyorlybbtn6ox7
     name: Moes IR Thermostat
@@ -68,6 +68,78 @@ primary_entity:
     - id: 12
       name: current_humidity
       type: integer
+      unit: "%"
       range:
         max: 100
         min: 0
+secondary_entities:
+  - entity: switch
+    name: power
+    dps:
+      - id: 1
+        type: boolean
+        name: infared_switch
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: binary_sensor
+    name: fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 6
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: serious_fault
+          - dps_val: 1
+            value: sensor_fault
+  - entity: switch
+    name: Filter reset
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: filter_reset
+  - entity: sensor
+    name: filter life
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: h
+        class: measurement
+        range:
+          max: 720
+          min: 0
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 12
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        range:
+          max: 100
+          min: 0
+  - entity: sensor
+    name: runtime
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: h
+        class: measurement
+        range:
+          max: 999999
+          min: 0

--- a/custom_components/tuya_local/devices/moes_ir_thermostat.yaml
+++ b/custom_components/tuya_local/devices/moes_ir_thermostat.yaml
@@ -1,0 +1,73 @@
+name: Thermostat
+products:
+  - id: aqlyorlybbtn6ox7 
+    name: Moes IR Thermostat
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: cold
+              value: cool
+            - dps_val: warm
+              value: heat
+            - dps_val: auto
+              value: auto
+            - dps_val: air
+              value: fan_only
+            - dps_val: dehumidify
+              value: dry
+    - id: 2
+      name: current_temperature
+      type: integer
+      unit: C
+      mapping:
+        - scale: 10
+    - id: 3
+      name: temperature
+      type: integer
+      unit: C
+      range:
+        min: 16
+        max: 30
+    - id: 4
+      name: mode
+      type: string
+      hidden: true
+    - id: 5
+      name: fan_mode
+      type: string
+      mapping:
+        - dps_val: low
+          value: low
+        - dps_val: middle
+          value: medium
+        - dps_val: high
+          value: high
+        - dps_val: auto
+          value: auto
+    - id: 9
+      name: target_temperature_high
+      type: integer
+      range:
+        min: 16
+        max: 30
+    - id: 10
+      name: target_temperature_low
+      type: integer
+      range:
+        min: 16
+        max: 30
+    - id: 12
+      name: current_humidity
+      type: integer
+      range:
+        max: 100
+        min: 0

--- a/custom_components/tuya_local/devices/moes_ir_thermostat.yaml
+++ b/custom_components/tuya_local/devices/moes_ir_thermostat.yaml
@@ -1,6 +1,6 @@
 name: Thermostat
 products:
-  - id: aqlyorlybbtn6ox7 
+  - id: aqlyorlybbtn6ox7
     name: Moes IR Thermostat
 primary_entity:
   entity: climate
@@ -53,18 +53,18 @@ primary_entity:
           value: high
         - dps_val: auto
           value: auto
-    - id: 9
-      name: target_temperature_high
-      type: integer
-      range:
-        min: 16
-        max: 30
-    - id: 10
-      name: target_temperature_low
-      type: integer
-      range:
-        min: 16
-        max: 30
+    # - id: 9
+    #   name: target_temperature_high
+    #   type: integer
+    #   range:
+    #     min: 16
+    #     max: 30
+    # - id: 10
+    #   name: target_temperature_low
+    #   type: integer
+    #   range:
+    #     min: 16
+    #     max: 30
     - id: 12
       name: current_humidity
       type: integer


### PR DESCRIPTION
This is my attempt to add compatibility for Moes IR Thermostat - It is a IR controller specific to Air conditioners with built in temperature and humidity sensors. There is also a variant wihtout the LCD screen, which I believe should work the same, but I only have the LCD Screen variant, so not able to confirm.

Details about the device: https://moeshouse.com/products/wifi-ir-thermostat-with-ac-remote-and-sensor?variant=40016596303953

Now, I was able to add the device successfully and it read all attributes correctly, and it is able to set the AC functions - It will update the Tuya device status correctly, example if you change target temperature to 20 C, it will get reflected on the device screen and even in the app... The only problem is, changing the properties via DPS locally will not trigger the IR commands, So it will not set the actual AC temperature.  

I have figured out how to send the IR commands via tinytuya using the Cloud integration, but I don't know yet how to bind these commands to the climate device, so when you attempt to change the device on HA, it should trigger the IR command. 

Here is an example of code that triggers the IR command correcty so The AC will get the command, and the Tuya device screen will also reflect the change (and it will propagate to HA):

``` python
import tinytuya
import json

tinytuya.set_debug()

c = tinytuya.Cloud()

device_id = '...' # IR Thermostat

# Get a listing of all programmed "remotes". This is also the id of the subdevice you may see listed
# on Tuya Cloud as an "Air conditioner", after you configure your AC model in the app.
# In this result you will also find the remote_index attribute which I believe is 
# the IR codeset for a specific brand.

# Example response:
# "result": [
#         {
#             "area_id": 0,
#             "brand_id": 182,
#             "brand_name": "Midea",
#             "category_id": 5,
#             "operator_id": 0,
#             "remote_id": "eb0dc7........", # this is the same as subdevice id on Tuya Cloud
#             "remote_index": 11272,
#             "remote_name": "Ar condicionado"
#         }

# res = c.cloudrequest( '/v2.0/infrareds/' + device_id + '/remotes' )

remote_id = '...'

# list of supported standard AC codes:
# https://developer.tuya.com/en/docs/cloud/infrared-air-conditioner-apis?id=Kb3oe9ehg02fn

# Send command using AC standard code. This is the method that works with my specific AC (Midea)
post_data = {
  "category_id": 5,
  "remote_index": 11272,
  "code": "temp",
  "value": 20
}
res = c.cloudrequest( '/v2.0/infrareds/' + device_id + '/air-conditioners/' + remote_id + '/command', post=post_data )

print( res )
print( json.dumps(res, indent=2) )
```

Any help to figure out how to bind these 2 things together is really appreciated.
