### PR TITLE
Add support for Energy Monitor 2 Gang Switch Module (LoraTap RR620W-JL)

### DIFF
--- a/custom_components/tuya_local/devices/energy_monitor_2gang_switch.yaml
+++ b/custom_components/tuya_local/devices/energy_monitor_2gang_switch.yaml
@@ -1,0 +1,124 @@
+name: Energy Monitor 2 Gang Switch Module
+products:
+  - id: keyjnuy4s3kre7m7
+    name: LoraTap RR620W-JL
+primary_entity:
+  entity: switch
+  name: Switch 1
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 42
+      name: random_time
+      type: string
+    - id: 43
+      name: cycle_time
+      type: string
+secondary_entities:
+  - entity: switch
+    name: Switch 2
+    dps:
+      - id: 2
+        name: switch
+        type: boolean
+  - entity: number
+    name: Timer 1
+    translation_key: timer
+    category: config
+    dps:
+      - id: 9
+        name: value
+        type: integer
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    name: Timer 2
+    translation_key: timer
+    category: config
+    dps:
+      - id: 10
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: select
+    translation_key: initial_state
+    category: config
+    dps:
+      - id: 38
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "on"
+          - dps_val: "2"
+            value: memory
+  - entity: select
+    name: Switch type
+    icon: "mdi:toggle-switch"
+    category: config
+    dps:
+      - id: 47
+        type: string
+        name: option
+        mapping:
+          - dps_val: flip
+            value: Flip
+          - dps_val: sync
+            value: Synchronized
+          - dps_val: button
+            value: Button
+  - entity: sensor
+    name: Energy
+    category: diagnostic
+    dps:
+      - id: 20
+        name: sensor
+        type: integer
+        optional: true
+        unit: Wh
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 21
+        name: sensor
+        type: integer
+        class: measurement
+        force: true
+        unit: mA
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 22
+        name: sensor
+        type: integer
+        class: measurement
+        force: true
+        unit: W
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 23
+        name: sensor
+        type: integer
+        force: true
+        class: measurement
+        unit: V
+        mapping:
+          - scale: 10

--- a/custom_components/tuya_local/devices/loratap_dual_switch.yaml
+++ b/custom_components/tuya_local/devices/loratap_dual_switch.yaml
@@ -36,7 +36,8 @@ secondary_entities:
         type: string
       - id: 43
         name: cycle_time
-        type: string  - entity: number
+        type: string
+  - entity: number
     name: Timer 2
     translation_key: timer
     category: config

--- a/custom_components/tuya_local/devices/loratap_dual_switch.yaml
+++ b/custom_components/tuya_local/devices/loratap_dual_switch.yaml
@@ -1,4 +1,4 @@
-name: Energy Monitor 2 Gang Switch Module
+name: Dual switch
 products:
   - id: keyjnuy4s3kre7m7
     name: LoraTap RR620W-JL
@@ -9,12 +9,6 @@ primary_entity:
     - id: 1
       name: switch
       type: boolean
-    - id: 42
-      name: random_time
-      type: string
-    - id: 43
-      name: cycle_time
-      type: string
 secondary_entities:
   - entity: switch
     name: Switch 2
@@ -30,13 +24,19 @@ secondary_entities:
       - id: 9
         name: value
         type: integer
+        unit: min
         range:
           min: 0
           max: 86400
         mapping:
           - scale: 60
             step: 60
-  - entity: number
+      - id: 42
+        name: random_time
+        type: string
+      - id: 43
+        name: cycle_time
+        type: string  - entity: number
     name: Timer 2
     translation_key: timer
     category: config
@@ -44,6 +44,7 @@ secondary_entities:
       - id: 10
         type: integer
         name: value
+        unit: min
         range:
           min: 0
           max: 86400
@@ -87,7 +88,9 @@ secondary_entities:
         name: sensor
         type: integer
         optional: true
-        unit: Wh
+        unit: kWh
+        mapping:
+          - scale: 1000
   - entity: sensor
     class: current
     category: diagnostic
@@ -96,6 +99,7 @@ secondary_entities:
         name: sensor
         type: integer
         class: measurement
+        optional: true
         force: true
         unit: mA
   - entity: sensor
@@ -106,6 +110,7 @@ secondary_entities:
         name: sensor
         type: integer
         class: measurement
+        optional: true
         force: true
         unit: W
         mapping:
@@ -117,6 +122,7 @@ secondary_entities:
       - id: 23
         name: sensor
         type: integer
+        optional: true
         force: true
         class: measurement
         unit: V


### PR DESCRIPTION
https://www.loratap.com/products/rr500w-jl (2 gang option)

https://www.youtube.com/watch?v=HL5wZadPwSE

Sold on AliExpress: https://www.aliexpress.com/item/1005004319518692.html

Generic looking dps, I combined the yaml from single energy monitor relay and dual relay switch and verified all the dps on Tuya IoT developer portal