### PR TITLE
Add support for Plikc Neve X W thermostat

### DIFF
--- a/custom_components/tuya_local/devices/plikc_neve_x_thermostat.yaml
+++ b/custom_components/tuya_local/devices/plikc_neve_x_thermostat.yaml
@@ -27,9 +27,9 @@ primary_entity:
           hidden: true
         - dps_val: holiday
           value: away
-          constraints: Durata vacanza
+          constraint: Durata vacanza
           conditions:
-          - dps_val: 1
+            - dps_val: 1
     - id: 3
       type: string
       name: hvac_action

--- a/custom_components/tuya_local/devices/plikc_neve_x_thermostat.yaml
+++ b/custom_components/tuya_local/devices/plikc_neve_x_thermostat.yaml
@@ -1,4 +1,4 @@
-name: Termostato
+name: Thermostat
 products:
   - id: 5kwgvcaqzzkzrftu
     name: Plikc Neve X W
@@ -13,23 +13,25 @@ primary_entity:
         - dps_val: false
           value: "off"
         - dps_val: true
-          value: heat
+          value: heat_cool
     - id: 2
       type: string
       name: preset_mode
       mapping:
         - dps_val: auto
-          value: home
+          value: program
         - dps_val: manual
-          value: boost
+          value: manual
         - dps_val: temporary
-          value: boost
+          value: temp_override
           hidden: true
         - dps_val: holiday
           value: away
-          constraint: Durata vacanza
+          constraint: holiday_duration
           conditions:
-            - dps_val: 1
+            - dps_val: 0
+              value: "Set holiday duration!"
+              hidden: true
     - id: 3
       type: string
       name: hvac_action
@@ -70,27 +72,27 @@ primary_entity:
         max: 350
       mapping:
         - scale: 10
+    - id: 33
+      type: integer
+      name: holiday_duration
+      hidden: true
 secondary_entities:
   - entity: number
-    name: Calibrazione
-    mode: box
+    name: Temperature calibration
     category: config
     icon: "mdi:thermometer-check"
     dps:
       - id: 27
         type: integer
         name: value
-        unit: °C
+        unit: °
         range:
           min: -30
           max: 30
         mapping:
           - scale: 10
-            step: 1
   - entity: number
-    name: Durata vacanza
-    mode: box
-    force: true
+    name: Holiday duration
     category: config
     icon: "mdi:calendar-range"
     dps:
@@ -110,7 +112,6 @@ secondary_entities:
         type: boolean
         name: button
         optional: true
-        persist: false
   - entity: lock
     translation_key: child_lock
     category: config
@@ -123,7 +124,7 @@ secondary_entities:
           - dps_val: null
             value: false
   - entity: sensor
-    name: Tempo rimanente
+    translation_key: time_remaining
     class: duration
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/plikc_neve_x_thermostat.yaml
+++ b/custom_components/tuya_local/devices/plikc_neve_x_thermostat.yaml
@@ -1,0 +1,147 @@
+name: Termostato
+products:
+  - id: 5kwgvcaqzzkzrftu
+    name: Plikc Neve X W
+primary_entity:
+  entity: climate
+  translation_key: thermostat
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: heat
+    - id: 2
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: auto
+          value: home
+        - dps_val: manual
+          value: boost
+        - dps_val: temporary
+          value: boost
+          hidden: true
+        - dps_val: holiday
+          value: away
+          constraints: Durata vacanza
+          conditions:
+          - dps_val: 1
+    - id: 3
+      type: string
+      name: hvac_action
+      readonly: true
+      mapping:
+        - dps_val: heat
+          value: heating
+        - dps_val: cold
+          value: cooling
+        - dps_val: "off"
+          value: idle
+    - id: 16
+      type: integer
+      name: temperature
+      unit: C
+      range:
+        min: 50
+        max: 350
+      mapping:
+        - scale: 10
+          constraint: preset_mode
+          conditions:
+            - dps_val: holiday
+              value_redirect: holiday_temp_set
+    - id: 24
+      type: integer
+      name: current_temperature
+      mapping:
+        - scale: 10
+    - id: 32
+      type: integer
+      name: holiday_temp_set
+      optional: true
+      hidden: true
+      force: true
+      range:
+        min: 50
+        max: 350
+      mapping:
+        - scale: 10
+secondary_entities:
+  - entity: number
+    name: Calibrazione
+    mode: box
+    category: config
+    icon: "mdi:thermometer-check"
+    dps:
+      - id: 27
+        type: integer
+        name: value
+        unit: °C
+        range:
+          min: -30
+          max: 30
+        mapping:
+          - scale: 10
+            step: 1
+  - entity: number
+    name: Durata vacanza
+    mode: box
+    force: true
+    category: config
+    icon: "mdi:calendar-range"
+    dps:
+      - id: 33
+        type: integer
+        name: value
+        unit: d
+        range:
+          min: 0
+          max: 99
+  - entity: button
+    name: Factory reset
+    class: restart
+    category: config
+    dps:
+      - id: 39
+        type: boolean
+        name: button
+        optional: true
+        persist: false
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 40
+        type: boolean
+        name: lock
+        optional: true
+        mapping:
+          - dps_val: null
+            value: false
+  - entity: sensor
+    name: Tempo rimanente
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 42
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 45
+        type: bitfield
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true


### PR DESCRIPTION
Add support for Plikc Neve X W thermostat.
Quite similar to Plikc Neve X WRF, but some issues of that integration have been fixed. Supports setting automatic, manual and holiday mode. Heating is correctly displayed when active.