### PR TITLE
Added file for new device: Eurom Sani towel radiator

### DIFF
--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -12,10 +12,10 @@ primary_entity:
         - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: r
-              value: heat
-            - dps_val: t
-              value: dry
+            - dps_val: "r"
+              value: "heat"
+            - dps_val: "t"
+              value: "dry"
               icon: "mdi:hanger"
     - id: 2
       type: integer
@@ -26,7 +26,7 @@ primary_entity:
       mapping:
         - constraint: mode
           conditions:
-            - dps_val: t
+            - dps_val: "t"
               value_redirect: towel_dry_temperature
               range:
                 min: 40
@@ -42,9 +42,9 @@ primary_entity:
       mapping:
         - constraint: mode
           conditions:
-            - dps_val: t
+            - dps_val: "t"
               value_mirror: heater_temperature
-            - dps_val: r
+            - dps_val: "r"
               value_mirror: room_temperature
     - id: 3
       type: integer
@@ -54,7 +54,7 @@ primary_entity:
       type: bitfield
       mapping:
         - dps_val: 0
-          value: OK
+          value: "OK"
     - id: 101
       type: string
       name: hvac_action
@@ -62,11 +62,11 @@ primary_entity:
         - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: r
-              value: heating
-            - dps_val: t
-              #value: heating
-              value: drying
+            - dps_val: "r"
+              value: "heating"
+            - dps_val: "t"
+              #value: "heating"
+              value: "drying"
         - dps_val: false
           value: idle
           constraint: hvac_mode
@@ -77,10 +77,10 @@ primary_entity:
       name: mode
       type: string
       mapping:
-        - dps_val: r
-          value: room
-        - dps_val: t
-          value: towel
+        - dps_val: "r"
+          value: "room"
+        - dps_val: "t"
+          value: "towel"
     - id: 105
       name: heater_temperature
       type: integer
@@ -93,27 +93,20 @@ primary_entity:
       range:
         min: 40
         max: 70
-    - id: 102
+    - id: 103
       name: preset_mode
       type: boolean
       mapping:
-        - dps_val: true
-          constraint: anti_frost_mode
-          conditions:
-            - dps_val: false
-              value: eco
-            - dps_val: true
-              hidden: true
-              value: invalid
         - dps_val: false
-          constraint: anti_frost_mode
-          conditions:
-            - dps_val: false
-              value: none
-            - dps_val: true
-              # todo: icon for preset
-              value: Anti-frost
-    - id: 103
-      name: anti_frost_mode
-      type: boolean
-      hidden: true
+          value: "none"
+        - dps_val: true
+          value: "Anti-frost"
+secondary_entities:
+  - entity: switch
+    name: "Eco-mode"
+    icon: "mdi:leaf"
+    category: config
+    dps:
+      - id: 102
+        name: value
+        type: boolean

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -1,7 +1,7 @@
-name: Sani Bathroom Radiator
+name: Bathroom radiator
 products:
   - id: bc6gdgt0cpq1jmjz
-    name: LBH-63 TOWEL RAIL EUROM
+    name: Eurom Sani LBH-63
 primary_entity:
   entity: climate
   translation_key: heater
@@ -15,10 +15,10 @@ primary_entity:
         - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: "r"
-              value: "heat"
-            - dps_val: "t"
-              value: "dry"
+            - dps_val: r
+              value: heat
+            - dps_val: t
+              value: dry
               icon: "mdi:hanger"
     - id: 2
       type: integer
@@ -30,7 +30,7 @@ primary_entity:
       mapping:
         - constraint: mode
           conditions:
-            - dps_val: "t"
+            - dps_val: t
               value_redirect: surface_temperature_setpoint
               range:
                 min: 40
@@ -42,7 +42,7 @@ primary_entity:
       mapping:
         - constraint: mode
           conditions:
-            - dps_val: "t"
+            - dps_val: t
               value_mirror: surface_temperature_internal
     - id: 105
       name: surface_temperature_internal
