### PR TITLE
Added support for Myuet ME82 thermostat

### DIFF
--- a/custom_components/tuya_local/devices/myuet_me82_thermostat.yaml
+++ b/custom_components/tuya_local/devices/myuet_me82_thermostat.yaml
@@ -4,6 +4,7 @@ products:
     name: Myuet ME82
 primary_entity:
   entity: climate
+  translation_key: thermostat
   dps:
     - id: 1
       type: boolean
@@ -48,20 +49,15 @@ primary_entity:
           value: heating
         - dps_val: close
           value: idle
+    - id: 2
+      type: string
+      name: preset_mode
+      mapping:
+        - dps_val: auto
+          value: program
+        - dps_val: manual
+          value: manual
 secondary_entities:
-  - entity: select
-    name: Mode
-    icon: "mdi:thermostat-auto"
-    category: config
-    dps:
-      - id: 2
-        type: string
-        name: option
-        mapping:
-          - dps_val: auto
-            value: Auto
-          - dps_val: manual
-            value: Manual
   - entity: switch
     translation_key: anti_frost
     category: config
@@ -192,21 +188,23 @@ secondary_entities:
             value: Six working days
           - dps_val: "no_day_off"
             value: Daily
-  - entity: select
-    name: Backlight
-    icon: "mdi:lightbulb-on"
+  - entity: light
+    translation_key: backlight
     category: config
     dps:
       - id: 52
         type: string
         optional: true
-        name: option
+        name: brightness
         mapping:
           - dps_val: "closed"
-            value: Off
+            value: 0
           - dps_val: "20_bright"
-            value: 20%
+            value: 51
           - dps_val: "50_bright"
-            value: 50%
+            value: 128
           - dps_val: "100_bright"
-            value: 100%
+            value: 255
+          - dps_val: null
+            value: 0
+            hidden: true

--- a/custom_components/tuya_local/devices/myuet_me82_thermostat.yaml
+++ b/custom_components/tuya_local/devices/myuet_me82_thermostat.yaml
@@ -1,0 +1,215 @@
+name: Thermostat
+products:
+  - id: 7ingxzrs0wo9rqsd
+    name: Myuet ME82
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      type: boolean
+      name: hvac_mode
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: "heat"
+    - id: 16
+      type: integer
+      name: temperature
+      mapping:
+        - scale: 10
+          step: 5
+      unit: C
+      range:
+        min: 50
+        max: 700
+    - id: 19
+      type: integer
+      name: max_temperature
+      optional: true
+      mapping:
+        - scale: 10
+          step: 10
+    - id: 26
+      type: integer
+      name: min_temperature
+      optional: true
+      mapping:
+        - scale: 10
+          step: 10
+    - id: 24
+      type: integer
+      name: current_temperature
+      mapping:
+        - scale: 10
+          step: 5
+    - id: 36
+      type: string
+      name: hvac_action
+      mapping:
+        - dps_val: open
+          value: heating
+        - dps_val: close
+          value: idle
+secondary_entities:
+  - entity: select
+    name: Mode
+    icon: "mdi:thermostat-auto"
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: auto
+            value: Auto
+          - dps_val: manual
+            value: Manual
+  - entity: switch
+    translation_key: anti_frost
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: null
+            value: false
+            hidden: true
+  - entity: number
+    name: Maximum temperature
+    class: temperature
+    category: config
+    icon: "mdi:thermometer-chevron-up"
+    dps:
+      - id: 19
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - scale: 10
+            step: 10
+        range:
+          min: 200
+          max: 700
+  - entity: number
+    name: Minimum temperature
+    class: temperature
+    category: config
+    icon: "mdi:thermometer-chevron-down"
+    dps:
+      - id: 26
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - scale: 10
+            step: 10
+        range:
+          min: 50
+          max: 200
+  - entity: number
+    name: Temperature calibration
+    category: config
+    icon: "mdi:thermometer-check"
+    dps:
+      - id: 27
+        type: integer
+        optional: true
+        name: value
+        unit: °
+        range:
+          min: -9
+          max: 9
+  - entity: button
+    translation_key: factory_reset
+    category: config
+    dps:
+      - id: 39
+        type: boolean
+        name: button
+        optional: true
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 40
+        type: boolean
+        name: lock
+        optional: true
+        mapping:
+          - dps_val: null
+            value: false
+            hidden: true
+  - entity: select
+    name: Temperature sensor
+    icon: "mdi:home-thermometer"
+    category: config
+    dps:
+      - id: 43
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: in
+            value: Internal
+          - dps_val: out
+            value: External
+          - dps_val: both
+            value: Both
+          - dps_val: null
+            value: Internal
+            hidden: true
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 45
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 45
+        type: bitfield
+        name: fault_code
+  - entity: select
+    name: Program type
+    icon: "mdi:calendar-week"
+    category: config
+    dps:
+      - id: 104
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: Disabled
+          - dps_val: "weekend"
+            value: Weekend
+          - dps_val: "single_break"
+            value: Six working days
+          - dps_val: "no_day_off"
+            value: Daily
+  - entity: select
+    name: Backlight
+    icon: "mdi:lightbulb-on"
+    category: config
+    dps:
+      - id: 52
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "closed"
+            value: Off
+          - dps_val: "20_bright"
+            value: 20%
+          - dps_val: "50_bright"
+            value: 50%
+          - dps_val: "100_bright"
+            value: 100%

--- a/custom_components/tuya_local/devices/myuet_me82_thermostat.yaml
+++ b/custom_components/tuya_local/devices/myuet_me82_thermostat.yaml
@@ -29,20 +29,17 @@ primary_entity:
       optional: true
       mapping:
         - scale: 10
-          step: 10
     - id: 26
       type: integer
       name: min_temperature
       optional: true
       mapping:
         - scale: 10
-          step: 10
     - id: 24
       type: integer
       name: current_temperature
       mapping:
         - scale: 10
-          step: 5
     - id: 36
       type: string
       name: hvac_action


### PR DESCRIPTION
I bought a cheap WiFi thermostat on Amazon,thought it would be the ME81, turned out to be an "ME82(LED).03 WifFi" with isn't really supported by any integration. Because I liked yours the most, I added the necessary config :) Awesome work with your integration! Made the configuration so much easier.