### PR TITLE
Support for Mirabella Genio Fairy Lights

### DIFF
--- a/custom_components/tuya_local/devices/mirabella_genio_fairy_light.yaml
+++ b/custom_components/tuya_local/devices/mirabella_genio_fairy_light.yaml
@@ -1,0 +1,44 @@
+name: Mirabella Genio Fairy Lights
+products:
+  - id: 000004akzt
+    name: Mirabella Genio Fairy Lights
+primary_entity:
+  entity: light
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+    - id: 3
+      name: brightness
+      type: integer
+      range:
+        min: 25
+        max: 255
+secondary_entities:
+  - entity: select
+    name: Scene
+    icon: "mdi:palette"
+    category: config
+    dps:
+      - id: 104
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "1"
+            value: "Combination"
+            default: true
+          - dps_val: "2"
+            value: "In Waves"
+          - dps_val: "3"
+            value: "Sequence"
+          - dps_val: "4"
+            value: "Slo-Glo"
+          - dps_val: "5"
+            value: "Chasing"
+          - dps_val: "6"
+            value: "Fade"
+          - dps_val: "7"
+            value: "Twinkle"
+          - dps_val: "8"
+            value: "Steady"


### PR DESCRIPTION
Have this working specifically for this product: https://www.mirabellagenio.com.au/product-range/mirabella-genio-wi-fi-1-8m-190l-led-multicolour-easy-tree-lights/
But the controller itself is a very generic plug that I believe will work for all their non-addressable fairy lights.