@@ -54,7 +54,7 @@ primary_entity:
       type: bitfield
       mapping:
         - dps_val: 0
-          value: "OK"
+          value: OK
     - id: 101
       type: string
       name: hvac_action
@@ -62,11 +62,10 @@ primary_entity:
         - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: "r"
-              value: "heating"
-            - dps_val: "t"
-              #value: "heating"
-              value: "drying"
+            - dps_val: r
+              value: heating
+            - dps_val: t
+              value: drying
         - dps_val: false
           value: idle
           constraint: hvac_mode
@@ -77,10 +76,10 @@ primary_entity:
       name: mode
       type: string
       mapping:
-        - dps_val: "r"
-          value: "room"
-        - dps_val: "t"
-          value: "towel"
+        - dps_val: r
+          value: room
+        - dps_val: t
+          value: towel
     - id: 106
       name: surface_temperature_setpoint
       type: integer
@@ -96,12 +95,12 @@ primary_entity:
       type: boolean
       mapping:
         - dps_val: false
-          value: "home"
+          value: home
         - dps_val: true
-          value: "away"
+          value: away
 secondary_entities:
   - entity: switch
-    name: "Eco-mode"
+    name: Eco-mode
     icon: "mdi:leaf"
     category: config
     dps:
@@ -109,7 +108,7 @@ secondary_entities:
         type: boolean
         name: switch
   - entity: sensor
-    name: "Surface temperature"
+    name: Surface temperature
     class: temperature
     category: diagnostic
     icon: "mdi:thermometer-lines"
@@ -119,7 +118,7 @@ secondary_entities:
         name: sensor
         unit: C
   - entity: sensor
-    name: "Room temperature"
+    name: Room temperature
     class: temperature
     category: diagnostic
     icon: "mdi:home-thermometer-outline"

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -79,7 +79,6 @@ primary_entity:
         - dps_val: t
           value: towel
     - id: 105
-      # todo: icon
       name: heater_temperature
       type: integer
       hidden: false
@@ -94,7 +93,7 @@ primary_entity:
         max: 70
     - id: 102
       name: preset_mode
-      type: string
+      type: boolean
       mapping:
         - dps_val: false
           constraint: frost_mode

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -112,6 +112,7 @@ secondary_entities:
     name: "Surface temperature"
     class: temperature
     category: diagnostic
+    icon: "mdi:thermometer-lines"
     dps:
       - id: 105
         type: integer
@@ -121,6 +122,7 @@ secondary_entities:
     name: "Room temperature"
     class: temperature
     category: diagnostic
+    icon: "mdi:home-thermometer-outline"
     dps:
       - id: 3
         type: integer

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -32,7 +32,9 @@ primary_entity:
                 min: 40
                 max: 70
     - id: 333
-      # dummy variable for current temperature of current mode (room / towel) while keeping both measured values available
+      # dummy variable for current temperature of 
+      # current mode (room / towel) while keeping
+      # both measured values available
       type: integer
       name: current_temperature
       optional: true
@@ -60,10 +62,10 @@ primary_entity:
         - dps_val: true
           constraint: mode
           conditions:
-          - dps_val: "r"
-            value: heating
-          - dps_val: "t"
-            value: drying
+            - dps_val: "r"
+              value: heating
+            - dps_val: "t"
+              value: drying
         - dps_val: false
           value: idle
           constraint: hvac_mode

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -1,5 +1,4 @@
 name: Eurom Sani-Bathroom-Radiator Towel Wifi heater
-extra keys not allowed @ data['primary_entity']['dps'][2]['read_only']
 primary_entity:
   entity: climate
   translation_key: heater

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -23,6 +23,7 @@ primary_entity:
       range:
         min: 0
         max: 37
+      unit: C
       mapping:
         - constraint: mode
           conditions:
