### PR TITLE
Update madimack_elite_v3_heatpump.yaml

### DIFF
--- a/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
+++ b/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
@@ -130,22 +130,6 @@ secondary_entities:
             value: C
   - entity: sensor
     category: diagnostic
-    name: Inlet water temperature
-    class: temperature
-    dps:
-      - id: 102
-        name: sensor
-        type: integer
-      - id: 6
-        name: unit
-        type: string
-        mapping:
-          - dps_val: f
-            value: F
-          - dps_val: c
-            value: C
-  - entity: sensor
-    category: diagnostic
     name: Outlet water temperature
     class: temperature
     dps:

--- a/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
+++ b/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
@@ -78,6 +78,13 @@ primary_entity:
 secondary_entities:
   - entity: sensor
     category: diagnostic
+    name: Fault code
+    dps:
+      - id: 15
+        name: sensor
+        type: integer
+  - entity: sensor
+    category: diagnostic
     name: Power level
     class: power_factor
     dps:
@@ -107,6 +114,22 @@ secondary_entities:
     class: temperature
     dps:
       - id: 24
+        name: sensor
+        type: integer
+      - id: 6
+        name: unit
+        type: string
+        mapping:
+          - dps_val: f
+            value: F
+          - dps_val: c
+            value: C
+  - entity: sensor
+    category: diagnostic
+    name: Inlet water temperature
+    class: temperature
+    dps:
+      - id: 102
         name: sensor
         type: integer
       - id: 6

--- a/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
+++ b/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
@@ -66,9 +66,6 @@ primary_entity:
     - id: 102
       name: current_temperature
       type: integer
-    - id: 15
-      name: unknown_15
-      type: integer
     - id: 101
       name: unknown_101
       type: integer

--- a/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
+++ b/custom_components/tuya_local/devices/madimack_elite_v3_heatpump.yaml
@@ -76,13 +76,20 @@ primary_entity:
       name: unknown_107
       type: boolean
 secondary_entities:
-  - entity: sensor
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
-    name: Fault code
     dps:
       - id: 15
+        type: bitfield
         name: sensor
-        type: integer
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 15
+        type: bitfield
+        name: fault_code
   - entity: sensor
     category: diagnostic
     name: Power level


### PR DESCRIPTION
Added dps 15 to secondary entities (fault code), mapping of fault code to actual message is to be researched. Also added 102 (Inlet water temperature) to secondary entities as well, to get a more consistent list in HA, similar to the Tuya app.