### PR TITLE
Add Support for Faroro Pet Feeder

### DIFF
--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -1,0 +1,135 @@
+name: Wi-Fi Pet Feeder
+product:
+  - id: vglnuveujzyrpku9
+    name: Faroro Automatic Cat Feeder
+primary_entity:
+  entity: number
+  name: Manual Feed
+  icon: "mdi:food-drumstick"
+  mode: box
+  dps:
+    - id: 3
+      name: value
+      type: integer
+      persist: false
+      range:
+        min: 1
+        max: 12
+secondary_entities:
+  - entity: sensor
+    name: Feed Status
+    icon: "mdi:paw"
+    class: enum
+    dps:
+      - id: 4
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: standby
+            value: Standby
+          - dps_val: feeding
+            value: Feeding
+  - entity: button
+    name: Factory Reset
+    icon: "mdi:lock-reset"
+    category: diagnostic
+    dps:
+      - id: 9
+        type: boolean
+        name: button
+  - entity: sensor
+    name: Last Feed Amount
+    icon: "mdi:food-drumstick"
+    category: diagnostic
+    dps:
+      - id: 15
+        name: sensor
+        type: integer
+  - entity: sensor
+    name: Voice Times
+    icon: "mdi:account-voice"
+    category: config
+    dps:
+      - id: 18
+        name: sensor
+        type: integer
+  - entity: switch
+    name: Indicator Light
+    icon: "mdi:lightbulb"
+    category: config
+    dps:
+      - id: 19
+        name: switch
+        type: boolean
+        mapping:
+          - dps_val: false
+            icon: "mdi:lightbulb-outline"
+  - entity: sensor
+    name: Battery Level
+    icon: "mdi:battery"
+    category: diagnostic
+    class: enum
+    dps:
+      - id: 101
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: "no"
+            value: None
+          - dps_val: low
+            value: Low
+          - dps_val: high
+            value: High
+  - entity: sensor
+    name: Food Level
+    icon: "mdi:food-drumstick"
+    class: enum
+    dps:
+      - id: 102
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: full
+            value: Full
+          - dps_val: less
+            value: Low
+            icon: "mdi:food-drumstick-outline"
+          - dps_val: lack
+            value: Empty
+            icon: "mdi:food-drumstick-off-outline"
+  - entity: binary_sensor
+    name: Food Jam Status
+    icon: "mdi:paw"
+    category: diagnostic
+    dps:
+      - id: 103
+        name: sensor
+        type: boolean
+  - entity: binary_sensor
+    name: Stuck Status
+    icon: "mdi:paw"
+    category: diagnostic
+    dps:
+      - id: 104
+        name: sensor
+        type: boolean
+  - entity: switch
+    name: Reboot
+    icon: "mdi:restart"
+    category: diagnostic
+    optional: true
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+  - entity: number
+    name: Button Portion Size
+    icon: "mdi:food-drumstick"
+    category: config
+    dps:
+      - id: 106
+        name: value
+        type: integer
+        range:
+          min: 1
+          max: 12

--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -6,7 +6,7 @@ primary_entity:
   entity: number
   name: Manual Feed
   icon: "mdi:food-drumstick"
-  mode: box
+  mode: "box"
   dps:
     - id: 3
       name: value
@@ -113,7 +113,7 @@ secondary_entities:
       - id: 104
         name: sensor
         type: boolean
-  - entity: switch
+  - entity: button
     name: Reboot
     icon: "mdi:restart"
     category: diagnostic
@@ -121,7 +121,7 @@ secondary_entities:
     dps:
       - id: 105
         type: boolean
-        name: switch
+        name: button
   - entity: number
     name: Button Portion Size
     icon: "mdi:food-drumstick"

--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -1,5 +1,5 @@
 name: Wi-Fi Pet Feeder
-product:
+products:
   - id: vglnuveujzyrpku9
     name: Faroro Automatic Cat Feeder
 primary_entity:

--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -1,10 +1,10 @@
-name: Wi-Fi Pet Feeder
+name: Pet feeder
 products:
   - id: vglnuveujzyrpku9
-    name: Faroro Automatic Cat Feeder
+    name: Faroro PF50
 primary_entity:
   entity: number
-  name: Manual Feed
+  name: Manual feed
   icon: "mdi:food-drumstick"
   mode: "box"
   dps:
@@ -17,7 +17,7 @@ primary_entity:
         max: 12
 secondary_entities:
   - entity: sensor
