### PR TITLE
Add another id for PUPPY KITTY Automatic Cat & Dog Feeder

### DIFF
--- a/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
@@ -6,6 +6,8 @@ products:
     name: GiotoHun Pet feeder
   - id: ojqmjnoxqygqldsp
     name: PUPPY KITTY Automatic Cat & Dog Feeder
+  - id: iwabnqimdhmzxzvp
+    name: PUPPY KITTY Automatic Cat & Dog Feeder
 primary_entity:
   entity: button
   name: Quick Feed


### PR DESCRIPTION
I bought another PUPPY KITTY Automatic Cat & Dog Feeder, but it had a different id (literally the same device though). Not sure if the parser can handle multiple ids for the same name, so I added it as a new product instead.