### PR TITLE
Added `swing_mode` value mapping to Nedis Portable Air Conditioner

### DIFF
--- a/custom_components/tuya_local/devices/nedis_mobile_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/nedis_mobile_airconditioner.yaml
@@ -58,7 +58,12 @@ primary_entity:
       name: feature_flags
     - id: 110
       type: boolean
-      name: swing_2
+      name: swing_mode
+      mapping:
+        - dps_val: true
+          value: "vertical"
+        - dps_val: false
+          value: "off"
 secondary_entities:
   - entity: switch
     translation_key: ionizer


### PR DESCRIPTION
Added missing `swing_mode` value mapping to Nedis Portable Air Conditioner.

The Swing Mode value mapping was missing forcing the user to set it through the Tuya App.

This was the only missing feature from the Tuya app to make full functionality available to tuya-local.

A thing to note is that both the Tuya app and the API mentions that this is Horizontal swing, if I'm not mistaken that means the fan blade swings left to right while the device itself has blades that swing up and down. So I marked it as vertical swing in the configuration.