-    name: Feed Status
+    name: Feed status
     icon: "mdi:paw"
     class: enum
     dps:
@@ -30,7 +30,7 @@ secondary_entities:
           - dps_val: feeding
             value: Feeding
   - entity: button
-    name: Factory Reset
+    name: Factory reset
     icon: "mdi:lock-reset"
     category: diagnostic
     dps:
@@ -38,7 +38,7 @@ secondary_entities:
         type: boolean
         name: button
   - entity: sensor
-    name: Last Feed Amount
+    name: Last feed amount
     icon: "mdi:food-drumstick"
     category: diagnostic
     dps:
@@ -46,7 +46,7 @@ secondary_entities:
         name: sensor
         type: integer
   - entity: sensor
-    name: Voice Times
+    name: Voice times
     icon: "mdi:account-voice"
     category: config
     dps:
@@ -54,7 +54,7 @@ secondary_entities:
         name: sensor
         type: integer
   - entity: switch
-    name: Indicator Light
+    name: Indicator light
     icon: "mdi:lightbulb"
     category: config
     dps:
@@ -65,23 +65,23 @@ secondary_entities:
           - dps_val: false
             icon: "mdi:lightbulb-outline"
   - entity: sensor
-    name: Battery Level
+    name: Battery level
     icon: "mdi:battery"
     category: diagnostic
-    class: enum
+    class: battery
     dps:
       - id: 101
         name: sensor
         type: string
         mapping:
           - dps_val: "no"
-            value: None
-          - dps_val: low
-            value: Low
-          - dps_val: high
-            value: High
+            value: 10
+          - dps_val: "low"
+            value: 30
+          - dps_val: "high"
+            value: 80
   - entity: sensor
-    name: Food Level
+    name: Food level
     icon: "mdi:food-drumstick"
     class: enum
     dps:
@@ -98,16 +98,18 @@ secondary_entities:
             value: Empty
             icon: "mdi:food-drumstick-off-outline"
   - entity: binary_sensor
-    name: Food Jam Status
+    name: Food jam status
     icon: "mdi:paw"
+    class: problem
     category: diagnostic
     dps:
       - id: 103
         name: sensor
         type: boolean
   - entity: binary_sensor
-    name: Stuck Status
+    name: Stuck status
     icon: "mdi:paw"
+    class: problem
     category: diagnostic
     dps:
       - id: 104
@@ -115,7 +117,7 @@ secondary_entities:
         type: boolean
   - entity: button
     name: Reboot
-    icon: "mdi:restart"
+    class: restart
     category: diagnostic
     dps:
       - id: 105
@@ -123,9 +125,10 @@ secondary_entities:
         name: button
         optional: true
   - entity: number
-    name: Button Portion Size
+    name: Button portion size
     icon: "mdi:food-drumstick"
     category: config
+    mode: "box"
     dps:
       - id: 106
         name: value

--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -31,8 +31,7 @@ secondary_entities:
             value: Feeding
   - entity: button
     name: Factory reset
-    icon: "mdi:lock-reset"
-    category: diagnostic
+    class: restart
     dps:
       - id: 9
         type: boolean
@@ -65,8 +64,6 @@ secondary_entities:
           - dps_val: false
             icon: "mdi:lightbulb-outline"
   - entity: sensor
-    name: Battery level
-    icon: "mdi:battery"
     category: diagnostic
     class: battery
     dps:
@@ -98,7 +95,7 @@ secondary_entities:
             value: Empty
             icon: "mdi:food-drumstick-off-outline"
   - entity: binary_sensor
-    name: Food jam status
+    name: Food jam
     icon: "mdi:paw"
     class: problem
     category: diagnostic
@@ -107,7 +104,7 @@ secondary_entities:
         name: sensor
         type: boolean
   - entity: binary_sensor
-    name: Stuck status
+    name: Stuck
     icon: "mdi:paw"
     class: problem
     category: diagnostic

--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -117,11 +117,11 @@ secondary_entities:
     name: Reboot
     icon: "mdi:restart"
     category: diagnostic
-    optional: true
     dps:
       - id: 105
         type: boolean
         name: button
+        optional: true
   - entity: number
     name: Button Portion Size
     icon: "mdi:food-drumstick"


### PR DESCRIPTION
I've been using and tweaking this config for over a year. A mostly normal pet feeder with a a couple quirks-

- Manual Feed has mode set to box, slider resulted in accidental dispensing on tap
- Manual Feed has persist set to false, otherwise brief disconnections would result in food dispensing