### PR TITLE
Add support for QCSmart garage door

### DIFF
--- a/custom_components/tuya_local/devices/qcsmart_garage_door.yaml
+++ b/custom_components/tuya_local/devices/qcsmart_garage_door.yaml
@@ -1,0 +1,25 @@
+name: QCSmart garage door
+products:
+  - id: bf68ea3165358a2846kahv
+    name: QCSmart garage door
+primary_entity:
+  entity: cover
+  class: garage
+  dps:
+    - id: 1
+      type: boolean
+      name: control
+      optional: true
+      mapping:
+        - dps_val: true
+          value: open
+        - dps_val: false
+          value: close
+    - id: 101
+      type: boolean
+      name: action
+      mapping:
+        - dps_val: true
+          value: opened
+        - dps_val: false
+          value: closed


### PR DESCRIPTION
This PR adds support for a garage door opener I bought on AliExpress. Unfortunately the device doesn't give much more information about available DPs (even using DP instruction on the Tuya API), so there is no state like "opening" or "closing".