### PR TITLE
Update dongguan_electric_curtain.yaml

### DIFF
--- a/custom_components/tuya_local/devices/dongguan_electric_curtain.yaml
+++ b/custom_components/tuya_local/devices/dongguan_electric_curtain.yaml
@@ -28,23 +28,8 @@ primary_entity:
       optional: true
       persist: false
     - id: 7
-      name: action
+      name: learning_state
       type: string
-      mapping:
-        - dps_val: opening
-          value: opening
-          constraint: current_position
-          conditions:
-            - dps_val: 0
-              value: opened
-        - dps_val: closing
-          value: closing
-          constraint: current_position
-          conditions:
-            - dps_val: 100
-              value: closed
-            - dps_val: null
-              value: closed
     - id: 12
       name: fault_code
       type: bitfield


### PR DESCRIPTION
7 DP is't action, it's learning state

```
               {
                    "abilityId": 7,
                    "accessMode": "ro",
                    "code": "work_state",
                    "description": "每次进入页面时判断学习状态“\\n1、standby为未学习状态，面板显示学习页面；\\n2、learning为学习中状态，此时面板禁用“开始学习”按钮，无法下发。\\n3、success为学习完成状态，显示控制页面。在学习页面收到success上报时，面板弹窗提示学习成功，点击确认后跳转到控制页面。\\n4、fail为学习失败状态，设备上报fail并将学习按钮上报false使能，此时面板弹窗提示”“学习失败，请检查方向是否选择正确并重新开始学习。”",
                    "name": "学习状态",
                    "typeSpec": {
                        "type": "enum",
                        "range": [
                            "standby",
                            "learning",
                            "success",
                            "fail"
                        ]
                    }
                },
```