### PR TITLE
Update beca_bht002_thermostat_c.yaml

### DIFF
--- a/custom_components/tuya_local/devices/beca_bht002_thermostat_c.yaml
+++ b/custom_components/tuya_local/devices/beca_bht002_thermostat_c.yaml
@@ -53,7 +53,7 @@ primary_entity:
       # There are many variants of BHT-002 on the market, not all support this
       optional: true
       name: hvac_action
-      conditions:
+      mapping:
         - dps_val: "0"
           value: idle
         - dps_val: "1"

--- a/custom_components/tuya_local/devices/beca_bht002_thermostat_c.yaml
+++ b/custom_components/tuya_local/devices/beca_bht002_thermostat_c.yaml
@@ -48,22 +48,16 @@ primary_entity:
           value: eco
         - dps_val: false
           value: comfort
-    - id: 102
-      type: integer
-      name: floor_temperature
-      mapping:
-        - scale: 2
     - id: 103
-      type: enum
-      name: tempSwitch
+      type: string
+      # There are many variants of BHT-002 on the market, not all support this
+      optional: true
+      name: hvac_action
       conditions:
         - dps_val: "0"
-          value: not_heating
+          value: idle
         - dps_val: "1"
           value: heating
-    - id: 104
-      type: boolean
-      name: floortempFunction
 secondary_entities:
   - entity: lock
     translation_key: child_lock
@@ -78,8 +72,13 @@ secondary_entities:
     dps:
       - id: 102
         type: integer
+        # If dp 104 is false, this may not be present
+        optional: true
         name: sensor
         unit: C
         class: measurement
         mapping:
           - scale: 2
+      - id: 104
+        type: boolean
+        name: available

--- a/custom_components/tuya_local/devices/beca_bht002_thermostat_c.yaml
+++ b/custom_components/tuya_local/devices/beca_bht002_thermostat_c.yaml
@@ -53,9 +53,17 @@ primary_entity:
       name: floor_temperature
       mapping:
         - scale: 2
+    - id: 103
+      type: enum
+      name: tempSwitch
+      conditions:
+        - dps_val: "0"
+          value: not_heating
+        - dps_val: "1"
+          value: heating
     - id: 104
       type: boolean
-      name: unknown_104
+      name: floortempFunction
 secondary_entities:
   - entity: lock
     translation_key: child_lock


### PR DESCRIPTION
Add support for DP IDs 103 and 104 in thermostat integration

- Added DP ID 103 to indicate whether the thermostat is actively heating.
- Added DP ID 104 to detect if the floor thermocouple is connected and enabled.

Product details:
"product_id": "IAYz2WK1th0cMLmL",
"product_name": "柏益温控器（采暖）",

Sample data structure:
{
  "result": { "properties": [ { "code": "Power", "custom_name": "", "dp_id": 1, "time": 1733598465661, "type": "bool", "value": false }, { "code": "TempSet", "custom_name": "", "dp_id": 2, "time": 1733008734835, "type": "value", "value": 40 }, { "code": "TempCurrent", "custom_name": "", "dp_id": 3, "time": 1734037293054, "type": "value", "value": 9 }, { "code": "Mode", "custom_name": "", "dp_id": 4, "time": 1733598460677, "type": "enum", "value": "1" }, { "code": "ECO", "custom_name": "", "dp_id": 5, "time": 1733007701676, "type": "bool", "value": false }, { "code": "ChildLock", "custom_name": "", "dp_id": 6, "time": 1733007701676, "type": "bool", "value": false }, { "code": "program", "custom_name": "", "dp_id": 101, "time": 1730404307417, "type": "raw", "value": "AAYoAAgoHgsoHg0oABEoABciAAYoAAgoHgsoHg0oABEoOxciAAYoAAgoHgsoHg0oABEoOxci" }, { "code": "floorTemp", "custom_name": "", "dp_id": 102, "time": 1734037576774, "type": "value", "value": 12 }, { "code": "tempSwitch", "custom_name": "", "dp_id": 103, "time": 1706360117750, "type": "enum", "value": "0" }, { "code": "floortempFunction", "custom_name": "", "dp_id": 104, "time": 1733007701676, "type": "bool", "value": true } ] }, "success": true, "t": 1734037579533, "tid": "eefd8606b8cc11efbc549ae2a79b4875" }