### PR TITLE
Make puppy kitty feeder a separate device

### DIFF
--- a/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
@@ -6,8 +6,6 @@ products:
     name: GiotoHun Pet feeder
   - id: ojqmjnoxqygqldsp
     name: PUPPY KITTY Automatic Cat & Dog Feeder
-  - id: iwabnqimdhmzxzvp
-    name: PUPPY KITTY Automatic Cat & Dog Feeder
 primary_entity:
   entity: button
   name: Quick Feed

--- a/custom_components/tuya_local/devices/puppy_kitty_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/puppy_kitty_pet_feeder.yaml
@@ -1,0 +1,65 @@
+name: Pet feeder
+products:
+  - id: iwabnqimdhmzxzvp
+    name: PUPPY KITTY Automatic Cat & Dog Feeder
+primary_entity:
+  entity: switch
+  name: Enable feeder
+  icon: "mdi:food-drumstick"
+  dps:
+    - id: 25
+      type: boolean
+      name: switch
+    - id: 1
+      name: meal_plan
+      type: string
+      optional: true
+secondary_entities:
+  - entity: sensor
+    icon: "mdi:paw"
+    name: Feed report
+    category: diagnostic
+    dps:
+      - id: 14
+        name: sensor
+        type: integer
+  - entity: button
+    class: restart
+    name: Factory reset
+    category: config
+    dps:
+      - id: 24
+        type: boolean
+        name: button
+        optional: true
+  - entity: number
+    icon: "mdi:paw"
+    name: Manual feed
+    category: config
+    dps:
+      - id: 3
+        name: value
+        type: integer
+        range:
+          min: 1
+          max: 20
+  - entity: binary_sensor
+    name: Feeding
+    class: running
+    icon: "mdi:paw"
+    category: diagnostic
+    dps:
+      - id: 4
+        type: string
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: feeding
+            value: true
+          - dps_val: standby
+            value: false
+          - dps_val: done
+            value: false
+          - dps_val: null
+            value: null
+          - value: false

--- a/custom_components/tuya_local/devices/puppy_kitty_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/puppy_kitty_pet_feeder.yaml
@@ -58,10 +58,7 @@ secondary_entities:
         mapping:
           - dps_val: feeding
             value: true
-          - dps_val: standby
-            value: false
-          - dps_val: done
-            value: false
-          - dps_val: null
-            value: null
           - value: false
+      - id: 4
+        type: string
+        name: raw

--- a/custom_components/tuya_local/devices/puppy_kitty_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/puppy_kitty_pet_feeder.yaml
@@ -23,6 +23,7 @@ secondary_entities:
       - id: 14
         name: sensor
         type: integer
+        optional: true
   - entity: button
     class: restart
     name: Factory reset
@@ -40,6 +41,7 @@ secondary_entities:
       - id: 3
         name: value
         type: integer
+        optional: true
         range:
           min: 1
           max: 20


### PR DESCRIPTION
Initially I made a pr to add this device (product id: iwabnqimdhmzxzvp) to the existing catit smart feeder config. However, even though I bought it from the same manufacturer, this particular id has a slightly different mapping.

It may be possible to combine this mapping and the catit one, although the catit mapping has a few sensors that dont exist on this device (food shortage and food blockage).

Unfortunately this device does not report anything except the last portion size (and only after being triggered at least once) and whether its on or off (switch with id 25). I also didn't quite add everything from the tinytuya devices.json file (my device has no batteries and doesn't report those values anyways).
Here is the devices.json:
```
{
        "name": "Automatic Pet Feeder",
        "id": "",
        "key": "",
        "mac": "",
        "uuid": "",
        "sn": "",
        "category": "cwwsq",
        "product_name": "Automatic Pet Feeder",
        "product_id": "iwabnqimdhmzxzvp",
        "biz_type": 18,
        "model": "",
        "sub": false,
        "icon": "https://images.tuyaeu.com/smart/icon/bay166625965320080Or/4e1ad859f112244a4a9efb8b64984540.png",
        "mapping": {
            "1": {
                "code": "meal_plan",
                "type": "Raw",
                "values": {}
            },
            "3": {
                "code": "manual_feed",
                "type": "Integer",
                "values": {
                    "unit": "",
                    "min": 1,
                    "max": 20,
                    "scale": 0,
                    "step": 1
                }
            },
            "4": {
                "code": "feed_state",
                "type": "Enum",
                "values": {
                    "range": [
                        "standby",
                        "feeding",
                        "done"
                    ]
                }
            },
            "10": {
                "code": "battery_percentage",
                "type": "Integer",
                "values": {
                    "unit": "%",
                    "min": 0,
                    "max": 100,
                    "scale": 0,
                    "step": 1
                }
            },
            "11": {
                "code": "charge_state",
                "type": "Boolean",
                "values": {}
            },
            "14": {
                "code": "feed_report",
                "type": "Integer",
                "values": {
                    "unit": "",
                    "min": 0,
                    "max": 20,
                    "scale": 0,
                    "step": 1
                }
            },
            "24": {
                "code": "factory_reset",
                "type": "Boolean",
                "values": {}
            },
            "25": {
                "code": "switch",
                "type": "Boolean",
                "values": {}
            }
        },
        "ip": "",
        "version": "3.4"
    },

```
Here is what a tinytuya scan reports:
```
Automatic Pet Feeder   Product ID = iwabnqimdhmzxzvp  [Valid Broadcast]:
    Address =    Device ID =  (len:22)  Local Key =   Version = 3.4  Type = default, MAC = 
    Status: {'3': 2, '25': True}
```