### PR TITLE
Add support for Windmill AC

### DIFF
--- a/custom_components/tuya_local/devices/windmill_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/windmill_airconditioner.yaml
@@ -1,0 +1,53 @@
+name: Windmill Air Conditioner
+products:
+  - id: ebd7ef1c98deabe827aukn
+    name: Windmill Air Conditioner
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: mode
+          conditions:
+            - dps_val: wind
+              value: fan_only
+            - dps_val: cool
+              value: cool
+            - dps_val: eco
+              value: auto
+    - id: 4
+      name: mode
+      type: string
+      hidden: true
+    - id: 5
+      name: fan_mode
+      type: string
+      mapping:
+        - dps_val: low
+          value: low
+        - dps_val: mid
+          value: medium
+        - dps_val: high
+          value: high
+        - dps_val: auto
+          value: auto
+    # Reported by device, seemingly unused
+    # - id: 22
+    - id: 23
+      name: current_temperature
+      type: integer
+      readonly: true
+    - id: 24
+      name: temperature
+      type: integer
+      range:
+        min: 60
+        max: 86
+      unit: F
+    # Reported by device, seemingly unused
+    # - id: 102


### PR DESCRIPTION
Older models of the [WIndmill AC](https://www.amazon.com/Windmill-Conditioner-Smart-Home-Unit/dp/B09TM28Q98/ref=sr_1_6) run on Tuya. The current models run on Blynk (I'm not sure when exactly they made the switch, I haven't been able to find model IDs, but the one I bought in 2022 is Tuya). Here's my attempt at creating a config for this device. I got the values by adding the AC as a Simple Switch in the tuya-local integration, and checking the device state in HA while cycling through all possible options.