@@ -31,24 +32,40 @@ primary_entity:
               range:
                 min: 40
                 max: 70
-    - id: 333
-      # dummy variable for current temperature of
-      # current mode (room / towel) while keeping
-      # both measured values available
+    - id: 3
       type: integer
       name: current_temperature
-      optional: true
-      # read_only: true
+      unit: C
       mapping:
         - constraint: mode
           conditions:
             - dps_val: "t"
-              value_mirror: heater_temperature
-            - dps_val: "r"
-              value_mirror: room_temperature
-    - id: 3
+              value_mirror: surface_temperature_internal
+#    - id: 333
+#      # dummy variable for current temperature of
+#      # current mode (room / towel) while keeping
+#      # both measured values available
+#      type: integer
+#      name: current_temperature
+#      optional: true
+#      # read_only: true
+#      unit: C
+#      mapping:
+#        - constraint: mode
+#          conditions:
+#            - dps_val: "t"
+#              value_mirror: surface_temperature_internal
+#            - dps_val: "r"
+#              value_mirror: room_temperature_internal
+#    - id: 3
+#      type: integer
+#      name: room_temperature_internal
+#      hidden: true
+    - id: 105
+      name: surface_temperature_internal
       type: integer
-      name: room_temperature
+      optional: true
+      hidden: true
     - id: 12
       name: error
       type: bitfield
@@ -81,15 +98,12 @@ primary_entity:
           value: "room"
         - dps_val: "t"
           value: "towel"
-    - id: 105
-      name: heater_temperature
-      type: integer
-      optional: true
     - id: 106
       name: towel_dry_temperature
       type: integer
       hidden: true
       optional: true
+      unit: C
       range:
         min: 40
         max: 70
@@ -110,3 +124,29 @@ secondary_entities:
       - id: 102
         type: boolean
         name: switch
+  - entity: sensor
+    name: "Surface temperature"
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: C
+  - entity: sensor
+    name: "Room temperature"
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        unit: C
+#  - entity: switch
+#    NOT WORKING: duplicate dps id's not functioning
+#    name: "Anti-frost mode"
+#    icon: "mdi:snowflake-melt"
+#    dps:
+#      - id: 103
+#        name: anti_frost
+#        type: boolean

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -1,0 +1,112 @@
+name: Eurom Sani-Bathroom-Radiator Towel Wifi heater
+primary_entity:
+  entity: climate
+  translation_key: heater
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: "r"
+              value: "heat"
+            - dps_val: "t"
+              value: "dry"
+              icon: "mdi:hanger"
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 0
+        max: 37
+      mapping:
+        - constraint: mode
+          conditions:
+            - dps_val: "t"
+              value_redirect: towel_dry_temperature
+              range:
+                min: 40
+                max: 70
+    - id: 333
+      # dummy variable for current temperature of current mode (room / towel) while keeping both measured values available
+      type: integer
+      name: current_temperature
+      optional: true
+      read_only: true
+      mapping:
+        - constraint: mode
+          conditions:
+            - dps_val: "t"
+              value_mirror: heater_temperature
+            - dps_val: "r"
+              value_mirror: room_temperature
+    - id: 3
+      type: integer
+      name: room_temperature
+    - id: 12
+      name: error
+      type: bitfield
+      mapping:
+        - dps_val: 0
+          value: "OK"
+    - id: 101
+      type: string
+      name: hvac_action
+      mapping:
+        - dps_val: true
+          constraint: mode
+          conditions:
+          - dps_val: "r"
+            value: heating
+          - dps_val: "t"
+            value: drying
+        - dps_val: false
+          value: idle
+          constraint: hvac_mode
+          conditions:
+            - dps_val: false
+              value: "off"
+    - id: 4
+      name: mode
+      type: string
+      mapping:
+        - dps_val: r
+          value: room
+        - dps_val: t
+          value: towel
+    - id: 105
+      # todo: icon
+      name: heater_temperature
+      type: integer
+      hidden: false
+      optional: true
+    - id: 106
+      name: towel_dry_temperature
+      type: integer
+      hidden: true
+      optional: true
+      range:
+        min: 40
+        max: 70
+    - id: 102
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: false
+          constraint: frost_mode
+          conditions:
+            - dps_val: false
+              value: "none"
+            - dps_val: true
+              # todo; icon
+              value: "Anti-frost"
+        - dps_val: true
+          value: "eco"
+    - id: 103
+      name: frost_mode
+      type: boolean
+      hidden: true

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -83,7 +83,6 @@ primary_entity:
     - id: 105
       name: heater_temperature
       type: integer
