### PR TITLE
Add support for Reiga ceiling fan without light

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -243,7 +243,7 @@
 - Orison RGB ambient bladeless ceiling fan
 - Ovlaim ceiling fan with cool/warm white dimmable light
 - Princess DC pedestal fan
-- Reiga 52 ceiling fan with light
+- Reiga ceiling fans with and without light
 - Royal Clima RCB 150 ventilation system
 - Skyfan DC fan
 - Skyfan DC fan with light
@@ -360,7 +360,7 @@
 ### Kitchen Appliances
 
 - Anko 1.7L smart kettle
-- Ciarra CBCS4850 range hood 
+- Ciarra CBCS4850 range hood
 - Casdon TD Pro 2 oven
 - Cecofry 5500 Connected air fryer
 - Inkbird iBBQ-4BW cooking probe thermometer
@@ -795,7 +795,7 @@ port and password.
 - PH-W218 water quality monitor
 - PlantsIO Ivy smart planter
 - PV28-CW 8 in 1 air quality monitor
-- RSE TY-WFH v3.01 gate controller 
+- RSE TY-WFH v3.01 gate controller
 - RTCZ-03 human presence sensor
 - RainPoint TTV103FRF water timer
 - SD123 HPR01 human presence radar

--- a/custom_components/tuya_local/devices/reiga_ceiling_fan.yaml
+++ b/custom_components/tuya_local/devices/reiga_ceiling_fan.yaml
@@ -1,0 +1,49 @@
+name: Ceiling Fan
+products:
+  - id: aktxh7558udrex8a
+    name: Reiga Smart Ceiling Fan
+primary_entity:
+  entity: fan
+  translation_only_key: fan_with_presets
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: normal
+          value: normal
+        - dps_val: nature
+          value: nature
+        - dps_val: sleep
+          value: sleep
+    - id: 3
+      type: integer
+      name: speed
+      range:
+        min: 1
+        max: 6
+    - id: 8
+      type: string
+      name: direction
+secondary_entities:
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: cancel
+          - dps_val: "1hour"
+            value: "1h"
+          - dps_val: "2hour"
+            value: "2h"
+          - dps_val: "4hour"
+            value: "4h"
+          - dps_val: "8hour"
+            value: "8h"


### PR DESCRIPTION
Hi,

I have added a device description for [Reiga smart ceiling fans](https://www.reigafan.com/) that do not have an integrated light. Tested with the fan that I have installed at home ([this model](https://www.reigafan.com/product/65-inch-wood-blade-ceiling-fan/)).

In addition, I propose to change the naming of a similar file, the one that describes fans from the same manufacturer with integrated lights (reiga_52_fan_light.yaml). The naming of the previously existing file suggests that it is only valid for fans with this specific size of the blades (52 inch), which I consider an unnecessary limitation of the scope. Like with the Windcalm fans I think it is fair to just differentiate between fans with or without light. 

Apologies if my edit to DEVICES.md messed up whitespaces in two locations, these were not intended.