### PR TITLE
Fix Afyeev 16A EV charger product ID and power sensor

### DIFF
--- a/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
@@ -1,0 +1,199 @@
+name: EV charger
+products:
+  - id: "bfda6008360ed3949fleb0"
+    name: "Afyeev 16A EV Charger"
+primary_entity:
+  entity: sensor
+  name: Charger State
+  icon: "mdi:ev-station"
+  class: enum
+  dps:
+    - id: 3
+      type: string
+      name: sensor
+      mapping:
+        - dps_val: charger_charging
+          value: Charging
+        - dps_val: charger_free
+          value: Available
+        - dps_val: charger_insert
+          value: Plugged in
+        - dps_val: charger_free_fault
+          value: Fault
+        - dps_val: charger_wait
+          value: Delaying
+        - dps_val: charger_pause
+          value: Paused
+        - dps_val: charger_end
+          value: Charged
+        - dps_val: charger_fault
+          value: Fault (plugged in)
+    - id: 23
+      type: string
+      name: system_version
+secondary_entities:
+  - entity: sensor
+    name: Total Forward Energy
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        optional: true
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Charging current
+    category: config
+    class: current
+    icon: "mdi:ev-plug-type2"
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: A
+        range:
+          min: 6
+          max: 16
+  - entity: sensor
+    name: Phase A Voltage
+    class: voltage
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mapping:
+          - mask: "FFFF000000000000"
+            scale: 10
+  - entity: sensor
+    name: Phase A Current
+    class: current
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mapping:
+          - mask: "000000FFFF000000"
+            scale: 1000
+  - entity: sensor
+    name: Phase A Power
+    class: power
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mapping:
+          - mask: "000000000000FFFF"
+            scale: 1000
+  - entity: sensor
+    class: power
+    category: sensor
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 1000
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10
+        type: bitfield
+        name: fault_code
+  - entity: select
+    name: Charging mode
+    icon: "mdi:ev-station"
+    category: config
+    dps:
+      - id: 14
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: Charge now
+          - dps_val: charge_pct
+            value: Charge PCT
+          - dps_val: charge_energy
+            value: Charge energy
+          - dps_val: charge_schedule
+            value: Charge schedule
+          - dps_val: charge_delay
+            value: Charge delay
+  - entity: switch
+    icon: "mdi:ev-station"
+    dps:
+      - id: 18
+        type: boolean
+        name: switch
+  - entity: sensor
+    class: temperature
+    name: Temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        unit: °C
+        class: measurement
+        mapping:
+          - scale: 1
+  - entity: sensor
+    name: Last charge energy
+    class: energy
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
+        unit: kWh
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 100
+  - entity: sensor
+    class: enum
+    name: Online state
+    icon: "mdi:wifi"
+    category: diagnostic
+    dps:
+      - id: 27
+        optional: true
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: offline
+            value: Offline
+          - dps_val: online
+            value: Online
+  - entity: number
+    name: Timer
+    category: config
+    icon: "mdi:car-clock"
+    dps:
+      - id: 28
+        type: integer
+        name: value
+        unit: h
+        optional: true
+        range:
+          min: 0
+          max: 15

--- a/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
@@ -95,7 +95,6 @@ secondary_entities:
             scale: 1000
   - entity: sensor
     class: power
-    category: sensor
     dps:
       - id: 9
         type: integer

--- a/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
@@ -1,7 +1,7 @@
 name: EV charger
-products:
-  - id: "bfda6008360ed3949fleb0"
-    name: "Afyeev 16A EV Charger"
+# products:
+#   - id: UNKNOWN
+#     name: "Afyeev 16A EV Charger"
 primary_entity:
   entity: sensor
   name: Charger State
@@ -33,7 +33,6 @@ primary_entity:
       name: system_version
 secondary_entities:
   - entity: sensor
-    name: Total Forward Energy
     class: energy
     dps:
       - id: 1
@@ -58,7 +57,6 @@ secondary_entities:
           min: 6
           max: 16
   - entity: sensor
-    name: Phase A Voltage
     class: voltage
     dps:
       - id: 6
@@ -70,7 +68,6 @@ secondary_entities:
           - mask: "FFFF000000000000"
             scale: 10
   - entity: sensor
-    name: Phase A Current
     class: current
     dps:
       - id: 6
@@ -80,18 +77,6 @@ secondary_entities:
         unit: A
         mapping:
           - mask: "000000FFFF000000"
-            scale: 1000
-  - entity: sensor
-    name: Phase A Power
-    class: power
-    dps:
-      - id: 6
-        type: base64
-        name: sensor
-        optional: true
-        unit: kW
-        mapping:
-          - mask: "000000000000FFFF"
             scale: 1000
   - entity: sensor
     class: power
@@ -104,6 +89,15 @@ secondary_entities:
         optional: true
         mapping:
           - scale: 1000
+          - dps_val: null
+            value_redirect: phase_a
+      - id: 6
+        type: base64
+        name: phase_a
+        optional: true
+        mapping:
+          - mask: "000000000000FFFF"
+            scale: 1000
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -146,7 +140,6 @@ secondary_entities:
         name: switch
   - entity: sensor
     class: temperature
-    name: Temperature
     category: diagnostic
     dps:
       - id: 24
@@ -157,8 +150,7 @@ secondary_entities:
         mapping:
           - scale: 1
   - entity: sensor
-    name: Last charge energy
-    class: energy
+    name: Last charge
     dps:
       - id: 25
         type: integer
@@ -168,10 +160,8 @@ secondary_entities:
         optional: true
         mapping:
           - scale: 100
-  - entity: sensor
-    class: enum
-    name: Online state
-    icon: "mdi:wifi"
+  - entity: binary_sensor
+    class: connectivity
     category: diagnostic
     dps:
       - id: 27
@@ -180,13 +170,12 @@ secondary_entities:
         name: sensor
         mapping:
           - dps_val: offline
-            value: Offline
+            value: false
           - dps_val: online
-            value: Online
+            value: true
   - entity: number
-    name: Timer
+    translation_key: timer
     category: config
-    icon: "mdi:car-clock"
     dps:
       - id: 28
         type: integer

--- a/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_16a_evcharger.yaml
@@ -1,7 +1,7 @@
 name: EV charger
-# products:
-#   - id: UNKNOWN
-#     name: "Afyeev 16A EV Charger"
+products:
+  - id: "dsmsam7xpb3ht7rl"
+    name: "Afyeev 16A EV Charger"
 primary_entity:
   entity: sensor
   name: Charger State
@@ -81,20 +81,11 @@ secondary_entities:
   - entity: sensor
     class: power
     dps:
-      - id: 9
-        type: integer
-        name: sensor
-        unit: kW
-        class: measurement
-        optional: true
-        mapping:
-          - scale: 1000
-          - dps_val: null
-            value_redirect: phase_a
       - id: 6
         type: base64
-        name: phase_a
+        name: sensor
         optional: true
+        unit: kW
         mapping:
           - mask: "000000000000FFFF"
             scale: 1000


### PR DESCRIPTION
With the recent update on tuya-local it was easy to include the product id. Thanks!

The power sensor wasn't working with the previous solution. It was 0 with a Phase A attribute with the actual sensor value from DP 6.
DP 9 is probably some kind of aggregated power value for 3-phase chargers, but it is always 0 according to my experience with my 1-phase device, so I promoted DP6 power value to first level.