### PR TITLE
Add device yaml for VEVOR Level 2 Electric Vehicle Charging Station

### DIFF
--- a/custom_components/tuya_local/devices/vevor_l2_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/vevor_l2_ev_charger.yaml
@@ -1,0 +1,223 @@
+name: L2 EV charger
+products:
+  - id: onb9rrxfl9ywgzrg
+    name: VEVOR L2 48A EV Charger
+primary_entity:
+  entity: sensor
+  name: Status
+  class: enum
+  icon: "mdi:ev-station"
+  dps:
+    - id: 3
+      type: string
+      name: sensor
+      mapping:
+        - dps_val: charger_free
+          value: Available
+        - dps_val: charger_insert
+          value: Plugged in
+        - dps_val: charger_free_fault
+          value: Fault (unplugged)
+        - dps_val: charger_wait
+          value: Waiting
+        - dps_val: charger_charging
+          value: Charging
+        - dps_val: charger_pause
+          value: Paused
+        - dps_val: charger_end
+          value: Finished
+        - dps_val: charger_fault
+          value: Fault
+    - id: 23
+      type: string
+      name: system_version
+    - id: 33
+      type: string
+      optional: true
+      name: mode_set
+secondary_entities:
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Charge current
+    category: config
+    class: current
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: A
+        range:
+          min: 8
+          max: 48
+  - entity: sensor
+    name: Single phase power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mapping:
+          - scale: 1000
+            mask: "0000000000FFFFFF"
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mapping:
+          - scale: 10
+            mask: "FFFF000000000000"
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mapping:
+          - scale: 1000
+            mask: "0000FFFFFF000000"
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Connection state
+    class: enum
+    icon: "mdi:ev-plug-type2"
+    category: diagnostic
+    dps:
+      - id: 13
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: controlpi_12v
+            value: Standby
+          - dps_val: controlpi_12v_pwn
+            value: Communication initialising
+          - dps_val: controlpi_9v
+            value: Vehicle detected
+          - dps_val: controlpi_9v_pwm
+            value: Vehicle connected
+          - dps_val: controlpi_6v
+            value: Ready to charge
+          - dps_val: controlpi_6v_pwm
+            value: Charging
+          - dps_val: controlpi_error
+            value: Error
+  - entity: select
+    name: Mode
+    icon: "mdi:ev-station"
+    category: config
+    dps:
+      - id: 14
+        type: string
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: Immediate
+          - dps_val: charge_pct
+            value: Charge to percent
+          - dps_val: charge_energy
+            value: Fixed charge
+          - dps_val: charge_schedule
+            value: Scheduled charge
+          - dps_val: charge_delay
+            value: Delayed charge
+  - entity: button
+    name: Clear energy
+    class: restart
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        name: button
+  - entity: switch
+    icon: "mdi:power"
+    dps:
+      - id: 18
+        type: boolean
+        name: switch
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Last charge
+    category: diagnostic
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: binary_sensor
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 27
+        type: string
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: online
+            value: true
+          - dps_val: offline
+            value: false
+  - entity: number
+    name: Delay time
+    category: config
+    icon: "mdi:clock"
+    dps:
+      - id: 28
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 12


### PR DESCRIPTION
This device yaml has been tested and is being used with:
VEVOR Level 2 Electric Vehicle Charging Station, 0-48A Adjustable, 11.5 kW 240V NEMA14-50 Plug Smart EV Charger with WiFi
https://www.vevor.com/portable-ev-charger-c_11497/vevor-level-2-electric-vehicle-charging-station-0-48a-adjustable-11-5-kw-240v-nema14-50-plug-smart-ev-charger-with-wifi-24-foot-tpe-charging-cable-for-indoor-outdoor-use-etl-energy-star-certifie-p_010273346615

Here's a screenshot of a dashboard using this device:
<img width="800" alt="Screenshot 2024-07-31 at 10 29 49 PM" src="https://github.com/user-attachments/assets/527798c9-3593-44d1-841e-15b65c01a6ea">

Compared to the Tuya Smart Life app:
<p float="left">
  <img src="https://github.com/user-attachments/assets/89e01cdf-9642-413b-a4a9-d82e79830137" width="400" />
  <img src="https://github.com/user-attachments/assets/51025710-a37d-4471-8e86-204e2dbe7829" width="400" /> 
</p>

This charger was found to be very similar to the previous VEVOR charger added via:
https://github.com/make-all/tuya-local/issues/1757

In case it is useful, here is the diagnostic download: 
[config_entry-tuya_local-01J2WV6Z4K9XZ6BQYGS518Q79N.json](https://github.com/user-attachments/files/16449348/config_entry-tuya_local-01J2WV6Z4K9XZ6BQYGS518Q79N.json)

Tuya Cloud properties query:
```
{
  "result": {
    "properties": [
      {
        "code": "forward_energy_total",
        "custom_name": "",
        "dp_id": 1,
        "time": 1722480198200,
        "type": "value",
        "value": 2428
      },
      {
        "code": "work_state",
        "custom_name": "",
        "dp_id": 3,
        "time": 1722470470357,
        "type": "enum",
        "value": "charger_charging"
      },
      {
        "code": "charge_cur_set",
        "custom_name": "",
        "dp_id": 4,
        "time": 1722029897034,
        "type": "value",
        "value": 38
      },
      {
        "code": "phase_a",
        "custom_name": "",
        "dp_id": 6,
        "time": 1722480198250,
        "type": "raw",
        "value": "CR8AkVAAIe4="
      },
      {
        "code": "power_total",
        "custom_name": "",
        "dp_id": 9,
        "time": 1722480198365,
        "type": "value",
        "value": 8686
      },
      {
        "code": "fault",
        "custom_name": "",
        "dp_id": 10,
        "time": 1720995142060,
        "type": "bitmap",
        "value": 0
      },
      {
        "code": "connection_state",
        "custom_name": "",
        "dp_id": 13,
        "time": 1722470470514,
        "type": "enum",
        "value": "controlpi_6v_pwm"
      },
      {
        "code": "work_mode",
        "custom_name": "",
        "dp_id": 14,
        "time": 1720923148163,
        "type": "enum",
        "value": "charge_now"
      },
      {
        "code": "clear_energy",
        "custom_name": "",
        "dp_id": 16,
        "time": 1720995369643,
        "type": "bool",
        "value": true
      },
      {
        "code": "switch",
        "custom_name": "",
        "dp_id": 18,
        "time": 1722480198189,
        "type": "bool",
        "value": true
      },
      {
        "code": "system_version",
        "custom_name": "",
        "dp_id": 23,
        "time": 1720995142060,
        "type": "string",
        "value": "V1.0.4"
      },
      {
        "code": "temp_current",
        "custom_name": "",
        "dp_id": 24,
        "time": 1722480198380,
        "type": "value",
        "value": 58
      },
      {
        "code": "charge_energy_once",
        "custom_name": "",
        "dp_id": 25,
        "time": 1722044643419,
        "type": "value",
        "value": 3546
      },
      {
        "code": "online_state",
        "custom_name": "",
        "dp_id": 27,
        "time": 1720923148163,
        "type": "enum",
        "value": "offline"
      },
      {
        "code": "timer_on",
        "custom_name": "",
        "dp_id": 28,
        "time": 1720923148163,
        "type": "value",
        "value": 0
      },
      {
        "code": "mode_set",
        "custom_name": "",
        "dp_id": 33,
        "time": 1720923148163,
        "type": "raw"
      }
    ]
  },
  "success": true,
  "t": 1722480338334,
  "tid": "2272f19b4fb011ef9b372aced4fceef5"
}
```