### PR TITLE
TYTE-D1: Fix current temperature scaling when set to Fahrenheit

### DIFF
--- a/custom_components/tuya_local/devices/tyte_d1_thermostat.yaml
+++ b/custom_components/tuya_local/devices/tyte_d1_thermostat.yaml
@@ -79,6 +79,8 @@ primary_entity:
       type: integer
       name: current_temp_f
       hidden: true
+      mapping:
+        - scale: 10
 secondary_entities:
   - entity: number
     translation_key: timer


### PR DESCRIPTION
When the device is set to Fahrenheit, current temperature is shown incorrectly.  

This adds the missing scaling on it to correct that.