### PR TITLE
Implement generic tuya human presence sensor

### DIFF
--- a/custom_components/tuya_local/devices/human_presence_detector.yaml
+++ b/custom_components/tuya_local/devices/human_presence_detector.yaml
@@ -65,7 +65,6 @@ secondary_entities:
           min: 0
           max: 28799
         unit: s
-          - entity: sensor
       - id: 105
         type: integer
         unit: min

--- a/custom_components/tuya_local/devices/human_presence_detector.yaml
+++ b/custom_components/tuya_local/devices/human_presence_detector.yaml
@@ -1,6 +1,6 @@
 name: human presence detector
 products:
-  - id: 02a339dfa475cd37
+  - id: e833v6jexwfkjrij
     name: RTCZ-03 human presence sensor
 primary_entity:
   entity: binary_sensor

--- a/custom_components/tuya_local/devices/human_presence_detector.yaml
+++ b/custom_components/tuya_local/devices/human_presence_detector.yaml
@@ -1,4 +1,4 @@
-name: human presence detector
+name: Human presence detector
 products:
   - id: e833v6jexwfkjrij
     name: RTCZ-03 human presence sensor
@@ -7,7 +7,7 @@ primary_entity:
   class: occupancy
   dps:
     - id: 1
-      type: boolean
+      type: string
       name: sensor
       mapping:
         - dps_val: peaceful
@@ -28,7 +28,7 @@ secondary_entities:
     class: motion
     dps:
       - id: 1
-        type: boolean
+        type: string
         name: sensor
         mapping:
           - dps_val: peaceful
@@ -56,7 +56,7 @@ secondary_entities:
         name: sensor
         unit: lx
   - entity: number
-    name: clear delay
+    name: Clear delay
     dps:
       - id: 103
         type: integer
@@ -65,9 +65,18 @@ secondary_entities:
           min: 0
           max: 28799
         unit: s
+          - entity: sensor
+      - id: 105
+        type: integer
+        unit: min
+        name: minutes
+      - id: 106
+        type: integer
+        unit: s
+        name: seconds
   - entity: light
     category: config
-    name: indicator light
+    translation_key: indicator
     dps:
       - id: 104
         type: boolean
@@ -96,7 +105,7 @@ secondary_entities:
         unit: cm
   - entity: number
     category: config
-    name: Detection Sensitivity
+    name: Detection sensitivity
     dps:
       - id: 111
         type: integer
@@ -106,7 +115,7 @@ secondary_entities:
           max: 10
   - entity: number
     category: config
-    name: Hold Sensitivity
+    name: Hold sensitivity
     dps:
       - id: 112
         type: integer
@@ -114,22 +123,6 @@ secondary_entities:
         range:
           min: 0
           max: 10
-  - entity: sensor
-    category: diagnostic
-    name: hold (min)
-    dps:
-      - id: 105
-        type: integer
-        unit: min
-        name: sensor
-  - entity: sensor
-    category: diagnostic
-    name: hold (sec)
-    dps:
-      - id: 106
-        type: integer
-        unit: s
-        name: sensor
   - entity: sensor
     category: diagnostic
     name: debug

