### PR TITLE
Add support for KCvents VT-501, Heat Recovery Ventilator

### DIFF
--- a/custom_components/tuya_local/devices/kcvents_vt501_fan.yaml
+++ b/custom_components/tuya_local/devices/kcvents_vt501_fan.yaml
@@ -1,0 +1,139 @@
+name: Heat Recovery Ventilator
+products:
+  - id: 5p0togo3y3yzgp2p
+    name: KCvents VT-501
+primary_entity:
+  entity: fan
+  translation_only_key: ventilation
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 101
+      type: boolean
+      name: speed
+      mapping:
+        - dps_val: true
+          value: 33
+        - dps_val: dummy_speed1
+          value: 66
+          value_redirect: speed2
+        - dps_val: dummy_speed2
+          value: 100
+          value_redirect: speed3
+        - dps_val: false
+          value_redirect: speed2
+    - id: 102
+      type: boolean
+      name: speed2
+      mapping:
+        - dps_val: true
+          value: 66
+        - dps_val: false
+          value_redirect: speed3
+      hidden: true
+    - id: 103
+      type: boolean
+      name: speed3
+      mapping:
+        - dps_val: true
+          value: 100
+        - dps_val: false
+          value: 0
+      hidden: true
+    - id: 105
+      type: boolean
+      name: preset_mode
+      mapping:
+        - dps_val: true
+          value: "Low Humidity"
+        - dps_val: dummy_mode1
+          value: "Medium Humidity"
+          value_redirect: preset_mode1
+        - dps_val: dummy_mode2
+          value: "High Humidity"
+          value_redirect: preset_mode2
+        - dps_val: dummy_mode3
+          value: fresh
+          value_redirect: preset_mode3
+        - dps_val: dummy_mode4
+          value: anti-condensation
+          value_redirect: preset_mode4
+        - dps_val: dummy_mode5
+          value: circulate
+          value_redirect: preset_mode5
+        - dps_val: false
+          value_redirect: preset_mode1
+    - id: 106
+      type: boolean
+      name: preset_mode1
+      mapping:
+        - dps_val: true
+          value: "Medium Humidity"
+        - dps_val: false
+          value_redirect: preset_mode2
+      hidden: true
+    - id: 107
+      type: boolean
+      name: preset_mode2
+      mapping:
+        - dps_val: true
+          value: "High Humidity"
+        - dps_val: false
+          value_redirect: preset_mode3
+      hidden: true
+    - id: 111
+      type: boolean
+      name: preset_mode3
+      mapping:
+        - dps_val: true
+          value: fresh
+        - dps_val: false
+          value_redirect: preset_mode4
+      hidden: true
+    - id: 112
+      type: boolean
+      name: preset_mode4
+      mapping:
+        - dps_val: true
+          value: anti-condensation
+        - dps_val: false
+          value_redirect: preset_mode5
+      hidden: true
+    - id: 113
+      type: boolean
+      name: preset_mode5
+      mapping:
+        - dps_val: true
+          value: circulate
+        - dps_val: false
+          value: NONE
+      hidden: true
+secondary_entities:
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: switch
+    translation_key: sleep
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        name: switch


### PR DESCRIPTION
Add support for KCvents VT-501, Heat Recovery Ventilator and closes #1349 

### Log message
`Device matches garage_door_opener with quality of 15%. DPS: {"updated_at": 1728842575.9640048, "1": true, "101": true, "102": false, "103": false, "104": false, "105": false, "106": false, "107": false, "108": 581, "109": 243, "111": false, "112": true, "113": false}`

### DPS information
```{
  "result": {
    "model": "{\"modelId\":\"00000338x2\",\"services\":[{\"actions\":[],\"code\":\"\",\"description\":\"\",\"events\":[],\"name\":\"默认服务\",\"properties\":[
{\"abilityId\":1,\"accessMode\":\"rw\",\"code\":\"switch\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_power2\"},\"name\":\"ON/OFF\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":101,\"accessMode\":\"rw\",\"code\":\"speed_one\",\"description\":\"\",\"name\":\"Low Speed\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":102,\"accessMode\":\"rw\",\"code\":\"speed_two\",\"description\":\"\",\"name\":\"Medium Speed\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":103,\"accessMode\":\"rw\",\"code\":\"speed_three\",\"description\":\"\",\"name\":\"High Speed\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":104,\"accessMode\":\"rw\",\"code\":\"sleep_mode\",\"description\":\"\",\"name\":\"Sleep mode\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":105,\"accessMode\":\"rw\",\"code\":\"huimidity_one\",\"description\":\"\",\"name\":\"Low Humidity\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":106,\"accessMode\":\"rw\",\"code\":\"huimidity_two\",\"description\":\"\",\"name\":\"Medium Humidity\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":107,\"accessMode\":\"rw\",\"code\":\"huimidity_three\",\"description\":\"\",\"name\":\"High Humidity\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":108,\"accessMode\":\"ro\",\"code\":\"huimi\",\"description\":\"\",\"name\":\"humidity\",\"typeSpec\":{\"type\":\"value\",\"max\":10000,\"min\":0,\"scale\":1,\"step\":1,\"unit\":\"\"}},
{\"abilityId\":109,\"accessMode\":\"ro\",\"code\":\"temper\",\"description\":\"\",\"name\":\"temperature\",\"typeSpec\":{\"type\":\"value\",\"max\":10000,\"min\":0,\"scale\":1,\"step\":1,\"unit\":\"\"}},
{\"abilityId\":111,\"accessMode\":\"rw\",\"code\":\"in_mode\",\"description\":\"\",\"name\":\"Fresh Air Mode\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":112,\"accessMode\":\"rw\",\"code\":\"out_mode\",\"description\":\"\",\"name\":\"Exhausted Air Mode\",\"typeSpec\":{\"type\":\"bool\"}},
{\"abilityId\":113,\"accessMode\":\"rw\",\"code\":\"auto_mode\",\"description\":\"\",\"name\":\"Regenerate Mode\",\"typeSpec\":{\"type\":\"bool\"}}]}]}"
  },
  "success": true,
  "t": 1728842662832,
  "tid": "93605583898d11efb77736033862a1ba"
}
```

### Product ID
5p0togo3y3yzgp2p

### Product Name
KCvents VT-501 / Single-room HRV VT501

### Information where to buy
- https://www.aliexpress.com/item/1005004163682971.html

### Manufacturer product page
- https://www.kcvents.com/portfolio-item/single-room-heat-recovery-units-vt501

### Screenshots
![Screenshot 2024-11-03 114652](https://github.com/user-attachments/assets/9d21c55f-2174-45ba-aa39-9e202067656e)
![Screenshot 2024-11-03 114740](https://github.com/user-attachments/assets/452e5a3f-8173-45c9-8c7e-6738bd3cb815)

### Known flaw:
With fan.turn_on and fan.turn_off the state reverses instead of the state going to the correct value. I haven't had time to find out if this is a general problem with fans or only with this device. However, since the device beeps every time the state changes, it is better to first check the state in an automation and only transmit state changes.
