### PR TITLE
Update hydrotherm_dynamic_x8_water_heaterv6 Values to match Unit Manual

### DIFF
--- a/custom_components/tuya_local/devices/hydrotherm_dynamic_x8_water_heaterv6.yaml
+++ b/custom_components/tuya_local/devices/hydrotherm_dynamic_x8_water_heaterv6.yaml
@@ -19,11 +19,11 @@ primary_entity:
             - dps_val: ECO
               value: eco
             - dps_val: HYB
-              value: high_demand
+              value: Hybrid
             - dps_val: HYB1
-              value: performance
+              value: Hybrid+
             - dps_val: ELE
-              value: electric
+              value: Element
     - id: 2
       type: string
       name: mode


### PR DESCRIPTION
Hello,

Very minor tweak to the display values of each of the operating modes. This is to match what is actually in the manual located here on Page 29: https://www.hydrothermhotwatersystems.com.au/wp-content/uploads/2024/02/HYD_DYNAMIC_USER_MANUAL_WEB.pdf

Helps make sure you select the right value and you know what it actually does.