### PR TITLE
Add configuration for Devola Intelligent Heater

### DIFF
--- a/custom_components/tuya_local/devices/devola_intelligent_heater.yaml
+++ b/custom_components/tuya_local/devices/devola_intelligent_heater.yaml
@@ -1,0 +1,60 @@
+name: Devola Intelligent Heater
+products:
+  - id: qAmsenZuNF74vRvj
+    name: Intelligent heater
+primary_entity:
+  entity: climate
+  translation_only_key: heater
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: true
+          value: "heat"
+        - dps_val: false
+          value: "off"
+    - id: 2
+      name: temperature
+      type: integer
+      unit: C
+      range:
+        min: 5
+        max: 50
+      scale: 0
+      step: 1
+    - id: 3
+      name: current_temperature
+      type: integer
+      unit: C
+      range:
+        min: 0
+        max: 50
+      scale: 0
+      step: 1
+    - id: 4
+      name: preset_mode
+      type: string
+      optional: true
+      mapping:
+        - dps_val: low
+          value: eco
+        - dps_val: high
+          value: boost
+        - dps_val: af
+          value: away
+secondary_entities:
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 12
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 12
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
Adding support for Devola Intelligent Heater - https://www.devola.co.uk/products/devola-designer-2kw-smart-glass-panel-heater-with-timer-black-dvpw2000b

This also supports the 1kw model and presumably the 1.5kw model as well