### PR TITLE
Add support for Lucci Connect fans 

### DIFF
--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -15,7 +15,7 @@ primary_entity:
         min: 1
         max: 3
 secondary_entities:
-  - entity: light
+  - entity: switch
     dps:
       - id: 102
         name: switch

--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -8,15 +8,13 @@ primary_entity:
   dps:
     - id: 1
       name: switch
-      type: boolean
-    
+      type: boolean  
     - id: 2
       name: speed
       type: integer
       range:
         min: 1
         max: 3
-
 secondary_entities:
   - entity: light
     dps:

--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -1,7 +1,7 @@
-name: Lucci Fan
+name: Ceiling Fan
 products:
   - id: U8wU126HQlIeQHvS
-    name: Lucci Fan
+    name: Lucci Connect WiFi Fan Remote
 primary_entity:
   entity: fan
   translation_only_key: fan_with_presets

--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -1,0 +1,25 @@
+name: Lucci Fan
+products:
+  - id: U8wU126HQlIeQHvS
+    name: Lucci Fan
+primary_entity:
+  entity: fan
+  translation_only_key: fan_with_presets
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    
+    - id: 2
+      name: speed
+      type: integer
+      range:
+        min: 1
+        max: 3
+
+secondary_entities:
+  - entity: light
+    dps:
+      - id: 102
+        name: switch
+        type: boolean

--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -8,7 +8,7 @@ primary_entity:
   dps:
     - id: 1
       name: switch
-      type: boolean  
+      type: boolean
     - id: 2
       name: speed
       type: integer

--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -4,7 +4,6 @@ products:
     name: Lucci Connect WiFi Fan Remote
 primary_entity:
   entity: fan
-  translation_only_key: fan_with_presets
   dps:
     - id: 1
       name: switch

--- a/custom_components/tuya_local/devices/lucci_fan.yaml
+++ b/custom_components/tuya_local/devices/lucci_fan.yaml
@@ -10,12 +10,16 @@ primary_entity:
       type: boolean
     - id: 2
       name: speed
-      type: integer
-      range:
-        min: 1
-        max: 3
+      type: string
+      mapping:
+        - dps_val: "1"
+          value: 33
+        - dps_val: "2"
+          value: 66
+        - dps_val: "3"
+          value: 100
 secondary_entities:
-  - entity: switch
+  - entity: light
     dps:
       - id: 102
         name: switch


### PR DESCRIPTION
Add support for Lucci Connect fans sold by Beacon Lighting in Australia

"product_name": "Lucci Fan",
"product_id": "U8wU126HQlIeQHvS",

Tinytuya data points:

"102": {
    "code": "light",
    "type": "Boolean",
    "values": {}
},

"2": {
    "code": "fan_speed",
    "type": "Enum",
    "values": {
        "range": [
            "1",
            "2",
            "3"
        ]
    }
},

"1": {
    "code": "switch",
    "type": "Boolean",
    "values": {}
}