-      hidden: false
       optional: true
     - id: 106
       name: towel_dry_temperature

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -1,4 +1,5 @@
 name: Eurom Sani-Bathroom-Radiator Towel Wifi heater
+extra keys not allowed @ data['primary_entity']['dps'][2]['read_only']
 primary_entity:
   entity: climate
   translation_key: heater
@@ -38,7 +39,7 @@ primary_entity:
       type: integer
       name: current_temperature
       optional: true
-      read_only: true
+      # read_only: true
       mapping:
         - constraint: mode
           conditions:

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -109,8 +109,4 @@ secondary_entities:
     dps:
       - id: 102
         type: boolean
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            value: "on"
+        name: switch

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -8,7 +8,7 @@ primary_entity:
       name: hvac_mode
       mapping:
         - dps_val: false
-          value: off
+          value: "off"
         - dps_val: true
           constraint: mode
           conditions:
@@ -65,14 +65,14 @@ primary_entity:
             - dps_val: r
               value: heating
             - dps_val: t
-              value: heating
-              #value: drying
+              #value: heating
+              value: drying
         - dps_val: false
           value: idle
           constraint: hvac_mode
           conditions:
             - dps_val: false
-              value: off
+              value: "off"
     - id: 4
       name: mode
       type: string

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -8,14 +8,14 @@ primary_entity:
       name: hvac_mode
       mapping:
         - dps_val: false
-          value: "off"
+          value: off
         - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: "r"
-              value: "heat"
-            - dps_val: "t"
-              value: "dry"
+            - dps_val: r
+              value: heat
+            - dps_val: t
+              value: dry
               icon: "mdi:hanger"
     - id: 2
       type: integer
@@ -26,7 +26,7 @@ primary_entity:
       mapping:
         - constraint: mode
           conditions:
-            - dps_val: "t"
+            - dps_val: t
               value_redirect: towel_dry_temperature
               range:
                 min: 40
@@ -42,9 +42,9 @@ primary_entity:
       mapping:
         - constraint: mode
           conditions:
-            - dps_val: "t"
+            - dps_val: t
               value_mirror: heater_temperature
-            - dps_val: "r"
+            - dps_val: r
               value_mirror: room_temperature
     - id: 3
       type: integer
@@ -54,7 +54,7 @@ primary_entity:
       type: bitfield
       mapping:
         - dps_val: 0
-          value: "OK"
+          value: OK
     - id: 101
       type: string
       name: hvac_action
@@ -62,16 +62,17 @@ primary_entity:
         - dps_val: true
           constraint: mode
           conditions:
-            - dps_val: "r"
+            - dps_val: r
               value: heating
-            - dps_val: "t"
-              value: drying
+            - dps_val: t
+              value: heating
+              #value: drying
         - dps_val: false
           value: idle
           constraint: hvac_mode
           conditions:
             - dps_val: false
-              value: "off"
+              value: off
     - id: 4
       name: mode
       type: string
@@ -96,17 +97,23 @@ primary_entity:
       name: preset_mode
       type: boolean
       mapping:
-        - dps_val: false
-          constraint: frost_mode
+        - dps_val: true
+          constraint: anti_frost_mode
           conditions:
             - dps_val: false
