### PR TITLE
Add support for Sulion Cadillac Fan RF Controller

### DIFF
--- a/custom_components/tuya_local/devices/sulion_ceiling_fan_remote.yaml
+++ b/custom_components/tuya_local/devices/sulion_ceiling_fan_remote.yaml
@@ -1,0 +1,22 @@
+name: Ceiling fan remote
+products:
+  - id: 0000008sff
+    name: Sulion Cadillac Fan Controller
+primary_entity:
+  entity: fan
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 3
+      type: integer
+      name: speed
+      range:
+        min: 1
+        max: 3
+secondary_entities:
+  - entity: light
+    dps:
+      - id: 15
+        type: boolean
+        name: switch


### PR DESCRIPTION
This is a subdevice of RF Hub "bf72a4a8fc742e40463nrg".
 
Output from tinytuya:

`    {
        "name": "Fan Light1",
        "id": "bfed41b494f0c79545dyfu",
        "key": "",
        "mac": "",
        "category": "rf_fan_light",
        "product_name": "\u98ce\u6247\u706f",
        "product_id": "0000008sff",
        "biz_type": 0,
        "model": "",
        "sub": true,
        "icon": "https://images.tuyaeu.com/smart/ir/icon/auix2zax7280.png",
        "uuid": "",
        "node_id": "458a9f103144d423",
        "mapping": {},
        "parent": "bf72a4a8fc742e40463nrg",
        "ip": "",
        "version": ""
    },
`