### PR TITLE
Add Fujicool and Yuzu Heatpump

### DIFF
--- a/custom_components/tuya_local/devices/fujicool_yuzu_heatpump.yaml
+++ b/custom_components/tuya_local/devices/fujicool_yuzu_heatpump.yaml
@@ -1,0 +1,270 @@
+name: Fujicool-Yuzu Heatpump (F)
+primary_entity:
+  entity: climate
+  translation_only_key: aircon_extra
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: cold
+              value: cool
+            - dps_val: hot
+              value: heat
+            - dps_val: wet
+              value: dry
+            - dps_val: wind
+              value: fan_only
+            - dps_val: auto
+              value: heat_cool
+    - id: 2
+      type: integer
+      name: temperature
+      range:
+        min: 160
+        max: 260
+      mapping:
+        - scale: 10
+          step: 10
+      unit: C
+    - id: 4
+      type: string
+      name: mode
+      hidden: true
+    - id: 5
+      type: string
+      name: fan_mode
+      mapping:
+        - dps_val: auto
+          value: auto
+        - dps_val: mute
+          value: quiet
+        - dps_val: low
+          value: low
+        - dps_val: mid_low
+          value: medlow
+        - dps_val: mid
+          value: medium
+        - dps_val: mid_high
+          value: medhigh
+        - dps_val: high
+          value: high
+        - dps_val: strong
+          value: strong
+    - id: 20
+      type: bitfield
+      name: fault_code
+    - id: 105
+      type: string
+      name: sleep_mode
+    - id: 110
+      type: bitfield
+      name: flags
+    - id: 113
+      type: string
+      name: swing_mode
+      mapping:
+        - dps_val: "0"
+          value: horizontal
+          constraint: horizontal_swing
+          conditions:
+            - dps_val: "0"
+              value: "off"
+            - dps_val: "1"
+              value: horizontal
+        - dps_val: "1"
+          value: both
+          constraint: horizontal_swing
+          conditions:
+            - dps_val: "0"
+              value: vertical
+            - dps_val: "1"
+              value: both
+        - value: both
+          constraint: horizontal_swing
+          conditions:
+            - dps_val: "0"
+              value: vertical
+    - id: 114
+      type: string
+      name: horizontal_swing
+      hidden: true
+    - id: 119
+      type: string
+      name: electricity_management
+    - id: 120
+      type: string
+      name: gen_mode
+    - id: 123
+      type: hex
+      name: flags_2
+    - id: 125
+      type: string
+      name: air_quality
+      optional: true
+    - id: 128
+      type: string
+      name: model_code
+    - id: 129
+      type: string
+      name: energy
+    - id: 130
+      type: integer
+      name: eco_temp
+    - id: 132
+      type: boolean
+      name: hot_cool
+    - id: 133
+      type: string
+      name: swing_action
+    - id: 134
+      type: json
+      name: statistics
+secondary_entities:
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 3
+        name: sensor
+        type: integer
+        unit: C
+        class: measurement
+  - entity: sensor
+    class: humidity
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: select
+    name: Vertical swing
+    category: config
+    icon: "mdi:arrow-up-down-bold"
+    dps:
+      - id: 113
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: Full
+          - dps_val: "2"
+            value: Upper
+          - dps_val: "3"
+            value: Lower
+  - entity: select
+    name: Vertical position
+    category: config
+    icon: "mdi:unfold-more-horizontal"
+    dps:
+      - id: 126
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Unknown
+          - dps_val: "1"
+            value: Top
+          - dps_val: "2"
+            value: Slightly up
+          - dps_val: "3"
+            value: Middle
+          - dps_val: "4"
+            value: Slightly down
+          - dps_val: "5"
+            value: Bottom
+  - entity: select
+    name: Horizontal swing
+    category: config
+    icon: "mdi:arrow-left-right-bold"
+    dps:
+      - id: 114
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: Full
+          - dps_val: "2"
+            value: Left
+          - dps_val: "3"
+            value: Center
+          - dps_val: "4"
+            value: Right
+  - entity: select
+    name: Horizontal position
+    category: config
+    icon: "mdi:unfold-more-vertical"
+    dps:
+      - id: 127
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Unknown
+          - dps_val: "1"
+            value: Leftmost
+          - dps_val: "2"
+            value: Slight Left
+          - dps_val: "3"
+            value: Center
+          - dps_val: "4"
+            value: Slight Right
+          - dps_val: "5"
+            value: Rightmost
+  - entity: light
+    translation_key: display
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - mask: "0008"
+  - entity: switch
+    name: Beep
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mapping:
+          - mask: "0010"
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: sensor
+    class: pm25
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: ugm3
+        optional: true
+        class: measurement
+  - entity: binary_sensor
+    name: Filter
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 131
+        type: boolean
+        name: sensor

--- a/custom_components/tuya_local/devices/fujicool_yuzu_heatpump.yaml
+++ b/custom_components/tuya_local/devices/fujicool_yuzu_heatpump.yaml
@@ -1,4 +1,7 @@
-name: Fujicool-Yuzu Heatpump (F)
+name: Heatpump
+# products:
+#  - id: UNKNOWN
+#    name: Fujicool Yuzu
 primary_entity:
   entity: climate
   translation_only_key: aircon_extra
@@ -32,6 +35,9 @@ primary_entity:
         - scale: 10
           step: 10
       unit: C
+    - id: 3
+      type: integer
+      name: current_temperature
     - id: 4
       type: string
       name: mode
@@ -56,9 +62,9 @@ primary_entity:
           value: high
         - dps_val: strong
           value: strong
-    - id: 20
-      type: bitfield
-      name: fault_code
+    - id: 18
+      type: integer
+      name: current_humidity
     - id: 105
       type: string
       name: sleep_mode
@@ -103,10 +109,6 @@ primary_entity:
     - id: 123
       type: hex
       name: flags_2
-    - id: 125
-      type: string
-      name: air_quality
-      optional: true
     - id: 128
       type: string
       name: model_code
@@ -126,23 +128,20 @@ primary_entity:
       type: json
       name: statistics
 secondary_entities:
-  - entity: sensor
-    class: temperature
-    dps:
-      - id: 3
-        name: sensor
-        type: integer
-        unit: C
-        class: measurement
-  - entity: sensor
-    class: humidity
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
     dps:
-      - id: 18
-        type: integer
+      - id: 20
+        type: bitfield
         name: sensor
-        unit: "%"
-        class: measurement
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code
   - entity: select
     name: Vertical swing
     category: config
@@ -239,17 +238,6 @@ secondary_entities:
         name: switch
         mapping:
           - mask: "0010"
-  - entity: binary_sensor
-    class: problem
-    category: diagnostic
-    dps:
-      - id: 20
-        type: bitfield
-        name: sensor
-        mapping:
-          - dps_val: 0
-            value: false
-          - value: true
   - entity: sensor
     class: pm25
     category: diagnostic
@@ -260,6 +248,10 @@ secondary_entities:
         unit: ugm3
         optional: true
         class: measurement
+      - id: 125
+        type: string
+        name: air_quality
+        optional: true
   - entity: binary_sensor
     name: Filter
     class: problem


### PR DESCRIPTION
This commit allows the usage of Fujicool and Yuzu Heatpump (self installable HVAZC sold in France). It may work with Airton Heatpumps too, but I can’t test it.