### PR TITLE
Add support for Eurom Sani LBH-63A bathroom radiator

### DIFF
--- a/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
+++ b/custom_components/tuya_local/devices/eurom_sani_bathroom_towel_radiator.yaml
@@ -2,6 +2,8 @@ name: Bathroom radiator
 products:
   - id: bc6gdgt0cpq1jmjz
     name: Eurom Sani LBH-63
+  - id: 7pojgyvxlwa4igrm
+    name: Eurom Sani LBH-63A
 primary_entity:
   entity: climate
   translation_key: heater


### PR DESCRIPTION
Adds support for Eurom Sani LBH-63A bathroom radiator.

Product: Sani Bathroom Radiator 1000 Wifi Black

Seems identical in functionality to existing LBH-63 configuration.