--- a/custom_components/tuya_local/devices/human_presence_detector.yaml
+++ b/custom_components/tuya_local/devices/human_presence_detector.yaml
@@ -1,0 +1,139 @@
+name: human presence detector
+products:
+  - id: 02a339dfa475cd37
+    name: RTCZ-03 human presence sensor
+primary_entity:
+  entity: binary_sensor
+  class: occupancy
+  dps:
+    - id: 1
+      type: boolean
+      name: sensor
+      mapping:
+        - dps_val: peaceful
+          value: false
+        - dps_val: presence
+          value: true
+        - dps_val: small_move
+          value: true
+        - dps_val: large_move
+          value: true
+        - dps_val: none
+          value: false
+    - id: 1
+      type: string
+      name: raw_state
+secondary_entities:
+  - entity: binary_sensor
+    class: motion
+    dps:
+      - id: 1
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: peaceful
+            value: false
+          - dps_val: presence
+            value: false
+          - dps_val: small_move
+            value: true
+          - dps_val: large_move
+            value: true
+          - dps_val: none
+            value: false
+  - entity: sensor
+    class: distance
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: cm
+  - entity: sensor
+    class: illuminance
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: lx
+  - entity: number
+    name: clear delay
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 28799
+        unit: s
+  - entity: light
+    category: config
+    name: indicator light
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+  - entity: number
+    category: config
+    name: Maximum detection distance
+    dps:
+      - id: 107
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 840
+        unit: cm
+  - entity: number
+    category: config
+    name: Minimum detection distance
+    dps:
+      - id: 108
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 840
+        unit: cm
+  - entity: number
+    category: config
+    name: Detection Sensitivity
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
+  - entity: number
+    category: config
+    name: Hold Sensitivity
+    dps:
+      - id: 112
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
+  - entity: sensor
+    category: diagnostic
+    name: hold (min)
+    dps:
+      - id: 105
+        type: integer
+        unit: min
+        name: sensor
+  - entity: sensor
+    category: diagnostic
+    name: hold (sec)
+    dps:
+      - id: 106
+        type: integer
+        unit: s
+        name: sensor
+  - entity: sensor
+    category: diagnostic
+    name: debug
+    dps:
+      - id: 120
+        type: string
+        name: sensor

--- a/custom_components/tuya_local/devices/human_presence_detector.yaml
+++ b/custom_components/tuya_local/devices/human_presence_detector.yaml
@@ -23,6 +23,9 @@ primary_entity:
     - id: 1
       type: string
       name: raw_state
+    - id: 120
+      type: string
+      name: debug
 secondary_entities:
   - entity: binary_sensor
     class: motion
@@ -122,10 +125,3 @@ secondary_entities:
         range:
           min: 0
           max: 10
-  - entity: sensor
-    category: diagnostic
-    name: debug
-    dps:
-      - id: 120
-        type: string
-        name: sensor


### PR DESCRIPTION
Not ready for merge.

@make-all I'm pulling my hair out and maybe you can help me... I think i've defined the device correctly but I can't get it to appear in the list of candidate devices (connects fine).

This is the result of tinytuya wizard:

```json
    {
        "name": "Human presence detector",
        "id": "REDACTED",
        "key": "REDACTED",
        "mac": "REDACTED",
        "uuid": "02a339dfa475cd37",
        "sn": "REDACTED",
        "category": "hps",
        "product_name": "Human presence detector",
        "product_id": "e833v6jexwfkjrij",
        "biz_type": 0,
        "model": "RTCZ-03",
        "sub": false,
        "icon": "https://images.tuyaeu.com/smart/icon/ay15427647462366edzT/8293b553146d0a545989f9486f1f9d29.jpg",
        "mapping": {
            "1": {
                "code": "presence_state",
                "type": "Enum",
                "values": {
                    "range": [
                        "none",
                        "presence",
                        "peaceful",
                        "small_move",
                        "large_move"
                    ]
                }
            }
        }
    }
```

and this is the result of a TinyTuya full status dump:

```
DEBUG:TinyTuya [1.15.1]

DEBUG:Python 3.12.3 (main, Apr 10 2024, 05:33:47) [GCC 13.2.0] on linux
DEBUG:Using pyca/cryptography 43.0.0 for crypto, GCM is supported
 > Send Request for Status <
REDACTED
 > Begin Monitor Loop <
REDACTED
Received Payload: {'dps': {'1': 'none', '101': 7, '102': 203, '103': 15, '104': True, '105': 0, '106': 15, '107': 840, '108': 0, '111': 0, '112': 5, '120': 'FDFCFBFA04001201000004030201'}}
```

I'm sure I'm missing something simple but I'm losing my mind...