### PR TITLE
Plantsio Ivy: add missing enums

### DIFF
--- a/custom_components/tuya_local/devices/plantsio_ivy_smart_planter.yaml
+++ b/custom_components/tuya_local/devices/plantsio_ivy_smart_planter.yaml
@@ -70,10 +70,16 @@ secondary_entities:
         mapping:
           - dps_val: 0
             value: "Initializing"
+          - dps_val: 1
+            value: "Analyzing"
           - dps_val: 2
             value: "Drinking"
           - dps_val: 3
             value: "Absorbing from soil"
+          - dps_val: 4
+            value: "Thirsty"
+          - dps_val: 5
+            value: "Dehydrated"
           - value: "Unknown state"
   - entity: sensor
     name: Light status
@@ -96,6 +102,8 @@ secondary_entities:
             value: "Too Much"
           - dps_val: 5
             value: "Insufficient"
+          - dps_val: 6
+            value: "Manual mode"
           - value: "Unknown state"
   - entity: sensor
     name: Temperature status
@@ -130,6 +138,8 @@ secondary_entities:
             value: "Initializing"
           - dps_val: 1
             value: "Good"
+          - dps_val: 2
+            value: "Too Dry"
           - value: "Unknown state"
   # Diagnostic entities
   - entity: sensor


### PR DESCRIPTION
In my original PR (#2069) I did not know all the different states mapped to the dps values.

I reached out to the developers and they shared all the mappings with me. I also tested to verify them for the conditions I could replicate.

I don't expect this to be my last commit, as there are still issues with the display (as outlined in https://github.com/make-all/tuya-local/discussions/2168) and want to get touch sensors to work as button so I can use them to trigger automatons. However I have been sitting on this change for a while now, I wanted to get it out.