### PR TITLE
Add support for Xiaomi Mijia Temperature & Humidity sensor

### DIFF
--- a/custom_components/tuya_local/devices/zigbee_xiaomi_mijia_LYWSD03MC_temperature_humidity_sensor.yaml
+++ b/custom_components/tuya_local/devices/zigbee_xiaomi_mijia_LYWSD03MC_temperature_humidity_sensor.yaml
@@ -1,0 +1,37 @@
+name: Climate sensor
+products:
+  - id: bf9cbc4edbada
+    name: Xiaomi mijia LYWSD03MC Temperature and Humidity Monitor
+primary_entity:
+  entity: sensor
+  class: temperature
+  dps:
+    - id: 101
+      type: integer
+      name: sensor
+      unit: "°C"
+      class: measurement
+      range:
+        min: -20
+        max: 60
+secondary_entities:
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        range:
+          min: 0
+          max: 500

--- a/custom_components/tuya_local/devices/zigbee_xiaomi_mijia_LYWSD03MC_temperature_humidity_sensor.yaml
+++ b/custom_components/tuya_local/devices/zigbee_xiaomi_mijia_LYWSD03MC_temperature_humidity_sensor.yaml
@@ -6,7 +6,7 @@ primary_entity:
   entity: sensor
   class: temperature
   dps:
-    - id: 101
+    - id: 103
       type: integer
       name: sensor
       unit: "°C"
@@ -18,7 +18,7 @@ secondary_entities:
   - entity: sensor
     class: humidity
     dps:
-      - id: 102
+      - id: 101
         type: integer
         name: sensor
         unit: "%"
@@ -27,7 +27,7 @@ secondary_entities:
     class: battery
     category: diagnostic
     dps:
-      - id: 103
+      - id: 102
         type: integer
         name: sensor
         unit: "%"


### PR DESCRIPTION
Added support for Xiaomi Mijia temperature and humidity sensor, model LYWSD03MC. I have one converted to zigbee.

![xiaomi-mijia-zigbee](https://github.com/user-attachments/assets/03f25ddf-f59f-4deb-ac70-539bbc69bbb2)
