### PR TITLE
Add support for ANWIO BR30 Light Bulb RGB+CCT

### DIFF
--- a/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
@@ -10,6 +10,8 @@ products:
     name: Lampux bedside lamp
   - id: wufw0loegkb1y3u3
     name: Genio Smart WIFI bulb A60 RGB+CCT
+  - id: gshkqhi4fx9qqwrr
+    name: ANWIO BR30 WiFi Smart LED Bulb RGB+CCT 13W
 primary_entity:
   entity: light
   dps:


### PR DESCRIPTION
Add support for [ANWIO BR30 WiFi Smart LED Bulb RGB+CCT 13W](https://www.amazon.com/gp/product/B08S6PC71Q) in `custom_components/tuya_local/devices/rgbcw_lightbulb.yaml`

Note: I'm using Smart Life, without [iot.tuya.com](https://iot.tuya.com/), so I only have limited technical details on the device. It is working fine in HA using `rgbcw_lightbulb` though.

HA log:
```
Device matches rgbcw_lightbulb with quality of 78%. DPS: {"updated_at": 1713726353.644236, "20": true, "21": "colour", "22": 1000, "23": 1000, "24": "00ac03e803e8", "25": "000e0d0000000000000000c80000", "26": 0, "34": false, "41": true}
```

DPs (dump from [tuya-uncover](https://github.com/blakadder/tuya-uncover)):
```
        "category": "dj",
        "product_id": "gshkqhi4fx9qqwrr",
        "dps": {
            "20": true,
            "209": "AAAA",
            "21": "colour",
            "210": "AAAA",
            "22": 1000,
            "23": 1000,
            "24": "007103e803e8",
            "25": "000e0d0000000000000000c80000",
            "26": 0,
            "27": "",
            "28": "",
            "29": "",
            "30": "AAAAAAA=",
            "31": "AAA=",
            "32": "AAA=",
            "33": "AAEAcQPoA+gD6APo",
            "34": false,
            "41": true
        }
```