### PR TITLE
Exposing a 'set DP' service

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -667,9 +667,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         if dev_id not in hass.data[DOMAIN]:
             raise HomeAssistantError("unknown device id")
 
-        device = hass.data[DOMAIN][dev_id]
-        # if not device.connected:
-        #     raise HomeAssistantError("not connected to device")
+        device = hass.data[DOMAIN][dev_id]["device"]
 
         await device.async_set_property(event.data[CONF_DP], event.data[CONF_VALUE])
 


### PR DESCRIPTION
It would be nice to expose property setting as a service for use in automations. For example, the Holman WX1 has an [encoded DP to control the schedule](https://github.com/make-all/tuya-local/blob/2d205a4cd4a822ed69907738d60f035380086878/custom_components/tuya_local/devices/holman_wx1_taptimer.yaml#L118-L121). This makes it necessary to use automations to control it, as per the comments in the [WX1 config](https://github.com/make-all/tuya-local/blob/2d205a4cd4a822ed69907738d60f035380086878/custom_components/tuya_local/devices/holman_wx1_taptimer.yaml#L118-L121), but that's not possible without an exposed service to set properties. 

Here's an example use from one of my automations:

```
  action:
  - service: tuya_local.set_dp
    data:
      device_id: E61
      dp: 110
      value: "{% from 'holman/holman_util.jinja' import holman_get_base, holman_get_data, holman_get_char_string %}
                 {% from 'holman/automations/holman_start_time_setter.jinja' import holman_start_time_setter %}
                 {% set base = (holman_get_base()|from_json).base%}
                 {% set data = (holman_get_data(base, 'var.potplants_start_a_buffer')|from_json).data %}
                 {% set data = (holman_start_time_setter(base, 'input_datetime.potplants_start_a_start_time',
                 'var.potplants_start_a_buffer')|from_json).data %}
                {{ holman_get_char_string(base, data) }}"
```