### PR TITLE
Adds MOES ZC-TD 5W GU10 ZigBee RGB bulb to zigbee_smart_bulb.yaml

### DIFF
--- a/custom_components/tuya_local/devices/zigbee_smart_bulb.yaml
+++ b/custom_components/tuya_local/devices/zigbee_smart_bulb.yaml
@@ -4,6 +4,8 @@ products:
     name: MOES zigbee smart bulb
   - id: it1u8ahz
     name: MOES smart bulb RGBCW zigbee
+  - id: rcggc0ys
+    name: MOES ZC-TD 5W GU10 ZigBee
 primary_entity:
   entity: light
   dps:


### PR DESCRIPTION
Bought a zigbee rgb bulb on aliexpress (https://www.aliexpress.com/item/1005005719073628.html)
The integration discovered it as a fan or smart switch and didn't offer the smart zigbee bulb device type, this commits fixes that problem.
```
{
  "category": "dj",
  "product_name": "ZC-TD 5W GU10 ZigBee",
  "product_id": "rcggc0ys",
  "biz_type": 18,
  "model": "ZB-TD5-RCW-GU10",
  "sub": true,
  "icon": "https://images.tuyaeu.com/smart/icon/ay15327721968035jwx9/d4df9b682da8dc3ee1b9e518981dccd0.png"
}
```