### PR TITLE
Add new device: Pool-Systems IPS-100max.yaml

### DIFF
--- a/custom_components/tuya_local/devices/poolsystems_ips100max.yaml
+++ b/custom_components/tuya_local/devices/poolsystems_ips100max.yaml
@@ -1,0 +1,92 @@
+name: Pool heatpump
+products:
+  - id: 1ovawewadpk2jiaw
+    name: Pool-Systems IPS-100MAX
+primary_entity:
+  entity: climate
+  dps:
+    - id: 101
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          icon: "mdi:hvac-off"
+          icon_priority: 1
+          value: "off"
+        - dps_val: true
+          constraint: work_mode
+          conditions:
+            - dps_val: smart
+              value: heat_cool
+            - dps_val: cool
+              value: cool
+            - dps_val: warm
+              value: heat
+    - id: 102
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: "silence"
+          value: sleep
+        - dps_val: "smart"
+          value: comfort
+        - dps_val: "booster"
+          value: boost
+    - id: 103
+      name: current_temperature
+      type: integer
+    - id: 104
+      name: temperature_unit
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: C
+        - dps_val: true
+          value: F
+    - id: 106
+      type: string
+      name: work_mode
+      hidden: true
+    - id: 107
+      name: temperature
+      type: integer
+    - id: 108
+      type: integer
+      name: min_temperature
+    - id: 109
+      type: integer
+      name: max_temperature
+secondary_entities:
+  - entity: sensor
+    category: diagnostic
+    name: Power level
+    icon: "mdi:signal"
+    class: power_factor
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    name: Water flow
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 110
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+  - entity: sensor
+    category: diagnostic
+    name: Power
+    class: power
+    dps:
+      - id: 112
+        name: sensor
+        type: integer
+        unit: W
+        optional: true

--- a/custom_components/tuya_local/devices/poolsystems_ips100max.yaml
+++ b/custom_components/tuya_local/devices/poolsystems_ips100max.yaml
@@ -50,6 +50,16 @@ primary_entity:
     - id: 107
       name: temperature
       type: integer
+      range:
+        min: 18
+        max: 40
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: true
+              range:
+                min: 60
+                max: 115
     - id: 108
       type: integer
       name: min_temperature
@@ -59,8 +69,6 @@ primary_entity:
 secondary_entities:
   - entity: sensor
     category: diagnostic
-    name: Power level
-    icon: "mdi:signal"
     class: power_factor
     dps:
       - id: 105
@@ -80,9 +88,21 @@ secondary_entities:
           - dps_val: 4
             value: true
           - value: false
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 110
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: false
+          - dps_val: 0
+            value: false
+          - value: true
   - entity: sensor
     category: diagnostic
-    name: Power
     class: power
     dps:
       - id: 112
@@ -90,3 +110,55 @@ secondary_entities:
         type: integer
         unit: W
         optional: true
+  - entity: number
+    category: config
+    name: Minimum temperature
+    class: temperature
+    dps:
+      - id: 108
+        type: integer
+        name: value
+        range:
+          min: 18
+          max: 40
+        mapping:
+          - constraint: unit
+            conditions:
+              - dps_val: true
+                range:
+                  min: 60
+                  max: 115
+      - id: 104
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F
+  - entity: number
+    category: config
+    name: Maximum temperature
+    class: temperature
+    dps:
+      - id: 109
+        type: integer
+        name: value
+        range:
+          min: 18
+          max: 40
+        mapping:
+          - constraint: unit
+            conditions:
+              - dps_val: true
+                range:
+                  min: 60
+                  max: 115
+      - id: 104
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F


### PR DESCRIPTION
This will add this new device: Pool-Systems IPS-100MAX
https://www.pool-systems.de/Pool-Waermepumpe-mit-Inverter/Pool-Waermepumpe-IPS-100MAX-Inverter-Premium-Silent-MAX-10KW-COP20.html

This works:
* switching between work modes: OFF, HEAT, COOL, AUTO(HEAT/COOL)
* switching between preset modes: SILENT, SMART, BOOST
* switching between °C and °F
* Setting desired temperature for either mode combination (work modes and preset modes) 
* Getting current temperature
* Getting power level in percent
* Getting power in watts
* binary_sensor indicating if water flows through the heat pump

There are two more datapoints for which I have no idea what they represent.

The heatpump is assumed to be hardware/software by Fairland.

