### PR TITLE
Add support for Solar Inverter GTB series

### DIFF
--- a/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
+++ b/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
@@ -1,7 +1,7 @@
-name: Solar Inverter GTB Series
+name: Solar inverter
 products:
   - id: czu7ynosrkxgbnsb
-    name: GTB Series
+    name: Solar Grid GTB Series
 primary_entity:
   entity: sensor
   class: energy
@@ -28,7 +28,6 @@ secondary_entities:
         type: integer
         name: sensor
         unit: W
-        force: true
         class: measurement
   - entity: sensor
     class: temperature
@@ -38,7 +37,6 @@ secondary_entities:
         type: integer
         name: sensor
         unit: C
-        force: true
         class: measurement
         mapping:
           - scale: 10

--- a/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
+++ b/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
@@ -1,0 +1,161 @@
+name: Smart Inverter GTB Series
+products:
+  - id: bf27badb1abd9bfc5beeuq
+    name: GTB Series
+primary_entity:
+  entity: sensor
+  class: energy
+  dps:
+    - id: 2
+      type: integer
+      name: sensor
+      unit: kWh
+      class: total_increasing
+      mapping:
+        - scale: 100
+    - id: 15
+      name: model
+      type: string
+    - id: 16
+      name: inverter_id
+      type: string
+secondary_entities:
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        unit: W
+        force: true
+        class: measurement
+        mapping:
+          - scale: 1
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: C
+        force: true
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: DC voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 3
+        type: base64
+        name: sensor
+        unit: V
+        optional: true
+        persist: true
+        force: true
+        class: measurement
+        mapping:
+          - mask: "FFFF00000000"
+            scale: 10
+  - entity: sensor
+    name: DC current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 3
+        type: base64
+        name: sensor
+        unit: A
+        optional: true
+        persist: true
+        class: measurement
+        mapping:
+          - mask: "0000FFFF0000"
+            scale: 10
+  - entity: sensor
+    name: DC power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 3
+        type: base64
+        name: sensor
+        unit: W
+        optional: true
+        persist: true
+        class: measurement
+        mapping:
+          - mask: "00000000FFFF"
+            scale: 0.1
+  - entity: sensor
+    name: AC voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        unit: V
+        optional: true
+        persist: true
+        force: true
+        class: measurement
+        mapping:
+          - mask: "FFFF0000000000000000"
+            scale: 10
+  - entity: sensor
+    name: AC current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        unit: A
+        optional: true
+        persist: true
+        class: measurement
+        mapping:
+          - mask: "0000FFFFFF0000000000"
+            scale: 1000
+  - entity: sensor
+    name: AC power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        unit: W
+        optional: true
+        persist: true
+        class: measurement
+        mapping:
+          - mask: "0000000000FFFFFF0000"
+            scale: 1
+  - entity: sensor
+    name: AC frequency
+    class: frequency
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        unit: Hz
+        optional: true
+        persist: true
+        class: measurement
+        mapping:
+          - mask: "0000000000000000FFFF"
+            scale: 10
+  - entity: switch
+    name: Inverter switch
+    category: config
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+        optional: true

--- a/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
+++ b/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
@@ -1,6 +1,6 @@
 name: Smart Inverter GTB Series
 products:
-  - id: bf27badb1abd9bfc5beeuq
+  - id: czu7ynosrkxgbnsb
     name: GTB Series
 primary_entity:
   entity: sensor
@@ -54,7 +54,6 @@ secondary_entities:
         name: sensor
         unit: V
         optional: true
-        persist: true
         force: true
         class: measurement
         mapping:
@@ -70,7 +69,6 @@ secondary_entities:
         name: sensor
         unit: A
         optional: true
-        persist: true
         class: measurement
         mapping:
           - mask: "0000FFFF0000"
@@ -85,7 +83,6 @@ secondary_entities:
         name: sensor
         unit: W
         optional: true
-        persist: true
         class: measurement
         mapping:
           - mask: "00000000FFFF"
@@ -100,7 +97,6 @@ secondary_entities:
         name: sensor
         unit: V
         optional: true
-        persist: true
         force: true
         class: measurement
         mapping:
@@ -116,7 +112,6 @@ secondary_entities:
         name: sensor
         unit: A
         optional: true
-        persist: true
         class: measurement
         mapping:
           - mask: "0000FFFFFF0000000000"
@@ -131,7 +126,6 @@ secondary_entities:
         name: sensor
         unit: W
         optional: true
-        persist: true
         class: measurement
         mapping:
           - mask: "0000000000FFFFFF0000"
@@ -146,7 +140,6 @@ secondary_entities:
         name: sensor
         unit: Hz
         optional: true
-        persist: true
         class: measurement
         mapping:
           - mask: "0000000000000000FFFF"

--- a/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
+++ b/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
@@ -1,4 +1,4 @@
-name: Smart Inverter GTB Series
+name: Solar Inverter GTB Series
 products:
   - id: czu7ynosrkxgbnsb
     name: GTB Series
@@ -30,8 +30,6 @@ secondary_entities:
         unit: W
         force: true
         class: measurement
-        mapping:
-          - scale: 1
   - entity: sensor
     class: temperature
     category: diagnostic
@@ -129,7 +127,6 @@ secondary_entities:
         class: measurement
         mapping:
           - mask: "0000000000FFFFFF0000"
-            scale: 1
   - entity: sensor
     name: AC frequency
     class: frequency
@@ -145,7 +142,6 @@ secondary_entities:
           - mask: "0000000000000000FFFF"
             scale: 10
   - entity: switch
-    name: Inverter switch
     category: config
     dps:
       - id: 101


### PR DESCRIPTION
# Product name:
Smart GTB-800 PV Micro inverter

# Product id:
bf27badb1abd9bfc5beeuq

# Where to buy:
https://www.aliexpress.com/item/1005007385290819.html

# Also known as:
Solar Grid, and with models GTB-300 GTB-350 GTB-400 GTB-500 GTB-600 GTB-700 GTB-800 etc up to GTB-2000

Data values for AC and DC current/voltage/power and frequency cannot be asked for. Must wait for them to be sent by the device when a value changes. DC values use dp:3 AC values use dp:7 and are base 64 encoded range of bytes. Other data is the same as most other solar inverters.

![image](https://github.com/user-attachments/assets/886ed231-749d-4f23-8833-2a941d004d14)

Pull request created after dark so energy readings showing 0...

