### PR TITLE
Madimack Elite V3 - Added Power Sensor and updated EEV sensor class and unit

### DIFF
--- a/custom_components/tuya_local/devices/madimack_elite_v3_heatpump_updated.yaml
+++ b/custom_components/tuya_local/devices/madimack_elite_v3_heatpump_updated.yaml
@@ -1,7 +1,7 @@
 name: Pool heatpump
 products:
   - id: kwrvh8zwvbbyp086
-    name: Madimack Elite V3 40kW
+    name: Madimack Elite V3 11-40kW
 primary_entity:
   entity: climate
   dps:
@@ -193,6 +193,8 @@ secondary_entities:
       - id: 121
         name: sensor
         type: integer
+        unit: P
+        class: measurement
   - entity: sensor
     category: diagnostic
     name: Fault code
@@ -200,3 +202,15 @@ secondary_entities:
       - id: 107
         name: sensor
         type: bitfield
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 125
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 1000


### PR DESCRIPTION
Configuration was missing the power entity on dps id 125. 
EEV sensor updated to treat the integer as a measurement.  
Changed name to include 11-40kW versions.

Tested with Madimack Elite V3 14kW