### PR TITLE
add no brand Smart Power Meter product ids

### DIFF
--- a/custom_components/tuya_local/devices/smartplugv2_energyv2.yaml
+++ b/custom_components/tuya_local/devices/smartplugv2_energyv2.yaml
@@ -4,6 +4,8 @@ products:
     name: Tongou TO-Q-SY1-JWT
   - id: w906qkrrhd3otiwd
     name: Moes ME322
+  - id: ncwuazeo5y1pujun
+    name: STY-63TM
 primary_entity:
   entity: switch
   class: outlet


### PR DESCRIPTION
I have two different type of smart energy meter from unknown brands with same product id, same profile as smartplugv2_energyv2

logs
```
2024-11-29 19:13:59.204 WARNING (MainThread) [custom_components.tuya_local.config_flow] Device matches smartplugv2_energyv2 with quality of 100%. DPS: {"updated_at": 1732887833.234286, "1": true, "9": 0, "17": 121, "18": 3505, "19": 7035, "20": 2345, "21": 1, "22": 16124, "23": 12432, "24": 3127, "25": 2683, "26": 0, "38": "memory", "40": "relay", "41": false, "42": ""}
2024-11-29 19:13:59.204 WARNING (MainThread) [custom_components.tuya_local.config_flow] Include the previous log messages with any new device request to https://github.com/make-all/tuya-local/issues/
```

pics
![sw2](https://github.com/user-attachments/assets/e85588b9-3ea1-4940-84f7-f7ddbf4ea8a0)
![sw1](https://github.com/user-attachments/assets/73b0d9a1-71b0-42ff-bc89-77ef11e3e2d9)

