### PR TITLE
Fix the Renpho Air Purifier AQI sensor, since AQI is deprecated.

### DIFF
--- a/custom_components/tuya_local/devices/renpho_rp_ap001s.yaml
+++ b/custom_components/tuya_local/devices/renpho_rp_ap001s.yaml
@@ -70,12 +70,19 @@ secondary_entities:
         type: boolean
   - entity: sensor
     name: Air quality
-    class: aqi
+    class: enum
     category: diagnostic
     dps:
       - id: 22
         type: string
         name: sensor
+        mapping:
+          - dps_val: "bad"
+            value: "Bad"
+          - dps_val: "fair"
+            value: "Fair"
+          - dps_val: "good"
+            value: "Good"
   - entity: sensor
     name: Prefilter life
     category: diagnostic


### PR DESCRIPTION
This fixes the deprecated AQI sensor setting in the Renpho Air Purifier, changing it from AQI to enum with a string mapping.

I've tested this against my purifiers, and it works.
