### PR TITLE
Added support for YX-025WB aroma diffuser

### DIFF
--- a/custom_components/tuya_local/devices/YX-025WB_aroma_diffuser.yaml
+++ b/custom_components/tuya_local/devices/YX-025WB_aroma_diffuser.yaml
@@ -21,8 +21,11 @@ primary_entity:
       name: preset_mode
       mapping:
         - dps_val: small
+          value: small
         - dps_val: large
+          value: large
         - dps_val: interval
+          value: interval
 secondary_entities:
   - entity: light
     icon: "mdi:light-recessed"

--- a/custom_components/tuya_local/devices/YX-025WB_aroma_diffuser.yaml
+++ b/custom_components/tuya_local/devices/YX-025WB_aroma_diffuser.yaml
@@ -1,0 +1,111 @@
+name: Aroma diffuser
+products:
+  - id: yishet3p12fvohmd
+    name: Aroma YX-025WB
+primary_entity:
+  entity: fan
+  icon: "mdi:scent"
+  dps:
+    - id: 2
+      name: switch
+      optional: true
+      type: boolean
+      mapping:
+        - dps_val: false
+          icon: "mdi:scent-off"
+        - dps_val: true
+          icon: "mdi:scent"
+    - id: 3
+      type: string
+      optional: true
+      name: preset_mode
+      mapping:
+        - dps_val: small
+        - dps_val: large
+        - dps_val: interval
+secondary_entities:
+  - entity: light
+    icon: "mdi:light-recessed"
+    dps:
+      - id: 7
+        name: switch
+        optional: true
+        type: boolean
+      - id: 9
+        name: color_mode
+        optional: true
+        type: string
+        mapping:
+          - dps_val: colour
+            value: hs
+          - dps_val: colourful1
+            value: Colorful
+      - id: 8
+        name: brightness
+        optional: true
+        type: integer
+        range:
+          min: 0
+          max: 255
+      - id: 10
+        name: rgbhsv
+        optional: true
+        type: hex
+        format:
+          - name: r
+            bytes: 1
+          - name: g
+            bytes: 1
+          - name: b
+            bytes: 1
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 1
+            range:
+              min: 0
+              max: 255
+          - name: v
+            bytes: 1
+            range:
+              min: 0
+              max: 255
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 11
+        type: bitfield
+        name: sensor
+        optional: true
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 4
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: 2h
+            value: "2 hours"
+          - dps_val: 4h
+            value: "4 hours"
+          - dps_val: cancel
+            value: "None"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: min
+        optional: true
+        range:
+          min: 0
+          max: 360

--- a/custom_components/tuya_local/devices/YX-025WB_aroma_diffuser.yaml
+++ b/custom_components/tuya_local/devices/YX-025WB_aroma_diffuser.yaml
@@ -1,7 +1,7 @@
 name: Aroma diffuser
 products:
   - id: yishet3p12fvohmd
-    name: Aroma YX-025WB
+    name: Liplasting YX-025WB
 primary_entity:
   entity: fan
   icon: "mdi:scent"
@@ -84,6 +84,16 @@ secondary_entities:
         type: bitfield
         name: sensor
         optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 11
+        type: bitfield
+        name: fault_code
+        optional: true
   - entity: select
     translation_key: timer
     category: config
@@ -94,11 +104,11 @@ secondary_entities:
         optional: true
         mapping:
           - dps_val: 2h
-            value: "2 hours"
+            value: "2h"
           - dps_val: 4h
-            value: "4 hours"
+            value: "4h"
           - dps_val: cancel
-            value: "None"
+            value: cancel
   - entity: sensor
     translation_key: time_remaining
     class: duration


### PR DESCRIPTION
These configurations seem to work with my aroma diffuser. The diffuser was a bit different from the pre-existing ones as it does not use dps id 1. I also didn't find any detailed information about the preset mode so I just left the values as itself for now. For more underlying information about the logs and product can be found in my Issue #2182 