### PR TITLE
Adding Mirabella Genio door/window sensor config

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -858,7 +858,7 @@ port and password.
 - Bresser Smart Thermo-hygrometer
 - CO2-Box air quality monitor
 - CT20W PIR motion detector
-- EM3390TF weather station (tested with Viflykoo branded device, probably identical to the same model number branded as Uzoli, Jely and others) 
+- EM3390TF weather station (tested with Viflykoo branded device, probably identical to the same model number branded as Uzoli, Jely and others)
 - Emax EM3378 Weather Station (selling as Hiper P1 and other rebrands)
 - EPT ultrasonic 3m tank level sensor
 - Goldair Platinum SleepSmart electric blanket
@@ -872,6 +872,7 @@ port and password.
 - Kogan KAWHTNOSLPA white noise sleep aid
 - Konlen/Rockson WF96L water level controller
 - Madimack Inverflow Pro pool pump
+- Mirabella Genio door/window sensor
 - Mirabella Genio motion sensor
 - Momcozy white noise machine (2 variants)
 - Nedis WIFISA10CWT air quality monitor

--- a/custom_components/tuya_local/devices/mirabella_genio_door_sensor.yaml
+++ b/custom_components/tuya_local/devices/mirabella_genio_door_sensor.yaml
@@ -1,0 +1,28 @@
+name: Mirabella Genio Door/Window Sensor
+products:
+  - id: iqoy7jgeosgbgk9i
+    name: Genio Door/Window Sensor
+primary_entity:
+  entity: binary_sensor
+  class: door
+  dps:
+    - id: 101
+      type: boolean
+      name: sensor
+secondary_entities:
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    name: Tamper alarm
+    class: tamper
+    dps:
+      - id: 102
+        type: boolean
+        name: sensor


### PR DESCRIPTION
Adding support for Mirabella Genio Door/Window Sensor. 

It's quite similar to the Tuya Generic Zigbee sensor, but reports on tampering (_or "tempering" as Tuya describes it_) and is not Zigbee, but instead uses an XR809/XR3 controller which is quite slow & laggy.