### PR TITLE
Added constraints to Away mode for Solaire Vitra Heater

### DIFF
--- a/custom_components/tuya_local/devices/solaire_vitra_smart_heater_s2.yaml
+++ b/custom_components/tuya_local/devices/solaire_vitra_smart_heater_s2.yaml
@@ -21,6 +21,14 @@ primary_entity:
       range:
         min: 7
         max: 30
+      mapping:
+        - constraint: preset_mode
+          conditions:
+            - dps_val: "antifreezen"
+              value: 7
+              range:
+                min: 7
+                max: 7
     - id: 3
       name: current_temperature
       type: integer
@@ -31,10 +39,10 @@ primary_entity:
       name: preset_mode
       type: string
       mapping:
-        - dps_val: eco
-          value: eco
         - dps_val: comfort
           value: comfort
+        - dps_val: eco
+          value: eco
         - dps_val: antifreezen
           value: away
     - id: 12


### PR DESCRIPTION
Added constraints to Away (Anti frost) mode for solaire_vitra_smart_heater_s2.yaml

In this mode the temperature is locked to 7C
Also changed order of Modes to match the order shown in the Smart Life app and on the display panel on the device itself
