### PR TITLE
adding support for the Arlec Smart Button

### DIFF
--- a/custom_components/tuya_local/devices/arlec_smart_button.yaml
+++ b/custom_components/tuya_local/devices/arlec_smart_button.yaml
@@ -1,10 +1,9 @@
 name: Smart Button
 products:
   - id: kpzc6pm8
-    name: Arlec Smart Button
+    name: Arlec SG022HA
 primary_entity:
   entity: event
-  name: Button
   class: button
   dps:
     - id: 1

--- a/custom_components/tuya_local/devices/arlec_smart_button.yaml
+++ b/custom_components/tuya_local/devices/arlec_smart_button.yaml
@@ -1,0 +1,28 @@
+name: Smart Button
+products:
+  - id: kpzc6pm8
+    name: Arlec Smart Button
+primary_entity:
+  entity: event
+  name: Button
+  class: button
+  dps:
+    - id: 1
+      type: string
+      name: event
+      mapping:
+        - dps_val: single_click
+          value: single_click
+        - dps_val: long_press
+          value: long_press
+        - dps_val: double_click
+          value: double_click
+secondary_entities:
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        unit: "%"


### PR DESCRIPTION
The device supported is: 
https://grid-connect.com.au/download/sg022ha/

It has to be connected via a smart hub.