### PR TITLE
Add support for generic light sensor

### DIFF
--- a/custom_components/tuya_local/devices/light_sensor.yaml
+++ b/custom_components/tuya_local/devices/light_sensor.yaml
@@ -1,0 +1,30 @@
+name: Light sensor
+products:
+  - id: p1632039035856duknw4
+  
+primary_entity:
+  entity: sensor
+  name: Brightness
+  class: illuminance
+  dps:
+    - id: 7
+      type: integer
+      name: sensor
+      unit: lx
+      class: measurement
+secondary_entities:
+  - entity: sensor
+    name: Light level
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 6
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: low
+            value: Low
+          - dps_val: middle
+            value: Medium
+          - dps_val: high
+            value: High

--- a/custom_components/tuya_local/devices/light_sensor.yaml
+++ b/custom_components/tuya_local/devices/light_sensor.yaml
@@ -1,10 +1,6 @@
 name: Light sensor
-products:
-  - id: p1632039035856duknw4
-  
 primary_entity:
   entity: sensor
-  name: Brightness
   class: illuminance
   dps:
     - id: 7
@@ -16,6 +12,7 @@ secondary_entities:
   - entity: sensor
     name: Light level
     class: enum
+    icon: "mdi:brightness-4"
     category: diagnostic
     dps:
       - id: 6


### PR DESCRIPTION
I wasn't sure if there was a better way to do this. Using a generic tuya light sensor that works the same as the existing illuminance sensor, but uses different dps ids.

Thanks,
Maddi