### PR TITLE
Add support for Pro PCIe computer power switch

### DIFF
--- a/custom_components/tuya_local/devices/jh_pcpro+.yaml
+++ b/custom_components/tuya_local/devices/jh_pcpro+.yaml
@@ -1,20 +1,19 @@
-name: Pcie computer power pro
+name: PC power switch
 products:
   - id: rtbhfbuii82scjrp
-    name: pcie pc pro power switch
+    name: PCIe PC Pro
 primary_entity:
   entity: switch
   class: outlet
   dps:
     - id: 1
       type: boolean
-      name: switch
-      
- 
+      name: switch/
+
 secondary_entities:
   - entity: button
     name: Reset
-    icon: mdi:restart
+    class: restart
     dps:
       - id: 101
         name: button
@@ -33,7 +32,7 @@ secondary_entities:
           - dps_val: forceReset
             value: true
   - entity: switch
-    name: Rf pairing
+    name: RF pairing
     category: config
     dps:
       - id: 7
@@ -47,7 +46,7 @@ secondary_entities:
         type: boolean
         name: switch
   - entity: select
-    name: Power on behavior
+    name: Initial state
     icon: mdi:power-settings
     category: config
     dps:
@@ -67,7 +66,7 @@ secondary_entities:
         type: boolean
         name: lock
   - entity: switch
-    name: Rf remote control
+    name: RF remote control
     icon: mdi:remote
     category: config
     dps:
@@ -79,4 +78,3 @@ secondary_entities:
             value: true
           - dps_val: "off"
             value: false
-     

--- a/custom_components/tuya_local/devices/jh_pcpro+.yaml
+++ b/custom_components/tuya_local/devices/jh_pcpro+.yaml
@@ -1,0 +1,82 @@
+name: Pcie computer power pro
+products:
+  - id: rtbhfbuii82scjrp
+    name: pcie pc pro power switch
+primary_entity:
+  entity: switch
+  class: outlet
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+      
+ 
+secondary_entities:
+  - entity: button
+    name: Reset
+    icon: mdi:restart
+    dps:
+      - id: 101
+        name: button
+        type: string
+        mapping:
+          - dps_val: Reset
+            value: true
+  - entity: button
+    name: Force reset
+    icon: mdi:restart-alert
+    dps:
+      - id: 101
+        name: button
+        type: string
+        mapping:
+          - dps_val: forceReset
+            value: true
+  - entity: switch
+    name: Rf pairing
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Buzzer
+    category: config
+    dps:
+      - id: 8
+        type: boolean
+        name: switch
+  - entity: select
+    name: Power on behavior
+    icon: mdi:power-settings
+    category: config
+    dps:
+      - id: 38
+        type: string
+        name: option
+        mapping:
+          - dps_val: "on"
+            value: "on"
+          - dps_val: "off"
+            value: "off"
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 40
+        type: boolean
+        name: lock
+  - entity: switch
+    name: Rf remote control
+    icon: mdi:remote
+    category: config
+    dps:
+      - id: 102
+        type: string
+        name: switch
+        mapping:
+          - dps_val: "on"
+            value: true
+          - dps_val: "off"
+            value: false
+     

--- a/custom_components/tuya_local/devices/jh_pcpro+.yaml
+++ b/custom_components/tuya_local/devices/jh_pcpro+.yaml
@@ -8,7 +8,7 @@ primary_entity:
   dps:
     - id: 1
       type: boolean
-      name: switch/
+      name: switch
 
 secondary_entities:
   - entity: button


### PR DESCRIPTION
Similar to the device mentioned at https://github.com/make-all/tuya-local/pull/1914 but this Pro version has more functionality and is physically a little bit bigger.
https://www.aliexpress.com/item/1005002776442806.html - Tuya PRO Long WIFI

```
{
  "result": {
    "active_time": 1716382333,
    "bind_space_id": "70408609",
    "category": "cz",
    "create_time": 1716382333,
    "custom_name": "",
    "icon": "smart/icon/ay1552295613286EPqcq/28ed5ba6da3ebeaccc8b38134a41259a.png",
    "id": "bfad3c3e69b23ff09bj0m5",
    "ip": "",
    "is_online": true,
    "lat": "",
    "local_key": "",
    "lon": "",
    "model": "JH-PcPro+",
    "name": "PC",
    "product_id": "rtbhfbuii82scjrp",
    "product_name": "电脑",
    "sub": false,
    "time_zone": "+10:00",
    "update_time": 1716794462,
    "uuid": "b33f266cf494a92c"
  },
  "success": true,
  "t": 1716809020912,
  "tid": "91dd36af1c1b11ef80c7da85933c7aab"
}
```

![image](https://github.com/make-all/tuya-local/assets/44917135/6f82dffe-aa31-419e-b6b6-bcc5ddaf130f)
