### PR TITLE
Updated support for Windcalm fans without lights

### DIFF
--- a/custom_components/tuya_local/devices/windcalm_fan.yaml
+++ b/custom_components/tuya_local/devices/windcalm_fan.yaml
@@ -14,10 +14,15 @@ primary_entity:
     - id: 63
       type: string
       name: direction
-    - id: 64
-      type: integer
-      name: timer
-      range:
-        min: 0
-        max: 540
-      unit: min
+secondary_entities:
+  - entity: number
+    translation_key: timer
+    category: config
+    dps:
+      - id: 64
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 540


### PR DESCRIPTION
Updated the configuration for Windcalm Fans without lights. It wasn't able to match the device based on the defined entities.