-              value: "none"
+              value: eco
             - dps_val: true
-              # todo; icon
-              value: "Anti-frost"
-        - dps_val: true
-          value: "eco"
+              hidden: true
+              value: invalid
+        - dps_val: false
+          constraint: anti_frost_mode
+          conditions:
+            - dps_val: false
+              value: none
+            - dps_val: true
+              # todo: icon for preset
+              value: Anti-frost
     - id: 103
-      name: frost_mode
+      name: anti_frost_mode
       type: boolean
       hidden: true

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -108,5 +108,9 @@ secondary_entities:
     category: config
     dps:
       - id: 102
-        name: value
         type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: "on"

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -1,4 +1,7 @@
-name: Eurom Sani-Bathroom-Radiator Towel Wifi heater
+name: Sani Bathroom Radiator
+products:
+  - id: bc6gdgt0cpq1jmjz
+    name: LBH-63 TOWEL RAIL EUROM
 primary_entity:
   entity: climate
   translation_key: heater
@@ -28,7 +31,7 @@ primary_entity:
         - constraint: mode
           conditions:
             - dps_val: "t"
-              value_redirect: towel_dry_temperature
+              value_redirect: surface_temperature_setpoint
               range:
                 min: 40
                 max: 70
@@ -41,26 +44,6 @@ primary_entity:
           conditions:
             - dps_val: "t"
               value_mirror: surface_temperature_internal
-#    - id: 333
-#      # dummy variable for current temperature of
-#      # current mode (room / towel) while keeping
-#      # both measured values available
-#      type: integer
-#      name: current_temperature
-#      optional: true
-#      # read_only: true
-#      unit: C
-#      mapping:
-#        - constraint: mode
-#          conditions:
-#            - dps_val: "t"
-#              value_mirror: surface_temperature_internal
-#            - dps_val: "r"
-#              value_mirror: room_temperature_internal
-#    - id: 3
-#      type: integer
-#      name: room_temperature_internal
-#      hidden: true
     - id: 105
       name: surface_temperature_internal
       type: integer
@@ -99,7 +82,7 @@ primary_entity:
         - dps_val: "t"
           value: "towel"
     - id: 106
-      name: towel_dry_temperature
+      name: surface_temperature_setpoint
       type: integer
       hidden: true
       optional: true
@@ -108,13 +91,14 @@ primary_entity:
         min: 40
         max: 70
     - id: 103
+      # anti-frost mode
       name: preset_mode
       type: boolean
       mapping:
         - dps_val: false
-          value: "none"
+          value: "home"
         - dps_val: true
-          value: "Anti-frost"
+          value: "away"
 secondary_entities:
   - entity: switch
     name: "Eco-mode"
@@ -142,11 +126,3 @@ secondary_entities:
         type: integer
         name: sensor
         unit: C
-#  - entity: switch
-#    NOT WORKING: duplicate dps id's not functioning
-#    name: "Anti-frost mode"
-#    icon: "mdi:snowflake-melt"
-#    dps:
-#      - id: 103
-#        name: anti_frost
-#        type: boolean

--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -32,7 +32,7 @@ primary_entity:
                 min: 40
                 max: 70
     - id: 333
-      # dummy variable for current temperature of 
+      # dummy variable for current temperature of
       # current mode (room / towel) while keeping
       # both measured values available
       type: integer


### PR DESCRIPTION
Hi,
I added the device "Eurom Sani-Bathroom-Radiator Towel Wifi heater". I tested it with the radiator. 
One thing that deviates from the manual, is that I created a non-existing dummy DP id for the current temperature, while maintaining the availability of the two sensor values: room temperature and surface temperature. The heater can control both, depending on the mode of operation, whether it controls the room or the heater itself.
Furthermore I wanted to specify an icon for the new operating mode 'anti-frost' but I did not manage to find out how to do that, using the icons.json file. If you have any suggestions? 
Jan-Gerard