### PR TITLE
fix(akai_dryer): drying time should be writable

### DIFF
--- a/custom_components/tuya_local/devices/akai_dryer.yaml
+++ b/custom_components/tuya_local/devices/akai_dryer.yaml
@@ -113,6 +113,53 @@ secondary_entities:
             value: "Medium"
           - dps_val: 3
             value: "High"
+  - entity: select
+    name: Drying time
+    dps:
+      - id: 3
+        name: option
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: "0:20"
+          - dps_val: 1
+            value: "0:30"
+          - dps_val: 2
+            value: "0:40"
+          - dps_val: 3
+            value: "0:50"
+          - dps_val: 4
+            value: "1:00"
+          - dps_val: 5
+            value: "1:10"
+          - dps_val: 6
+            value: "1:20"
+          - dps_val: 7
+            value: "1:30"
+          - dps_val: 8
+            value: "1:40"
+          - dps_val: 9
+            value: "1:50"
+          - dps_val: 10
+            value: "2:00"
+          - dps_val: 11
+            value: "2:10"
+          - dps_val: 12
+            value: "2:20"
+          - dps_val: 13
+            value: "2:30"
+          - dps_val: 14
+            value: "2:40"
+          - dps_val: 15
+            value: "2:50"
+          - dps_val: 16
+            value: "3:00"
+          - dps_val: 17
+            value: "3:10"
+          - dps_val: 18
+            value: "3:20"
+          - dps_val: 19
+            value: "3:30"
   - entity: switch
     name: Anti crease
     icon: "mdi:iron"
@@ -126,14 +173,6 @@ secondary_entities:
       - id: 106
         name: lock
         type: boolean
-  - entity: sensor
-    name: Drying time
-    class: duration
-    dps:
-      - id: 3
-        name: sensor
-        type: integer
-        unit: min
   - entity: sensor
     name: Drying time remaining
     class: duration


### PR DESCRIPTION
this DP is used when the Drying Mode is Time

the string values I've chosen are based on what's displayed on the dryer's LED display

I initially tried to provide values in minutes so they could be displayed in HASS and formatted appropriately but I couldn't seem to get that to work. Should I remove `class: duration` and `unit: min`? 