### PR TITLE
Include "name" for "smart_watering_device"

### DIFF
--- a/custom_components/tuya_local/devices/smart_watering_device.yaml
+++ b/custom_components/tuya_local/devices/smart_watering_device.yaml
@@ -4,6 +4,7 @@ products:
     name: Becasmart BAF-908
 primary_entity:
   entity: valve
+  name: Power
   class: water
   dps:
     - id: 1


### PR DESCRIPTION
Includes a missing name for smart_watering_device to avoid it being given the default name "None".