### PR TITLE
Added support for De'Longhi Pinguino PAC

### DIFF
--- a/custom_components/tuya_local/devices/pinguino_portable_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/pinguino_portable_airconditioner.yaml
@@ -1,0 +1,130 @@
+name: Portable Air Conditioner
+products:
+  - id: anR7aeh1YPTKAz5a
+    name: De'Longhi Pinguino PACEL140LRFK 3ALBK
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - value: "off"
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: null
+              value: "off"
+            - dps_val: "1"
+              value: dry
+            - dps_val: "2"
+              value: cool
+            - dps_val: "3"
+              value: fan_only
+            - dps_val: "4"
+              value: auto
+    - id: 5
+      name: mode
+      type: string
+    - id: 6
+      type: integer
+      name: temperature
+      range:
+        min: 18
+        max: 32
+      mapping:
+        - constraint: temperature_unit
+          conditions:
+            - dps_val: true
+              range:
+                min: 64
+                max: 90
+    - id: 8
+      type: string
+      name: fan_mode
+      mapping:
+        - value: auto
+        - dps_val: "0"
+          value: auto
+        - dps_val: "1"
+          value: auto
+          constraint: mode
+          conditions:
+            - dps_val: "2"
+              value: low
+            - dps_val: "3"
+              value: low
+        - dps_val: "2"
+          value: auto
+          constraint: mode
+          conditions:
+            - dps_val: "2"
+              value: medium
+            - dps_val: "3"
+              value: medium
+        - dps_val: "3"
+          value: auto
+          constraint: mode
+          conditions:
+            - dps_val: "2"
+              value: high
+            - dps_val: "3"
+              value: high
+    - id: 16
+      name: swing_mode
+      type: boolean
+      mapping:
+        - value: "off"
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: vertical
+    - id: 21
+      name: temperature_unit
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "C"
+        - dps_val: true
+          value: "F"
+secondary_entities:
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 21
+        type: boolean
+        name: option
+        mapping:
+          - dps_val: false
+            value: celsius
+          - dps_val: true
+            value: fahrenheit
+  - entity: sensor
+    class: enum
+    dps:
+      - id: 20
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "blue"
+          - dps_val: "2"
+            value: "green"
+          - dps_val: "3"
+            value: "orange"


### PR DESCRIPTION
Hello. This commit adds support for the De'Longhi Pinguino portable air conditioner. Everything seems to work well. I could've been slightly cleaner if nested conditions (or something equivalent to an &&) were supported, but this is the best we can do I think.

![image](https://github.com/user-attachments/assets/9df3360c-4449-4030-86f3-6d42bb849153)
![image](https://github.com/user-attachments/assets/b8f86556-ce92-44f6-b7c4-44e357d8dad3)
![image](https://github.com/user-attachments/assets/1df7b1e0-83de-4e3b-b97b-69e9f2481fef)

Also the auto mode is actually eco, but eco isn't an hvac_mode. I added the dummy Preset section just to clarify this.

Sometimes though, I get this error notification regularly when I'm not touching anything:
Failed to perform the action climate/set_hvac_mode. expected HVACMode or one of 'off', 'heat', 'cool', 'heat_cool', 'auto', 'dry', 'fan_only' for dictionary value @ data['hvac_mode']

I have no idea what would trigger this. Maybe I messed up somewhere. Welcoming any feedback.