### PR TITLE
Implement Arlec PC191HA Series 2 Socket

### DIFF
--- a/custom_components/tuya_local/devices/arlec_pc191ha_s2_socket.yaml
+++ b/custom_components/tuya_local/devices/arlec_pc191ha_s2_socket.yaml
@@ -1,0 +1,121 @@
+name: Advanced energy monitoring smartplug
+products:
+  - id: auojpnb4hpc13ftb
+    name: Arlec PC191HA Series 2
+primary_entity:
+  entity: switch
+  class: outlet
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 21
+      type: integer
+      name: test_bit
+      optional: true
+    - id: 26
+      type: bitfield
+      name: fault_code
+      optional: true
+secondary_entities:
+  - entity: number
+    category: config
+    translation_key: timer
+    dps:
+      - id: 9
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: sensor
+    category: diagnostic
+    name: Energy
+    dps:
+      - id: 17
+        name: sensor
+        type: integer
+        unit: Wh
+        optional: true
+      - id: 25
+        type: integer
+        name: calibration
+        optional: true
+  - entity: sensor
+    category: diagnostic
+    class: current
+    dps:
+      - id: 18
+        name: sensor
+        type: integer
+        class: measurement
+        unit: mA
+      - id: 23
+        type: integer
+        name: calibration
+        optional: true
+  - entity: sensor
+    category: diagnostic
+    class: power
+    dps:
+      - id: 19
+        name: sensor
+        type: integer
+        class: measurement
+        unit: W
+        mapping:
+          - scale: 10
+      - id: 24
+        type: integer
+        name: calibration
+        optional: true
+  - entity: sensor
+    category: diagnostic
+    class: voltage
+    dps:
+      - id: 20
+        name: sensor
+        type: integer
+        class: measurement
+        unit: V
+        mapping:
+          - scale: 10
+      - id: 22
+        type: integer
+        name: calibration
+        optional: true
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 26
+        type: bitfield
+        name: sensor
+        optional: true
+        persist: false
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+  - entity: select
+    category: config
+    name: Initial state
+    icon: "mdi:toggle-switch"
+    dps:
+      - id: 38
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "on"
+            value: "On"
+          - dps_val: "off"
+            value: "Off"
+          - dps_val: memory
+            value: "Last State"


### PR DESCRIPTION
Despite stating the model number suggesting that it is a merely a revision of the original Arlec PC181HA, this is actually a redesign with the CB2S module replacing the WB2S module in the previous series.

The CB2S is newer but less technically capable and as such has quite a few features stripped out.

This PR implements the Series 2 which prevents various non-existent entities from appearing.