### PR TITLE
Add sh07s_ty smart sprinkler variant

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -26,7 +26,7 @@
 - Goldair heater models beginning with the code GPPH, GCPV, GECO
 - Hama radiator controller
 - Heatstorm HS-6000-GC heavy duty heater
-- Herschel infrared heater 
+- Herschel infrared heater
 - HJZ oil column radiator
 - Hombli radiator controller
 - INOW Wi-Fi heating element (single and dual air/water temperature control variants)
@@ -194,7 +194,7 @@
 - Deta fan controller
 - Djive ARC humidifying fan
 - Duux Whisper Flex pedestal fan
-- Eglo 5 speed + sleep ceiling fan 
+- Eglo 5 speed + sleep ceiling fan
 - Fanco Eco Silent Deluxe ceiling fan with LED light
 - Goldair GCPF315 fan
 - Goldair Platinum tower fan (2 variants)
@@ -350,7 +350,7 @@
 - V-WIFI-DL02-ES energy consumption clamp meter
 - WDYK 2P63A energy meter
 - WDYK 3 phase 4 pole 400V energy meter circuit breaker
-- Yagusmart 3PN 63A 3-phase eneregy meter 
+- Yagusmart 3PN 63A 3-phase eneregy meter
 - ZM-Wi-Fi smart meter
 
 ### Battery Charger
@@ -647,6 +647,7 @@ port and password.
 - Qoto 03 smart water valve / sprinkler controller
 - Qoto 05 smart water valve / sprinkler controller
 - SH07-8 smart sprinkler controller
+- SH07S_TY 8-zone sprinkler controller (sold as Aquarobo on Amazon)
 - Zemismart DP-WBS01 8-zone sprinkler controller (also sold as Benexmart and other brands)
 
 ### Miscellaneous

--- a/custom_components/tuya_local/devices/sh07s_ty_sprinkler_controller.yaml
+++ b/custom_components/tuya_local/devices/sh07s_ty_sprinkler_controller.yaml
@@ -1,0 +1,93 @@
+name: Sprinkler controller
+products:
+  - id: mxh2sjigimo463mg
+    name: Smart sprinkler controller
+primary_entity:
+  entity: valve
+  name: Valve 1
+  class: water
+  dps:
+    - id: 101
+      name: valve
+      type: boolean
+secondary_entities:
+  - entity: valve
+    name: Valve 2
+    class: water
+    dps:
+      - id: 102
+        name: valve
+        type: boolean
+  - entity: valve
+    name: Valve 3
+    class: water
+    dps:
+      - id: 103
+        name: valve
+        type: boolean
+  - entity: valve
+    name: Valve 4
+    class: water
+    dps:
+      - id: 104
+        name: valve
+        type: boolean
+  - entity: valve
+    name: Valve 5
+    class: water
+    dps:
+      - id: 105
+        name: valve
+        type: boolean
+  - entity: valve
+    name: Valve 6
+    class: water
+    dps:
+      - id: 106
+        name: valve
+        type: boolean
+  - entity: sensor
+    name: Smart weather
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 108
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: sunny
+            value: sunny
+            icon: "mdi:weather-sunny"
+          - dps_val: cloudy
+            value: cloudy
+            icon: "mdi:weather-cloudy"
+          - dps_val: rainy
+            value: rainy
+            icon: "mdi:weather-rainy"
+          - dps_val: snowy
+            value: snowy
+            icon: "mdi:weather-snowy"
+          - dps_val: null
+            value: unavailable
+            icon: "mdi:weather-sunny-off"
+  - entity: valve
+    name: All Valves
+    class: water
+    dps:
+      - id: 109
+        name: valve
+        type: boolean
+  - entity: valve
+    name: Valve 7
+    class: water
+    dps:
+      - id: 110
+        name: valve
+        type: boolean
+  - entity: valve
+    name: Valve 8
+    class: water
+    dps:
+      - id: 111
+        name: valve
+        type: boolean


### PR DESCRIPTION
The existing sh07 device had a three issues for my device:
- It took the first 8 switch DPs and assigned them to zones. But on the sh07s_ty I have, the 7th is the all zones switch and the real 7th and 8th valve are actually the 8th and 9th in the switch DPs.
- It created a bunch of disabled switches for all those same zones under configuration that seem to have no purpose.
- The information weather sensor wasn't included.

This is the device I have. It's branded as AquaRobo:
https://www.amazon.com/gp/product/B0CR3TKGFH/ref=ppx_yo_dt_b_asin_title_o03_s00?ie=UTF8&psc=1