### PR TITLE
Fix: Water Heater Entity becomes unavailable when Temperature is not available but not set to None

### DIFF
--- a/custom_components/tuya_local/water_heater.py
+++ b/custom_components/tuya_local/water_heater.py
@@ -108,6 +108,9 @@ class TuyaLocalWaterHeater(TuyaLocalEntity, WaterHeaterEntity):
         """Return the precision of the temperature setting."""
         # unlike sensor, this is a decimal of the smallest unit that can be
         # represented, not a number of decimal places.
+        if self._temperature_dps is None:
+            return None
+
         return 1.0 / max(
             self._temperature_dps.scale(self._device),
             (
@@ -149,7 +152,7 @@ class TuyaLocalWaterHeater(TuyaLocalEntity, WaterHeaterEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         if self._temperature_dps is None:
-            raise NotImplementedError()
+            return None
         return self._temperature_dps.get_value(self._device)
 
     @property


### PR DESCRIPTION
Fix an issue that occurs that causes the Water Heater Entity to become unavailable.

It looks like Home Assistant expects the Target Temperature to be set to None even when the flag for setting a temperature isn't present. It seems like the same is also expected of the precision value.

Tested with the "sanden_gaua45hpd_heatpumpcontroller" which doesn't provide the ability to set the temperature through Tuya.


