### PR TITLE
Nedis Pet Feeder: More optional dps

### DIFF
--- a/custom_components/tuya_local/devices/nedis_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/nedis_pet_feeder.yaml
@@ -56,6 +56,7 @@ secondary_entities:
     icon: "mdi:scale"
     dps:
       - id: 110
+        optional: true
         type: integer
         name: value
         unit: g
@@ -87,6 +88,7 @@ secondary_entities:
     icon: "mdi:paw-outline"
     dps:
       - id: 106
+        optional: true
         type: integer
         name: sensor
         unit: portions
@@ -115,5 +117,6 @@ secondary_entities:
     icon: "mdi:history"
     dps:
       - id: 109
+        optional: true
         type: integer
         name: sensor


### PR DESCRIPTION
My Nedis pet feeder are missing some currently required DPS:
```
2024-08-14 19:36:57.837 DEBUG (MainThread) [custom_components.tuya_local.config_flow] Found device: {'category': 'cwwsq', 'id': 'bf90cb8cd230c43f49lm9z', 'ip': '79.160.218.51', 'local_key': '<redacted>', 'name': 'Pet Feeder', 'node_id': '', 'online': False, 'product_id': 'h4jjekaxygsstaq3', 'product_name': 'Pet feeder', 'uid': '<redacted>', 'uuid': '<redacted>', 'support_local': True, 'device_cid': None, 'version': None}
2024-08-14 19:36:57.837 DEBUG (MainThread) [custom_components.tuya_local.config_flow] Adding device: bf90cb8cd230c43f49lm9z
2024-08-14 19:36:57.838 DEBUG (MainThread) [custom_components.tuya_local.config_flow] Device count: 1
2024-08-14 19:36:57.838 DEBUG (MainThread) [custom_components.tuya_local.config_flow] Hub count: 0
2024-08-14 19:37:00.520 DEBUG (MainThread) [custom_components.tuya_local.config_flow] Scanning network to get IP address for bf90cb8cd230c43f49lm9z.
2024-08-14 19:37:01.534 DEBUG (MainThread) [custom_components.tuya_local.config_flow] Found: {'ip': '192.168.1.12', 'version': '3.3', 'id': 'bf90cb8cd230c43f49lm9z', 'product_id': 'h4jjekaxygsstaq3', 'data': {'ip': '192.168.1.12', 'gwId': 'bf90cb8cd230c43f49lm9z', 'active': 2, 'encrypt': True, 'productKey': 'h4jjekaxygsstaq3', 'version': '3.3', 'name': '', 'key': '', 'mac': '', 'id': 'bf90cb8cd230c43f49lm9z', 'ability': 0, 'token': '', 'wf_cfg': '', 'dev_type': 'default', 'origin': 'broadcast'}}
2024-08-14 19:37:06.705 DEBUG (MainThread) [custom_components.tuya_local.device] Refreshing device state for Test
2024-08-14 19:37:06.705 INFO (MainThread) [custom_components.tuya_local.device] Setting protocol version for Test to 3.3
2024-08-14 19:37:06.805 DEBUG (SyncWorker_5) [custom_components.tuya_local.device] Test refreshed device state: {"dps": {"101": 2, "102": 1, "103": true, "104": 2, "105": 1, "107": 2, "108": 2, "111": false}}
2024-08-14 19:37:06.805 DEBUG (SyncWorker_5) [custom_components.tuya_local.device] new state (incl pending): {"updated_at": 1723657026.804908, "101": 2, "102": 1, "103": true, "104": 2, "105": 1, "107": 2, "108": 2, "111": false}
…
2024-08-14 19:37:12.887 DEBUG (MainThread) [custom_components.tuya_local.helpers.device_config] Loaded device config nedis_pet_feeder.yaml
2024-08-14 19:37:12.887 DEBUG (MainThread) [custom_components.tuya_local.helpers.device_config] Not match for Nedis Pet Feeder, missing required DPs: [{'110': 'int'}, {'106': 'int'}, {'109': 'int'}]
…
2024-08-14 19:37:16.595 WARNING (MainThread) [custom_components.tuya_local.config_flow] Device matches ir_remote_sensors with quality of 25%. DPS: {"updated_at": 1723657026.804908, "101": 2, "102": 1, "103": true, "104": 2, "105": 1, "107": 2, "108": 2, "111": false}
2024-08-14 19:37:16.596 WARNING (MainThread) [custom_components.tuya_local.config_flow] Include the previous log message with any new device request to https://github.com/make-all/tuya-local/issues/
```

Note that this is the same symptom as reported in https://github.com/make-all/tuya-local/issues/379#issuecomment-1427792789

On a side note, I see that DPS 109 is mapped to history, and I used to see history in the Smart Life app for this device, but it disappeared at some point. No idea if that is a change by Tuya, or if I did something I should not have done in their developer console.

By the way - thank you very much for this integration!