### PR TITLE
Add support for HeatStorm HS-1500 heater

### DIFF
--- a/custom_components/tuya_local/devices/heatstorm_hs1500_heater.yaml
+++ b/custom_components/tuya_local/devices/heatstorm_hs1500_heater.yaml
@@ -1,0 +1,132 @@
+name: Heatstorm heater
+products:
+  - id: gifk0oubmovuz3ky
+    name: HS-1500
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: heat
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 4
+        max: 37
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: f
+              value_redirect: set_temp_f
+              range:
+                min: 40
+                max: 99
+    - id: 3
+      type: integer
+      name: current_temperature
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: f
+              value_redirect: cur_temp_f
+    - id: 4
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: Auto
+          value: comfort
+        - dps_val: Low
+          value: eco
+        - dps_val: High
+          value: boost
+    - id: 13
+      type: bitfield
+      name: fault_code
+      mapping:
+        - dps_val: 1
+          value: Temp sensor fault
+        - dps_val: 2
+          value: Tilt over
+        - dps_val: 3
+          value: Over-voltage
+    - id: 19
+      type: string
+      name: temperature_unit
+      mapping:
+        - dps_val: c
+          value: C
+        - dps_val: f
+          value: F
+    - id: 20
+      type: integer
+      name: set_temp_f
+      range:
+        min: 40
+        max: 99
+      hidden: true
+    - id: 21
+      type: integer
+      name: cur_temp_f
+      hidden: true
+
+secondary_entities:
+  - entity: light
+    name: Display
+    category: config
+    dps:
+      - id: 5
+        name: brightness
+        type: string
+        mapping:
+          - dps_val: "Off"
+            value: 0
+          - dps_val: "10"
+            value: 26
+          - dps_val: "50"
+            value: 128
+          - dps_val: "100"
+            value: 255
+  - entity: lock
+    name: Child lock
+    icon: "mdi:hand-back-right-off"
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 13
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    name: Temperature unit
+    icon: "mdi:temperature-celsius"
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: Celsius
+          - dps_val: f
+            value: Fahrenheit

--- a/custom_components/tuya_local/devices/heatstorm_hs1500_heater.yaml
+++ b/custom_components/tuya_local/devices/heatstorm_hs1500_heater.yaml
@@ -4,6 +4,7 @@ products:
     name: HS-1500
 primary_entity:
   entity: climate
+  translation_only_key: heater
   dps:
     - id: 1
       type: boolean
@@ -53,7 +54,7 @@ primary_entity:
           value: Temp sensor fault
         - dps_val: 2
           value: Tilt over
-        - dps_val: 3
+        - dps_val: 4
           value: Over-voltage
     - id: 19
       type: string
@@ -74,10 +75,9 @@ primary_entity:
       type: integer
       name: cur_temp_f
       hidden: true
-
 secondary_entities:
   - entity: light
-    name: Display
+    translation_key: display
     category: config
     dps:
       - id: 5
@@ -93,8 +93,7 @@ secondary_entities:
           - dps_val: "100"
             value: 255
   - entity: lock
-    name: Child lock
-    icon: "mdi:hand-back-right-off"
+    translation_key: child_lock
     category: config
     dps:
       - id: 7
@@ -106,7 +105,6 @@ secondary_entities:
           - dps_val: false
             value: true
   - entity: binary_sensor
-    name: Fault
     class: problem
     category: diagnostic
     dps:
@@ -118,8 +116,7 @@ secondary_entities:
             value: false
           - value: true
   - entity: select
-    name: Temperature unit
-    icon: "mdi:temperature-celsius"
+    translation_key: temperature_unit
     category: config
     dps:
       - id: 19
@@ -127,6 +124,6 @@ secondary_entities:
         name: option
         mapping:
           - dps_val: c
-            value: Celsius
+            value: celsius
           - dps_val: f
-            value: Fahrenheit
+            value: fahrenheit

--- a/custom_components/tuya_local/devices/heatstorm_hs1500_heater.yaml
+++ b/custom_components/tuya_local/devices/heatstorm_hs1500_heater.yaml
@@ -1,7 +1,7 @@
-name: Heatstorm heater
+name: Heater
 products:
   - id: gifk0oubmovuz3ky
-    name: HS-1500
+    name: Heatstorm HS-1500
 primary_entity:
   entity: climate
   translation_only_key: heater
@@ -46,16 +46,6 @@ primary_entity:
           value: eco
         - dps_val: High
           value: boost
-    - id: 13
-      type: bitfield
-      name: fault_code
-      mapping:
-        - dps_val: 1
-          value: Temp sensor fault
-        - dps_val: 2
-          value: Tilt over
-        - dps_val: 4
-          value: Over-voltage
     - id: 19
       type: string
       name: temperature_unit
@@ -115,6 +105,19 @@ secondary_entities:
           - dps_val: 0
             value: false
           - value: true
+      - id: 13
+        type: bitfield
+        name: fault_code
+      - id: 13
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 1
+            value: Temp sensor fault
+          - dps_val: 2
+            value: Tilt over
+          - dps_val: 4
+            value: Over-voltage
   - entity: select
     translation_key: temperature_unit
     category: config


### PR DESCRIPTION
Add support for the [HeatStorm HS-1500](https://www.amazon.com/Heat-Storm-HS-1500-PHX-WIFI-Infrared-Heater/dp/B07JXRWJ8D) wall mounted heater. 

I validated DPs via Tuya developer account website with my own devices. It is mostly similar to the HS-6000 excepting some DPs, namely the hvac_mode one which is not present on the hs1500.
