### PR TITLE
fix missing .yaml, fix yaml parsing due to "step" in current temp, fix eco/comfort mode

### DIFF
--- a/custom_components/tuya_local/devices/friedrich_uct08b10a_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/friedrich_uct08b10a_airconditioner.yaml
@@ -53,7 +53,6 @@ primary_entity:
           conditions:
             - dps_val: c
               value_redirect: temperature_in_c
-　　　　　　　 step: 5
     - id: 2
       name: temperature_in_c
       type: integer
@@ -106,15 +105,18 @@ primary_entity:
     - id: 123
       name: preset_mode
       type: hex
-      mask: "0001"
       mapping:
+        - mask: "0001"
         - dps_val: 0
           value: comfort
+          mask: "0001"
         - dps_val: 1
           value: eco
+          mask: "0001"
         - dps_val: null
           value: comfort
           hidden: true
+          mask: "0001"
     - id: 128
       name: style
       type: string


### PR DESCRIPTION
**Note - I realized this was an issue after I updated to latest tuya-local. I suspect perhaps you kept the file non-yaml due to the issues below so feel free to delete this PR if you have other fixes in mind.**

Fixes for:
* missing .yaml extension
* yaml parsing due to "step" in current temp
* eco/comfort mode not being reflected in HA or controllable
