### PR TITLE
Add support for welltobe cat feeder

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -509,7 +509,7 @@ of device.
 - LightStar CCT track light
 - Loycco sound machine with nightlight (also sold as Momland nightlight with white noise)
 - Loginovo TV sync backlight
-- LSC smart connect RGB CCT lightbulb (similar to older generic bulbs, so may work for others) 
+- LSC smart connect RGB CCT lightbulb (similar to older generic bulbs, so may work for others)
 - Lytmi Fantasy/Neo 3 HDMI sync backlight
 - Marpou RGBCW ceiling light
 - Mirabella Genio Pixel LED oval light
@@ -664,6 +664,7 @@ port and password.
 - PNI water feeder
 - Rojeco PTM-001 pet feeder (two versions)
 - V330L pet feeder
+- WellToBe Automatic Pet Feeder (WB S36D)
 - YP pet feeder
 
 ### Remote controllers
@@ -756,7 +757,7 @@ port and password.
 - PT216/PT19DB-2 temperature and humidity sensor
 - SGS01 plant sensor
 - Smart Ape solar garden light
-- TCS024B plant moisture sensor 
+- TCS024B plant moisture sensor
 - TH05 temperature and humidity sensor
 - XCase NX-4964 lock box
 - YL01 water quality tester

--- a/custom_components/tuya_local/devices/welltobe_cat_feeder.yaml
+++ b/custom_components/tuya_local/devices/welltobe_cat_feeder.yaml
@@ -1,7 +1,7 @@
 name: Pet feeder
 products:
   - id: qqzpxhisd6zs8zyq
-    name: WellToBe Automatic Pet Feeder (WB S36D)
+    name: WellToBe WB S36D
 primary_entity:
   entity: number
   icon: "mdi:paw"
@@ -24,21 +24,28 @@ secondary_entities:
         type: boolean
         name: switch
   - entity: binary_sensor
-    name: Fault
-    icon: "mdi:alert"
     class: problem
     category: diagnostic
     dps:
       - id: 14
-        type: integer
+        type: bitfield
         name: sensor
-  - entity: switch
-    name: 12/24 hour clock
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    name: Clock type
     icon: "mdi:clock"
     dps:
       - id: 102
         type: boolean
-        name: switch
+        name: option
+        mapping:
+          - dps_val: false
+            value: "12 hour"
+          - dps_val: true
+            value: "24 hour"
   - entity: sensor
     icon: "mdi:battery"
     name: Battery

--- a/custom_components/tuya_local/devices/welltobe_cat_feeder.yaml
+++ b/custom_components/tuya_local/devices/welltobe_cat_feeder.yaml
@@ -1,0 +1,49 @@
+name: Pet feeder
+products:
+  - id: qqzpxhisd6zs8zyq
+    name: WellToBe Automatic Pet Feeder (WB S36D)
+primary_entity:
+  entity: number
+  icon: "mdi:paw"
+  name: Manual feed
+  dps:
+    - id: 3
+      name: value
+      optional: true
+      type: integer
+      unit: portions
+      range:
+        min: 1
+        max: 6
+secondary_entities:
+  - entity: switch
+    name: Slow feed
+    icon: "mdi:speedometer-slow"
+    dps:
+      - id: 6
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    name: Fault
+    icon: "mdi:alert"
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 14
+        type: integer
+        name: sensor
+  - entity: switch
+    name: 12/24 hour clock
+    icon: "mdi:clock"
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+  - entity: sensor
+    icon: "mdi:battery"
+    name: Battery
+    category: diagnostic
+    dps:
+      - id: 103
+        name: sensor
+        type: string


### PR DESCRIPTION
Adding support for [WellToBe Automatic Pet Feeder (WB S36D)](https://www.amazon.ca/Automatic-WellToBe-Dispenser-Splitter-Recorder/dp/B099RYV9KT)

- [x] Reviewed other supported feeders first, with this device being more basic.
- [x] Used TUYA Dev Platform to confirm config settings.
- [x] Tested within my local environment for the last month.


![Screenshot 2024-07-24 at 16-33-34 Settings – Home Assistant](https://github.com/user-attachments/assets/288f6c66-19e0-42e0-8b8b-939172c70ceb)
