### PR TITLE
Create vta+_fan_heater

### DIFF
--- a/custom_components/tuya_local/devices/vta+_fan_heater
+++ b/custom_components/tuya_local/devices/vta+_fan_heater
@@ -1,0 +1,78 @@
+name: Fan heater
+products:
+  - id: ebcb3fda096d331d27h8yc
+    name: VTA+ AXIAL Fan Heater
+primary_entity:
+  entity: climate
+  translation_only_key: heater
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          constraint: preset_mode
+          conditions:
+            - dps_val: "null"
+              value: fan_only
+            - dps_val: "level_1"
+              value: fan_only
+            - dps_val: "level_2"
+              value: heat
+            - dps_val: "level_3"
+              value: heat
+    - id: 5
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: "level_1"
+          value: none
+          hidden: true
+        - dps_val: "level_2"
+          value: eco
+        - dps_val: "level_3"
+          value: boost
+    - id: 8
+      type: boolean
+      name: swing_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: "on"
+secondary_entities:
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        name: lock
+        type: boolean
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: "cancel"
+            value: cancel
+          - dps_val: "1h"
+            value: "1h"
+          - dps_val: "2h"
+            value: "2h"
+          - dps_val: "4h"
+            value: "4h"
+          - dps_val: "8h"
+            value: "8h"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: min

--- a/custom_components/tuya_local/devices/vta+_fan_heater
+++ b/custom_components/tuya_local/devices/vta+_fan_heater
@@ -17,6 +17,7 @@ primary_entity:
           conditions:
             - dps_val: "null"
               value: fan_only
+              hidden: true
             - dps_val: "level_1"
               value: fan_only
             - dps_val: "level_2"

--- a/custom_components/tuya_local/devices/vtaplus_axial_fanheater
+++ b/custom_components/tuya_local/devices/vtaplus_axial_fanheater
@@ -1,7 +1,7 @@
 name: Fan heater
-products:
-  - id: ebcb3fda096d331d27h8yc
-    name: VTA+ AXIAL Fan Heater
+# products:
+#   - id: UNKNOWN
+#     name: VTA+ AXIAL Fan Heater
 primary_entity:
   entity: climate
   translation_only_key: heater


### PR DESCRIPTION
This creates a new device that wasn't recognised and i tested fully creating a local .yaml file on the divices folder via Studio Code Server. I took inspiration from the nedis_ptc_fan_heater.yaml, but that device has much more functions and dps not marked as optionals, so it wouldn't recognise my device. That Fan heater has a great feature that use constraints the hvac_mode with preset_mode, so the fan only option that is reported as preset, now works as a hvac_mode. I also improved the code by adding a "null" dps_val on the hvac_mode conditions, using the documentation of the integration, which previously reported momentarily an error when selecting this "custom" hvac_mode. I also found an error on the nedis_ptc .yaml timer values, that i intend to correct in another pull request.

This is the QueryThingsDataModel API result for your inspection:

 "model": "{\"modelId\":\"e6kcdc\",\"services\":[{\"actions\":[],\"code\":\"\",\"description\":\"\",\"events\":[],\"name\":\"默认服务\",\"properties\":[{\"abilityId\":1,\"accessMode\":\"rw\",\"code\":\"switch\",\"description\":\"\",\"name\":\"开关\",\"typeSpec\":{\"type\":\"bool\"}},{\"abilityId\":5,\"accessMode\":\"rw\",\"code\":\"level\",\"description\":\"\",\"name\":\"档位\",\"typeSpec\":{\"type\":\"enum\",\"range\":[\"level_1\",\"level_2\",\"level_3\"]}},{\"abilityId\":7,\"accessMode\":\"rw\",\"code\":\"child_lock\",\"description\":\"\",\"name\":\"童锁\",\"typeSpec\":{\"type\":\"bool\"}},{\"abilityId\":8,\"accessMode\":\"rw\",\"code\":\"shake\",\"description\":\"\",\"name\":\"摇头\",\"typeSpec\":{\"type\":\"bool\"}},{\"abilityId\":19,\"accessMode\":\"rw\",\"code\":\"countdown_set\",\"description\":\"\",\"name\":\"倒计时\",\"typeSpec\":{\"type\":\"enum\",\"range\":[\"cancel\",\"1h\",\"2h\",\"4h\",\"8H\"]}},{\"abilityId\":20,\"accessMode\":\"ro\",\"code\":\"countdown_left\",\"description\":\"\",\"name\":\"倒计时剩余时间\",\"typeSpec\":{\"type\":\"value\",\"max\":480,\"min\":0,\"scale\":0,\"step\":1,\"unit\":\"min\"}}]}]}"
  },

Thanks