### PR TITLE
A1 smart lock: Set optional DPs

### DIFF
--- a/custom_components/tuya_local/devices/raykube_a1promax_lock.yaml
+++ b/custom_components/tuya_local/devices/raykube_a1promax_lock.yaml
@@ -127,6 +127,7 @@ secondary_entities:
       - id: 33
         type: boolean
         name: switch
+        optional: true
   - entity: number
     name: Auto lock time
     category: config
@@ -139,6 +140,7 @@ secondary_entities:
         range:
           min: 1
           max: 1800
+        optional: true
   - entity: button
     name: Sync clock
     icon: "mdi:clock"


### PR DESCRIPTION
In my device, DPs 33 and 36 are not set by default, and the device can work without setting them.