### PR TITLE
Update faroro_pet_feeder.yaml

### DIFF
--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -12,6 +12,7 @@ primary_entity:
       name: value
       type: integer
       persist: false
+      optional: true
       range:
         min: 1
         max: 12


### PR DESCRIPTION
Corrected value - upon reinstallation this dp had to be set to optional for the device to be recognized.