### PR TITLE
Create kogan_kasmgphXXXX_heater.yaml

### DIFF
--- a/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
+++ b/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
@@ -1,10 +1,10 @@
-name: Kogan KASMGPH Series Heater
+name: Heater
 products:
   - id: 9l3riftrq9acjunt
     name: Kogan KASMGPH15YA Premium Glass Panel Heater
 primary_entity:
   entity: climate
-  name: "Climate"
+  translation_key: heater
   dps:
     - id: 1
       name: hvac_mode
@@ -34,19 +34,19 @@ primary_entity:
       type: integer
 secondary_entities:
   - entity: switch
-    name: "Night Mode"
+    translation_key: sleep
     dps:
       - id: 6
         type: boolean
         name: switch
   - entity: lock
-    name: "Child Lock"
+    translation_key: child_lock
     dps:
       - id: 7
         type: boolean
         name: lock
   - entity: select
-    name: "Timer"
+    translation_key: timer
     dps:
       - id: 19
         type: string
@@ -54,7 +54,7 @@ secondary_entities:
         optional: true
         mapping:
           - dps_val: cancel
-            value: "Timer Off"
+            value: cancel
           - dps_val: "1h"
             value: "1h"
           - dps_val: "2h"
@@ -68,11 +68,11 @@ secondary_entities:
           - dps_val: "6h"
             value: "6h"
   - entity: sensor
-    name: "Timer Remaining"
+    translation_key: time_remaining
     dps:
       - id: 20
         type: integer
         name: sensor
         class: measurement
         optional: true
-        unit: "minutes"
+        unit: min

--- a/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
+++ b/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
@@ -69,7 +69,6 @@ secondary_entities:
             value: "6h"
   - entity: sensor
     name: "Timer Remaining"
-    readonly: true
     dps:
     - id: 20
       type: integer

--- a/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
+++ b/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
@@ -1,0 +1,79 @@
+name: Kogan KASMGPH Series Heater
+products:
+  - id: 9l3riftrq9acjunt
+    name: Kogan KASMGPH15YA Premium Glass Panel Heater
+primary_entity:
+  entity: climate
+  name: "Climate"
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: true
+          value: "heat"
+        - dps_val: false
+          value: "off"
+    - id: 5
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: Low
+          value: eco
+        - dps_val: High
+          value: boost
+    - id: 2
+      name: temperature
+      type: integer
+      unit: C
+      range:
+        min: 5
+        max: 45
+    - id: 3
+      name: current_temperature
+      type: integer
+secondary_entities:
+  - entity: switch
+    name: "Night Mode"
+    dps:
+    - id: 6
+      type: boolean
+      name: switch
+  - entity: lock
+    name: "Child Lock"
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+  - entity: select
+    name: "Timer"
+    dps:
+      - id: 19
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: cancel
+            value: "Timer Off"
+          - dps_val: "1h"
+            value: "1h"
+          - dps_val: "2h"
+            value: "2h"
+          - dps_val: "3h"
+            value: "3h"
+          - dps_val: "4h"
+            value: "4h"
+          - dps_val: "5h"
+            value: "5h"
+          - dps_val: "6h"
+            value: "6h"
+  - entity: sensor
+    name: "Timer Remaining"
+    readonly: true
+    dps:
+    - id: 20
+      type: integer
+      name: sensor
+      class: measurement
+      optional: true
+      unit: "minutes"

--- a/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
+++ b/custom_components/tuya_local/devices/kogan_kasmgphXXXX_heater.yaml
@@ -36,9 +36,9 @@ secondary_entities:
   - entity: switch
     name: "Night Mode"
     dps:
-    - id: 6
-      type: boolean
-      name: switch
+      - id: 6
+        type: boolean
+        name: switch
   - entity: lock
     name: "Child Lock"
     dps:
@@ -70,9 +70,9 @@ secondary_entities:
   - entity: sensor
     name: "Timer Remaining"
     dps:
-    - id: 20
-      type: integer
-      name: sensor
-      class: measurement
-      optional: true
-      unit: "minutes"
+      - id: 20
+        type: integer
+        name: sensor
+        class: measurement
+        optional: true
+        unit: "minutes"


### PR DESCRIPTION
Add support for the white 1.5kw Kogan Smarterhome KASMGPH15YA. This is tested and working on KASMGPH15YA.

While I have not tested, since the user guide appears to be the same for all the series, this would likely work with all KASMGPH series heaters. E.g.

1.5kw - KASMGPH15YA (White) and KASMGPH15YB (Black) 
2.0kw - KASMGPH20YA (White) and KASMGPH20YB (Black) 
2.4kw - KASMGPH24YA (White) and KASMGPH24YB (Black)
