### PR TITLE
FIx incorrect currency unit for atorch S1WP power meter

### DIFF
--- a/custom_components/tuya_local/devices/atorch_s1wp.yaml
+++ b/custom_components/tuya_local/devices/atorch_s1wp.yaml
@@ -34,7 +34,7 @@ secondary_entities:
         name: sensor
         type: integer
         class: measurement
-        unit: mA
+        unit: A
         mapping:
           - scale: 1000
   - entity: sensor


### PR DESCRIPTION
Fix incorrect current unit for atorch S1WP power meter.