### PR TITLE
Added Leictory LK06 sprinkler controller & made the SH07 sprinkler controller device definiton support controllers with at least 4 zones

### DIFF
--- a/custom_components/tuya_local/devices/sh07_sprinkler_controller.yaml
+++ b/custom_components/tuya_local/devices/sh07_sprinkler_controller.yaml
@@ -4,6 +4,8 @@ products:
     name: SH07-8
   - id: mxh2sjigimo463mg
     name: Aquarobo SH07S-TY
+  - id: figmzixtki7bourh
+    name: Leictory LK06
 primary_entity:
   entity: valve
   name: Valve 1
@@ -41,6 +43,7 @@ secondary_entities:
       - id: 105
         name: valve
         type: boolean
+        optional: true
   - entity: valve
     name: Valve 6
     class: water
@@ -48,6 +51,7 @@ secondary_entities:
       - id: 106
         name: valve
         type: boolean
+        optional: true
   - entity: valve
     name: Valve 7
     class: water
@@ -55,6 +59,7 @@ secondary_entities:
       - id: 110
         name: valve
         type: boolean
+        optional: true
   - entity: valve
     name: Valve 8
     class: water
@@ -62,6 +67,7 @@ secondary_entities:
       - id: 111
         name: valve
         type: boolean
+        optional: true
   - entity: sensor
     name: Weather
     class: enum


### PR DESCRIPTION
Little bit of extra for DP 107:
```
dp 107 can contain at most 10 schedules
dp 107:

//8BARAIqggJAAEKAgsDDAQNBQ4GD/8CARYI/g8AAQEPAxkFEAZ4/wMBFxwQEBoBAxEFd/8EARYRKAoAAAEKAwo= -> ffff01011008aa080900010a020b030c040d050e060fff02011608fe0f0001010f031905100678ff0301171c10101a0103110577ff04011611280a0000010a030a

ff //preamble

ff01 //schedule preamble + first schedule
01 // enabled
1008 // start hh:mm -> 16:08
aa // days 10101010 (sun tue thu sat)
08 // cycle mins
09 // soak mins
00 // smart weather off (does not skip watering when the weather is rainy or snowy)
010a // zone 1 10 mins
020b // zone 2 11 mins
030c // zone 3 12 mins
040d // zone 4 13 mins
050e // zone 5 14 mins
060f // zone 6 15 mins

ff02 //schedule preamble + second schedule
01 // enabled
1608 // start hh:mm
fe // days (all)
0f // cycle mins
00 // soak mins
01 // smart weather on (skips watering when the weather is rainy or snowy)
010f // zone 1
0319 // zone 3
0510 // zone 5
0678 // zone 6
```