### PR TITLE
device atorch_s1wp add update interval entity

### DIFF
--- a/custom_components/tuya_local/devices/atorch_s1wp.yaml
+++ b/custom_components/tuya_local/devices/atorch_s1wp.yaml
@@ -531,3 +531,14 @@ secondary_entities:
             value: "Off"
           - dps_val: memory
             value: Memory
+  - entity: number
+    category: config
+    name: Update interval
+    icon: "mdi:update"
+    dps:
+      - id: 139
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 90

--- a/custom_components/tuya_local/devices/atorch_s1wp.yaml
+++ b/custom_components/tuya_local/devices/atorch_s1wp.yaml
@@ -539,6 +539,7 @@ secondary_entities:
       - id: 139
         type: integer
         name: value
+        optional: true
         unit: s
         range:
           min: 1

--- a/custom_components/tuya_local/devices/atorch_s1wp.yaml
+++ b/custom_components/tuya_local/devices/atorch_s1wp.yaml
@@ -539,6 +539,7 @@ secondary_entities:
       - id: 139
         type: integer
         name: value
+        unit: s
         range:
           min: 1
           max: 90


### PR DESCRIPTION
this entity can set the update interval of the device, default is 60 seconds

but if set it less than 60 seconds, it will be reset to 60 seconds after 5 minutes.  it can use automate script for keep 1 second