### PR TITLE
Add device Pool Heatpump Fairland X20 series

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -109,6 +109,7 @@
 - BWT FI 45 heatpump
 - Evotherm ETI series heatpump
 - Fairland IPHCR15 pool heatpump (matches others above, but allows control of heat/cool modes while others seem to be fixed to auto only)
+- Fairland IX20 pool heatpump (New 2024 model not compatible with IPS Pro)
 - Garden PAC pool heatpump (also works with Summerwave Si Series)
 - IPS Pro pool-systems heatpump (seems to match Fairland Inver-X as well)
 - Madimack Eco pool heatpump

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -109,7 +109,7 @@
 - BWT FI 45 heatpump
 - Evotherm ETI series heatpump
 - Fairland IPHCR15 pool heatpump (matches others above, but allows control of heat/cool modes while others seem to be fixed to auto only)
-- Fairland IX20 pool heatpump (New 2024 model not compatible with IPS Pro)
+- Fairland X20 pool heatpump (2024 model not compatible with IPS Pro)
 - Garden PAC pool heatpump (also works with Summerwave Si Series)
 - IPS Pro pool-systems heatpump (seems to match Fairland Inver-X as well)
 - Madimack Eco pool heatpump

--- a/custom_components/tuya_local/devices/fairland_ix20_heatpump.yaml
+++ b/custom_components/tuya_local/devices/fairland_ix20_heatpump.yaml
@@ -1,0 +1,152 @@
+name: Pool heatpump
+products:
+  - id: 000004jrci
+    name: Fairland IX20 series
+primary_entity:
+  entity: climate
+  dps:
+    - id: 101
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: smart
+              value: heat_cool
+            - dps_val: cool
+              value: cool
+            - dps_val: warm
+              value: heat
+    - id: 102
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: "silence"
+          value: sleep
+        - dps_val: "smart"
+          value: comfort
+        - dps_val: "booster"
+          value: boost
+    - id: 103
+      name: current_temperature
+      type: integer
+    - id: 104
+      name: temperature_unit
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: C
+        - dps_val: true
+          value: F
+    - id: 106
+      name: mode
+      type: string
+      icon_priority: 4
+      mapping:
+        - dps_val: warm
+          icon: "mdi:hot-tub"
+        - dps_val: cool
+          icon: "mdi:snowflake"
+        - dps_val: smart
+          icon: "mdi:refresh-auto"
+    - id: 107
+      name: temperature
+      type: integer
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: true
+              range:
+                min: 64
+                max: 104
+      range:
+        min: 18
+        max: 40
+    - id: 108
+      type: integer
+      name: min_temperature
+    - id: 109
+      type: integer
+      name: max_temperature
+    - id: 110
+      type: bitfield
+      name: error
+      mapping:
+        - dps_val: 0
+          value: OK
+        - dps_val: 4
+          value: Water Flow Protection
+          icon: "mdi:water-pump-off"
+          icon_priority: 2
+    - id: 111
+      type: bitfield
+      name: error_2
+secondary_entities:
+  - entity: sensor
+    category: diagnostic
+    class: power_factor
+    dps:
+      - id: 105
+        name: sensor
+        type: integer
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 112
+        name: sensor
+        type: integer
+        unit: W
+        optional: true
+  - entity: binary_sensor
+    name: Water flow
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 110
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+  - entity: binary_sensor
+    name: Show power
+    category: diagnostic
+    dps:
+      - id: 113
+        name: sensor
+        type: boolean
+        optional: true
+
+  - entity: binary_sensor
+    name: Show Cooling
+    category: diagnostic
+    dps:
+      - id: 114
+        name: sensor
+        type: bitfield
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "on"
+  - entity: binary_sensor
+    name: Show Turbo
+    category: diagnostic
+    dps:
+      - id: 115
+        name: sensor
+        type: bitfield
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "on"

--- a/custom_components/tuya_local/devices/fairland_x20_heatpump.yaml
+++ b/custom_components/tuya_local/devices/fairland_x20_heatpump.yaml
@@ -1,7 +1,7 @@
 name: Pool heatpump
 products:
-  - id: 000004jrci
-    name: Fairland IX20 series
+  - id: a4bepadftizzrd8g
+    name: Fairland X20 series
 primary_entity:
   entity: climate
   dps:
@@ -44,14 +44,6 @@ primary_entity:
     - id: 106
       name: mode
       type: string
-      icon_priority: 4
-      mapping:
-        - dps_val: warm
-          icon: "mdi:hot-tub"
-        - dps_val: cool
-          icon: "mdi:snowflake"
-        - dps_val: smart
-          icon: "mdi:refresh-auto"
     - id: 107
       name: temperature
       type: integer


### PR DESCRIPTION
Add support for the Fairland X20 series of Pool Heatpumps
https://www.fairland.com.cn/product/inverx20-inverter-pool-heat-pump.html

Supported functions/sensors:

- operation mode: OFF, HEAT, COOL, AUTO(HEAT/COOL)
- preset modes: SILENT, SMART, BOOST (called turbo on the Fairland App)
- switching between °C and °F
- Set the desired temperature in the range 18-40 °C and 64-104 °F
- Current temperature
- Power factor in percent
- Current Power in watts
- 2 Fault sensors (details below)
- binary sensors for operation modes

Fault error 1: ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9", "EA", "EB", "ED", "P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "PA", "F1", "F2", "F3", "F4", "F5", "F6", "F7"]

Fault error 2: ["F8", "F9", "Fb", "Fa"]

I could only identify "E3" as "No water flow" and "E5" as "abnormal power supply"

[fairland-x20-data-model.json](https://github.com/user-attachments/files/16567740/fairland-x20-data-model.json)
[fairland-x20-dps-sample.json](https://github.com/user-attachments/files/16567745/fairland-x20-dps-sample.json)

<img width="579" alt="Screenshot 2024-08-23 at 14 57 06" src="https://github.com/user-attachments/assets/6a3bad2a-2985-43bb-bcd4-1b6daa4bb406">

