### PR TITLE
Add support for powerworld PW040 monoblock inverter heat pumps.

### DIFF
--- a/custom_components/tuya_local/devices/powerworld_pw040.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040.yaml
@@ -1,5 +1,3 @@
----
----
 name: PW040
 products:
   - id: 5oc9wmac3bbidekc
@@ -9,21 +7,21 @@ primary_entity:
   translation_key: heater
   name: Warmwasser
   dps:
-    - id: 123
+    - id: 123  # e_WarmwasserSoll_T
       type: integer
-      name: temperature  # e_WarmwasserSoll_T
-      unit: C
+      name: temperature
       range:
         min: 30
         max: 55
-    - id: 108
+      unit: C
+    - id: 108  # Warmwasser_T (ist)
       type: integer
-      name: current_temperature  # Warmwasser_T (ist)
+      name: current_temperature
     - id: 4
+      hidden: true
       type: integer
       name: temp_set
       optional: true
-      hidden: true
       range:
         min: 0
         max: 9999
@@ -67,11 +65,11 @@ secondary_entities:
           - dps_val: wth
             value: nur WW
           - dps_val: cool
-            value: Kühlen
+            value: Kuehlen
           - dps_val: wth_heat
             value: WW und Heizen
           - dps_val: wth_cool
-            value: WW und Kühlen
+            value: WW und Kuehlen
   - entity: select
     name: Heiz-RL-Steuerung
     category: config
@@ -81,9 +79,9 @@ secondary_entities:
         name: option
         mapping:
           - dps_val: 0  # manuelle RLsoll_T
-            value: "manuell"  # boost
+            value: manuell  # boost
           - dps_val: 1  # HeizKennlinie aktiv
-            value: "Heizkennlinie"  # eco
+            value: Heizkennlinie  # eco
   - entity: sensor
     name: WpRL_T
     class: temperature
@@ -262,7 +260,6 @@ secondary_entities:
           min: 0
           max: 1500
   - entity: sensor
-    hidden: true
     name: DcLuefter2_vWind
     category: diagnostic
     dps:
@@ -287,13 +284,12 @@ secondary_entities:
           min: 28
           max: 55
   - entity: number
-    hidden: true
     name: RLzuKuehlsoll_dT  # e_RL_zu_KuehlSoll_dT
     category: config
     dps:
       - id: 121
-        type: integer
         hidden: true
+        type: integer
         name: value
         unit: C
         range:
@@ -305,20 +301,19 @@ secondary_entities:
     dps:
       - id: 122
         type: integer
-        name: valve
+        name: value
         unit: C
         range:
           min: 2
           max: 18
   - entity: number
-    hidden: true
     name: Kuehlsoll_T  # e_KuehlSoll_T
     class: temperature
     category: config
     dps:
       - id: 124
-        type: integer
         hidden: true
+        type: integer
         unit: C
         name: value
         range:
@@ -365,7 +360,7 @@ secondary_entities:
       - id: 135
         type: string
         unit: Hz
-        name: value
+        name: option
         mapping:
           - dps_val: 0
             value: FreqBeibehalten

--- a/custom_components/tuya_local/devices/powerworld_pw040.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040.yaml
@@ -1,22 +1,28 @@
 name: PW040
 products:
   - id: 5oc9wmac3bbidekc
-    name: Powerworld PW040 (Vertriebsbezeichnung Michl SMP13)
+    name: Powerworld PW040 (sold as "Michl SMP13")
 entities:
-  - entity: climate
-    translation_key: heater
-    name: Warmwasser
+  - entity: number
+    name: WarmwasserSoll_T  # hot water target value
+    category: config
     dps:
-      - id: 123  # e_WarmwasserSoll_T
+      - id: 123
+        hidden: true
         type: integer
-        name: temperature
+        name: value
+        unit: C
         range:
           min: 30
           max: 55
-        unit: C
-      - id: 108  # Warmwasser_T (ist)
+  - entity: number
+    name: Warmwasser_T  # hot water (actual value)
+    category: config
+    dps:
+      - id: 108  # Warmwasser_T (ist): hot water (actual value)
         type: integer
-        name: current_temperature
+        name: value
+        unit: C
       - id: 4
         hidden: true
         type: integer
@@ -26,7 +32,7 @@ entities:
           min: 0
           max: 9999
   - entity: select
-    name: Betrieb
+    name: Betrieb  # operation
     category: config
     dps:
       - id: 1
@@ -34,11 +40,11 @@ entities:
         name: option
         mapping:
           - dps_val: false
-            value: "aus"
+            value: "aus"  # off
           - dps_val: true
-            value: "aktiv"
+            value: "aktiv"  # active
   - entity: select
-    name: Energiemodus
+    name: Energiemodus  # energy mode
     category: config
     dps:
       - id: 2
@@ -52,7 +58,7 @@ entities:
           - dps_val: mute
             value: eco
   - entity: select
-    name: Betriebsart
+    name: Betriebsart  # Operating mode
     category: config
     dps:
       - id: 5
@@ -60,27 +66,27 @@ entities:
         name: option
         mapping:
           - dps_val: heat
-            value: nur Heizen
-          - dps_val: wth
-            value: nur WW
+            value: nur Heizen  # only heating
+          - dps_val: wth  # only hot water
+            value: nur WW  # only hot water
           - dps_val: cool
-            value: Kuehlen
+            value: Kuehlen  # cooling
           - dps_val: wth_heat
-            value: WW und Heizen
+            value: WW und Heizen  # hot water and heating
           - dps_val: wth_cool
-            value: WW und Kuehlen
+            value: WW und Kuehlen  # hot water and cooling
   - entity: select
-    name: Heiz-RL-Steuerung
+    name: Heiz-RL-Steuerung  # heating return flow control
     category: config
     dps:
       - id: 132
         type: string
         name: option
         mapping:
-          - dps_val: 0  # manuelle RLsoll_T
+          - dps_val: 0  # manuelle RLsoll_T - take return flow target value
             value: manuell  # boost
           - dps_val: 1  # HeizKennlinie aktiv
-            value: Heizkennlinie  # eco
+            value: Heizkennlinie  # eco - characteristic curve
   - entity: sensor
     name: WpRL_T
     class: temperature
@@ -94,7 +100,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: WpVL_T  # (ist)
+    name: WpVL_T  # outlet temperature
     class: temperature
     category: diagnostic
     dps:
@@ -106,7 +112,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: Umgebung_T
+    name: Umgebung_T  # ambient temperature
     class: temperature
     category: diagnostic
     dps:
@@ -119,7 +125,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: GasVL_T
+    name: GasVL_T  # gas outlet temperature
     class: temperature
     category: diagnostic
     dps:
@@ -132,7 +138,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: GasRL_T
+    name: GasRL_T  # gas temperature return flow
     class: temperature
     category: diagnostic
     dps:
@@ -145,7 +151,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: Verdampfer_T
+    name: Verdampfer_T  # vaporiser temperature
     class: temperature
     category: diagnostic
     dps:
@@ -158,7 +164,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: Kuehlschlangen_T
+    name: Kuehlschlangen_T  # coil temperature
     class: temperature
     category: diagnostic
     dps:
@@ -170,7 +176,7 @@ entities:
         range:
           min: -30
           max: 99
-  - entity: sensor
+  - entity: sensor  # main expansion valve opening level
     name: Ventiloeffnung_HauptExpansion_P
     category: diagnostic
     dps:
@@ -182,7 +188,7 @@ entities:
         range:
           min: 0
           max: 500
-  - entity: sensor
+  - entity: sensor  # enthalpy expansion valve opening level
     name: Ventiloeffnung_EnthalpieExpansion_P
     category: diagnostic
     dps:
@@ -195,7 +201,7 @@ entities:
           min: 0
           max: 500
   - entity: sensor
-    name: Kompressor_I
+    name: Kompressor_I  # Compressor current
     class: current
     category: diagnostic
     dps:
@@ -208,7 +214,7 @@ entities:
           min: 0
           max: 65
   - entity: sensor
-    name: Kompressor_f
+    name: Kompressor_f  # Compressor frequency
     class: frequency
     category: diagnostic
     dps:
@@ -221,7 +227,7 @@ entities:
           min: -99
           max: 150
   - entity: sensor
-    name: Kuehlkoerper_T
+    name: Kuehlkoerper_T  # Heat sink temperature
     class: temperature
     category: diagnostic
     dps:
@@ -234,7 +240,7 @@ entities:
           min: -99
           max: 150
   - entity: sensor
-    name: Bus_Udc
+    name: Bus_Udc  # bus dc voltage
     class: voltage
     category: diagnostic
     dps:
@@ -247,7 +253,7 @@ entities:
           min: 0
           max: 999
   - entity: sensor
-    name: DcLuefter1_vWind
+    name: DcLuefter1_vWind  # dc fan 1 speed
     category: diagnostic
     dps:
       - id: 116
@@ -259,7 +265,7 @@ entities:
           min: 0
           max: 1500
   - entity: sensor
-    name: DcLuefter2_vWind
+    name: DcLuefter2_vWind  # dc fan 2 speed
     category: diagnostic
     dps:
       - id: 15
@@ -271,7 +277,7 @@ entities:
         range:
           min: 0
           max: 1500
-  - entity: number
+  - entity: number  # manual heat water temperature
     name: Heizwasser_Tsoll manuell  # e_HeizRLsoll_T_ohneKennlinie (einstellbar)
     category: config
     dps:
@@ -282,7 +288,7 @@ entities:
         range:
           min: 28
           max: 55
-  - entity: number
+  - entity: number  # return flow to cool target value (delta temperature)
     name: RLzuKuehlsoll_dT  # e_RL_zu_KuehlSoll_dT
     category: config
     dps:
@@ -294,7 +300,7 @@ entities:
         range:
           min: 2
           max: 18
-  - entity: number
+  - entity: number  # return flow to return flow target value (delta temp.)
     name: RLzuRLsoll_dT  # e_RL_zu_RLsoll_dT
     category: config
     dps:
@@ -305,7 +311,7 @@ entities:
         range:
           min: 2
           max: 18
-  - entity: number
+  - entity: number  # cooling target value (temperature)
     name: Kuehlsoll_T  # e_KuehlSoll_T
     class: temperature
     category: config
@@ -318,7 +324,7 @@ entities:
         range:
           min: 7
           max: 30
-  - entity: number
+  - entity: number  # water compensation temperature
     name: WasserAusgleich_T  # e_WasserAusgleich_T
     class: temperature
     category: config
@@ -330,7 +336,7 @@ entities:
         range:
           min: -5
           max: 15
-  - entity: number
+  - entity: number  # temperature offset of characteristic curve
     name: Kennlinie_Offset_T  # ea_Offset_T
     class: temperature
     category: config
@@ -342,7 +348,7 @@ entities:
         range:
           min: 0
           max: 40
-  - entity: number
+  - entity: number  # gradient of characteristic curve
     name: Kennlinie_m_x10  # ea_Steigung_m_x10
     category: config
     dps:
@@ -352,7 +358,7 @@ entities:
         range:
           min: 1
           max: 30
-  - entity: select
+  - entity: select  # compressor frequency @ target temperature
     name: Kompressor_f @Zieltemperatur  # ea_f_at_ZielTemp_str
     category: config
     dps:
@@ -365,7 +371,7 @@ entities:
             value: FreqBeibehalten
           - dps_val: 1
             value: FreqReduktion
-  - entity: number
+  - entity: number  # pipe heater start temperature
     name: RohrheizungStart_T  # ea_RohrheizungStart_T
     class: temperature
     category: config
@@ -378,7 +384,7 @@ entities:
           min: -20
           max: 20
   - entity: number
-    name: Warmwasser_t  # ea_WarmwasserStart_t
+    name: WarmwasserStart_t  # hot water start time
     category: config
     dps:
       - id: 137
@@ -388,7 +394,7 @@ entities:
         range:
           min: 0
           max: 60
-  - entity: select
+  - entity: select  # water pump stop config
     name: Modus WP-Wasserpumpe  # ea_WasserpumpenStopp_str
     category: config
     dps:
@@ -397,10 +403,10 @@ entities:
         name: option
         mapping:
           - dps_val: 0
-            value: Stopp
+            value: Stopp  # stop immediately
           - dps_val: 1
-            value: Nachlauf
-  - entity: number
+            value: Nachlauf  # stop after trail
+  - entity: number  # defrost start temperature
     name: Abtau_Tstart  # ew_AbtauenStart_T
     class: temperature
     category: config
@@ -412,7 +418,7 @@ entities:
         range:
           min: -15
           max: -1
-  - entity: number
+  - entity: number  # defrost stop temperature
     name: Abtau_Tstopp  # ew_AbtauenEnde_T
     class: temperature
     category: config
@@ -424,7 +430,7 @@ entities:
         range:
           min: 1
           max: 40
-  - entity: number
+  - entity: number  # defrost hysteresis (delta temperature)
     name: Abtau_dT  # ew_Abtauen_dT (Hysterese)
     class: temperature
     category: config
@@ -436,7 +442,7 @@ entities:
         range:
           min: 0
           max: 15
-  - entity: number
+  - entity: number  # compressor minimal frequency @ target temperature
     name: Kompressor_fMin @Zieltemperatur  # ew_fMin_at_ZielTemp
     class: frequency
     category: config
@@ -448,7 +454,7 @@ entities:
         range:
           min: 30
           max: 120
-  - entity: number
+  - entity: number  # compressor maximal frequency @ target temperature
     name: Kompressor_fMax @Zieltemperatur  # ew_fMax_at_ZielTemp
     class: frequency
     category: config
@@ -460,7 +466,7 @@ entities:
         range:
           min: 30
           max: 120
-  - entity: number
+  - entity: number  # compressor hot water frequency compensation
     name: Kompressor_fWW-Kompensation  # ew_fWarmwasser_Kompensation
     class: frequency
     category: config

--- a/custom_components/tuya_local/devices/powerworld_pw040.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040.yaml
@@ -1,7 +1,8 @@
 name: PW040
 products:
   - id: 5oc9wmac3bbidekc
-    name: Powerworld PW040 (sold as "Michl SMP13")
+    manufacturer: Powerworld / Michl
+    model: PW040 / SMP13
 entities:
   - entity: number
     name: WarmwasserSoll_T  # hot water target value

--- a/custom_components/tuya_local/devices/powerworld_pw040.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040.yaml
@@ -1,0 +1,480 @@
+---
+---
+name: PW040
+products:
+  - id: 5oc9wmac3bbidekc
+    name: Powerworld PW040 (Vertriebsbezeichnung Michl SMP13)
+primary_entity:
+  entity: climate
+  translation_key: heater
+  name: Warmwasser
+  dps:
+    - id: 123
+      type: integer
+      name: temperature  # e_WarmwasserSoll_T
+      unit: C
+      range:
+        min: 30
+        max: 55
+    - id: 108
+      type: integer
+      name: current_temperature  # Warmwasser_T (ist)
+    - id: 4
+      type: integer
+      name: temp_set
+      optional: true
+      hidden: true
+      range:
+        min: 0
+        max: 9999
+secondary_entities:
+  - entity: select
+    name: Betrieb
+    category: config
+    dps:
+      - id: 1
+        type: boolean
+        name: option
+        mapping:
+          - dps_val: false
+            value: "aus"
+          - dps_val: true
+            value: "aktiv"
+  - entity: select
+    name: Energiemodus
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: smart
+            value: comfort
+          - dps_val: strong
+            value: boost
+          - dps_val: mute
+            value: eco
+  - entity: select
+    name: Betriebsart
+    category: config
+    dps:
+      - id: 5
+        type: string
+        name: option
+        mapping:
+          - dps_val: heat
+            value: nur Heizen
+          - dps_val: wth
+            value: nur WW
+          - dps_val: cool
+            value: Kühlen
+          - dps_val: wth_heat
+            value: WW und Heizen
+          - dps_val: wth_cool
+            value: WW und Kühlen
+  - entity: select
+    name: Heiz-RL-Steuerung
+    category: config
+    dps:
+      - id: 132
+        type: string
+        name: option
+        mapping:
+          - dps_val: 0  # manuelle RLsoll_T
+            value: "manuell"  # boost
+          - dps_val: 1  # HeizKennlinie aktiv
+            value: "Heizkennlinie"  # eco
+  - entity: sensor
+    name: WpRL_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        unit: C
+        name: sensor
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: WpVL_T  # (ist)
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        unit: C
+        name: sensor
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: Umgebung_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        unit: C
+        name: sensor
+        class: measurement
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: GasVL_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        unit: C
+        name: sensor
+        class: measurement
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: GasRL_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        unit: C
+        name: sensor
+        class: measurement
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: Verdampfer_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        unit: C
+        name: sensor
+        class: measurement
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: Kuehlschlangen_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 107
+        type: integer
+        unit: C
+        name: sensor
+        class: measurement
+        range:
+          min: -30
+          max: 99
+  - entity: sensor
+    name: Ventiloeffnung_HauptExpansion_P
+    category: diagnostic
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        unit: P
+        class: measurement
+        range:
+          min: 0
+          max: 500
+  - entity: sensor
+    name: Ventiloeffnung_EnthalpieExpansion_P
+    category: diagnostic
+    dps:
+      - id: 111
+        type: integer
+        name: sensor
+        unit: P
+        class: measurement
+        range:
+          min: 0
+          max: 500
+  - entity: sensor
+    name: Kompressor_I
+    class: current
+    category: diagnostic
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+        range:
+          min: 0
+          max: 65
+  - entity: sensor
+    name: Kompressor_f
+    class: frequency
+    category: diagnostic
+    dps:
+      - id: 115
+        type: integer
+        name: sensor
+        unit: Hz
+        class: measurement
+        range:
+          min: -99
+          max: 150
+  - entity: sensor
+    name: Kuehlkoerper_T
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 113
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        range:
+          min: -99
+          max: 150
+  - entity: sensor
+    name: Bus_Udc
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 117
+        type: integer
+        name: sensor
+        unit: V
+        class: measurement
+        range:
+          min: 0
+          max: 999
+  - entity: sensor
+    name: DcLuefter1_vWind
+    category: diagnostic
+    dps:
+      - id: 116
+        type: integer
+        name: sensor
+        unit: rpm
+        class: measurement
+        range:
+          min: 0
+          max: 1500
+  - entity: sensor
+    hidden: true
+    name: DcLuefter2_vWind
+    category: diagnostic
+    dps:
+      - id: 15
+        hidden: true
+        type: integer
+        name: sensor
+        unit: rpm
+        class: measurement
+        range:
+          min: 0
+          max: 1500
+  - entity: number
+    name: Heizwasser_Tsoll manuell  # e_HeizRLsoll_T_ohneKennlinie (einstellbar)
+    category: config
+    dps:
+      - id: 125
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 28
+          max: 55
+  - entity: number
+    hidden: true
+    name: RLzuKuehlsoll_dT  # e_RL_zu_KuehlSoll_dT
+    category: config
+    dps:
+      - id: 121
+        type: integer
+        hidden: true
+        name: value
+        unit: C
+        range:
+          min: 2
+          max: 18
+  - entity: number
+    name: RLzuRLsoll_dT  # e_RL_zu_RLsoll_dT
+    category: config
+    dps:
+      - id: 122
+        type: integer
+        name: valve
+        unit: C
+        range:
+          min: 2
+          max: 18
+  - entity: number
+    hidden: true
+    name: Kuehlsoll_T  # e_KuehlSoll_T
+    class: temperature
+    category: config
+    dps:
+      - id: 124
+        type: integer
+        hidden: true
+        unit: C
+        name: value
+        range:
+          min: 7
+          max: 30
+  - entity: number
+    name: WasserAusgleich_T  # e_WasserAusgleich_T
+    class: temperature
+    category: config
+    dps:
+      - id: 126
+        type: integer
+        unit: C
+        name: value
+        range:
+          min: -5
+          max: 15
+  - entity: number
+    name: Kennlinie_Offset_T  # ea_Offset_T
+    class: temperature
+    category: config
+    dps:
+      - id: 133
+        type: integer
+        unit: C
+        name: value
+        range:
+          min: 0
+          max: 40
+  - entity: number
+    name: Kennlinie_m_x10  # ea_Steigung_m_x10
+    category: config
+    dps:
+      - id: 134
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 30
+  - entity: select
+    name: Kompressor_f @Zieltemperatur  # ea_f_at_ZielTemp_str
+    category: config
+    dps:
+      - id: 135
+        type: string
+        unit: Hz
+        name: value
+        mapping:
+          - dps_val: 0
+            value: FreqBeibehalten
+          - dps_val: 1
+            value: FreqReduktion
+  - entity: number
+    name: RohrheizungStart_T  # ea_RohrheizungStart_T
+    class: temperature
+    category: config
+    dps:
+      - id: 136
+        type: integer
+        unit: C
+        name: value
+        range:
+          min: -20
+          max: 20
+  - entity: number
+    name: Warmwasser_t  # ea_WarmwasserStart_t
+    category: config
+    dps:
+      - id: 137
+        type: integer
+        unit: min
+        name: value
+        range:
+          min: 0
+          max: 60
+  - entity: select
+    name: Modus WP-Wasserpumpe  # ea_WasserpumpenStopp_str
+    category: config
+    dps:
+      - id: 138
+        type: string
+        name: option
+        mapping:
+          - dps_val: 0
+            value: Stopp
+          - dps_val: 1
+            value: Nachlauf
+  - entity: number
+    name: Abtau_Tstart  # ew_AbtauenStart_T
+    class: temperature
+    category: config
+    dps:
+      - id: 139
+        type: integer
+        unit: C
+        name: value
+        range:
+          min: -15
+          max: -1
+  - entity: number
+    name: Abtau_Tstopp  # ew_AbtauenEnde_T
+    class: temperature
+    category: config
+    dps:
+      - id: 140
+        type: integer
+        unit: C
+        name: value
+        range:
+          min: 1
+          max: 40
+  - entity: number
+    name: Abtau_dT  # ew_Abtauen_dT (Hysterese)
+    class: temperature
+    category: config
+    dps:
+      - id: 141
+        type: integer
+        unit: C
+        name: value
+        range:
+          min: 0
+          max: 15
+  - entity: number
+    name: Kompressor_fMin @Zieltemperatur  # ew_fMin_at_ZielTemp
+    class: frequency
+    category: config
+    dps:
+      - id: 142
+        type: integer
+        unit: Hz
+        name: value
+        range:
+          min: 30
+          max: 120
+  - entity: number
+    name: Kompressor_fMax @Zieltemperatur  # ew_fMax_at_ZielTemp
+    class: frequency
+    category: config
+    dps:
+      - id: 143
+        type: integer
+        unit: Hz
+        name: value
+        range:
+          min: 30
+          max: 120
+  - entity: number
+    name: Kompressor_fWW-Kompensation  # ew_fWarmwasser_Kompensation
+    class: frequency
+    category: config
+    dps:
+      - id: 144
+        type: integer
+        unit: Hz
+        name: value
+        range:
+          min: -50
+          max: 20

--- a/custom_components/tuya_local/devices/powerworld_pw040.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040.yaml
@@ -15,14 +15,16 @@ entities:
         range:
           min: 30
           max: 55
-  - entity: number
+  - entity: sensor
     name: Warmwasser_T  # hot water (actual value)
-    category: config
+    class: temperature
+    category: diagnostic
     dps:
       - id: 108  # Warmwasser_T (ist): hot water (actual value)
         type: integer
-        name: value
         unit: C
+        name: sensor
+        class: measurement
       - id: 4
         hidden: true
         type: integer

--- a/custom_components/tuya_local/devices/powerworld_pw040.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040.yaml
@@ -2,30 +2,29 @@ name: PW040
 products:
   - id: 5oc9wmac3bbidekc
     name: Powerworld PW040 (Vertriebsbezeichnung Michl SMP13)
-primary_entity:
-  entity: climate
-  translation_key: heater
-  name: Warmwasser
-  dps:
-    - id: 123  # e_WarmwasserSoll_T
-      type: integer
-      name: temperature
-      range:
-        min: 30
-        max: 55
-      unit: C
-    - id: 108  # Warmwasser_T (ist)
-      type: integer
-      name: current_temperature
-    - id: 4
-      hidden: true
-      type: integer
-      name: temp_set
-      optional: true
-      range:
-        min: 0
-        max: 9999
-secondary_entities:
+entities:
+  - entity: climate
+    translation_key: heater
+    name: Warmwasser
+    dps:
+      - id: 123  # e_WarmwasserSoll_T
+        type: integer
+        name: temperature
+        range:
+          min: 30
+          max: 55
+        unit: C
+      - id: 108  # Warmwasser_T (ist)
+        type: integer
+        name: current_temperature
+      - id: 4
+        hidden: true
+        type: integer
+        name: temp_set
+        optional: true
+        range:
+          min: 0
+          max: 9999
   - entity: select
     name: Betrieb
     category: config

--- a/custom_components/tuya_local/devices/powerworld_pw040_waterheatpump.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw040_waterheatpump.yaml
@@ -1,31 +1,45 @@
-name: PW040
+name: Water heat pump
 products:
   - id: 5oc9wmac3bbidekc
     manufacturer: Powerworld / Michl
     model: PW040 / SMP13
 entities:
-  - entity: number
-    name: WarmwasserSoll_T  # hot water target value
-    category: config
+  - entity: water_heater
+    translation_key: water_air
     dps:
-      - id: 123
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: work_mode
+            conditions:
+              - dps_val: heat
+                value: heat
+              - dps_val: wth
+                value: hotwater
+              - dps_val: cool
+                value: cool
+              - dps_val: wth_heat
+                value: hotwater_heat
+              - dps_val: wth_cool
+                value: hotwater_cool
+      - id: 5
+        type: string
+        name: work_mode
         hidden: true
+      - id: 125
         type: integer
-        name: value
+        name: temperature
         unit: C
         range:
-          min: 30
+          min: 28
           max: 55
-  - entity: sensor
-    name: Warmwasser_T  # hot water (actual value)
-    class: temperature
-    category: diagnostic
-    dps:
       - id: 108  # Warmwasser_T (ist): hot water (actual value)
         type: integer
-        unit: C
-        name: sensor
-        class: measurement
+        name: current_temperature
       - id: 4
         hidden: true
         type: integer
@@ -34,25 +48,64 @@ entities:
         range:
           min: 0
           max: 9999
-  - entity: select
-    name: Betrieb  # operation
-    category: config
+  - entity: climate
     dps:
       - id: 1
         type: boolean
-        name: option
+        name: hvac_mode
         mapping:
           - dps_val: false
-            value: "aus"  # off
+            value: "off"
+            available: wth_off
           - dps_val: true
-            value: "aktiv"  # active
-  - entity: select
-    name: Energiemodus  # energy mode
-    category: config
-    dps:
+            constraint: work_mode
+            conditions:
+              - dps_val: heat
+                value: heat
+                available: wth_off
+              - dps_val: cool
+                value: cool
+                available: wth_off
+              - dps_val: wth
+                value: "off"
+                available: wth_on
+              - dps_val: wth_heat
+                value: heat
+                available: wth_on
+              - dps_val: wth_cool
+                value: cool
+                available: wth_on
+      - id: 5
+        type: string
+        name: work_mode
+        hidden: true
+      - id: 5
+        type: string
+        name: wth_on
+        hidden: true
+        mapping:
+          - dps_val: wth
+            value: true
+          - dps_val: wth_heat
+            value: true
+          - dps_val: wth_cool
+            value: true
+          - value: false
+      - id: 5
+        type: string
+        name: wth_off
+        hidden: true
+        mapping:
+          - dps_val: wth
+            value: false
+          - dps_val: wth_heat
+            value: false
+          - dps_val: wth_cool
+            value: false
+          - value: true
       - id: 2
         type: string
-        name: option
+        name: preset_mode
         mapping:
           - dps_val: smart
             value: comfort
@@ -60,50 +113,48 @@ entities:
             value: boost
           - dps_val: mute
             value: eco
-  - entity: select
-    name: Betriebsart  # Operating mode
-    category: config
-    dps:
-      - id: 5
-        type: string
-        name: option
+      - id: 101
+        type: integer
+        name: current_temperature
+      - id: 123
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 30
+          max: 55
         mapping:
-          - dps_val: heat
-            value: nur Heizen  # only heating
-          - dps_val: wth  # only hot water
-            value: nur WW  # only hot water
-          - dps_val: cool
-            value: Kuehlen  # cooling
-          - dps_val: wth_heat
-            value: WW und Heizen  # hot water and heating
-          - dps_val: wth_cool
-            value: WW und Kuehlen  # hot water and cooling
+          - constraint: work_mode
+            conditions:
+              - dps_val:
+                  - cool
+                  - wth_cool
+                value_redirect: cooling_temp
+                range:
+                  min: 7
+                  max: 30
+      - id: 124
+        hidden: true
+        type: integer
+        unit: C
+        name: cooling_temp
+        range:
+          min: 7
+          max: 30
   - entity: select
-    name: Heiz-RL-Steuerung  # heating return flow control
+    name: Heating return
     category: config
     dps:
       - id: 132
         type: string
         name: option
         mapping:
-          - dps_val: 0  # manuelle RLsoll_T - take return flow target value
-            value: manuell  # boost
-          - dps_val: 1  # HeizKennlinie aktiv
-            value: Heizkennlinie  # eco - characteristic curve
+          - dps_val: 0
+            value: Manual
+          - dps_val: 1
+            value: Eco
   - entity: sensor
-    name: WpRL_T
-    class: temperature
-    category: diagnostic
-    dps:
-      - id: 101
-        type: integer
-        unit: C
-        name: sensor
-        range:
-          min: -30
-          max: 99
-  - entity: sensor
-    name: WpVL_T  # outlet temperature
+    name: Outlet temperature
     class: temperature
     category: diagnostic
     dps:
@@ -111,12 +162,9 @@ entities:
         type: integer
         unit: C
         name: sensor
-        range:
-          min: -30
-          max: 99
   - entity: sensor
-    name: Umgebung_T  # ambient temperature
     class: temperature
+    name: Ambient temperature
     category: diagnostic
     dps:
       - id: 103
@@ -124,11 +172,8 @@ entities:
         unit: C
         name: sensor
         class: measurement
-        range:
-          min: -30
-          max: 99
   - entity: sensor
-    name: GasVL_T  # gas outlet temperature
+    name: Gas outlet temperature
     class: temperature
     category: diagnostic
     dps:
@@ -141,7 +186,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: GasRL_T  # gas temperature return flow
+    name: Gas return temperature
     class: temperature
     category: diagnostic
     dps:
@@ -150,11 +195,8 @@ entities:
         unit: C
         name: sensor
         class: measurement
-        range:
-          min: -30
-          max: 99
   - entity: sensor
-    name: Verdampfer_T  # vaporiser temperature
+    name: Vaporiser temperature
     class: temperature
     category: diagnostic
     dps:
@@ -167,7 +209,7 @@ entities:
           min: -30
           max: 99
   - entity: sensor
-    name: Kuehlschlangen_T  # coil temperature
+    name: Coil temperature
     class: temperature
     category: diagnostic
     dps:
@@ -179,8 +221,8 @@ entities:
         range:
           min: -30
           max: 99
-  - entity: sensor  # main expansion valve opening level
-    name: Ventiloeffnung_HauptExpansion_P
+  - entity: sensor
+    name: EEV opening
     category: diagnostic
     dps:
       - id: 109
@@ -192,7 +234,7 @@ entities:
           min: 0
           max: 500
   - entity: sensor  # enthalpy expansion valve opening level
-    name: Ventiloeffnung_EnthalpieExpansion_P
+    name: EEV2 opening
     category: diagnostic
     dps:
       - id: 111
@@ -204,7 +246,6 @@ entities:
           min: 0
           max: 500
   - entity: sensor
-    name: Kompressor_I  # Compressor current
     class: current
     category: diagnostic
     dps:
@@ -217,7 +258,6 @@ entities:
           min: 0
           max: 65
   - entity: sensor
-    name: Kompressor_f  # Compressor frequency
     class: frequency
     category: diagnostic
     dps:
@@ -230,7 +270,7 @@ entities:
           min: -99
           max: 150
   - entity: sensor
-    name: Kuehlkoerper_T  # Heat sink temperature
+    name: Heatsink temperature
     class: temperature
     category: diagnostic
     dps:
@@ -243,7 +283,7 @@ entities:
           min: -99
           max: 150
   - entity: sensor
-    name: Bus_Udc  # bus dc voltage
+    name: DC voltage
     class: voltage
     category: diagnostic
     dps:
@@ -256,7 +296,7 @@ entities:
           min: 0
           max: 999
   - entity: sensor
-    name: DcLuefter1_vWind  # dc fan 1 speed
+    name: DC fan 1
     category: diagnostic
     dps:
       - id: 116
@@ -268,7 +308,7 @@ entities:
           min: 0
           max: 1500
   - entity: sensor
-    name: DcLuefter2_vWind  # dc fan 2 speed
+    name: DC fan 2
     category: diagnostic
     dps:
       - id: 15
@@ -280,31 +320,19 @@ entities:
         range:
           min: 0
           max: 1500
-  - entity: number  # manual heat water temperature
-    name: Heizwasser_Tsoll manuell  # e_HeizRLsoll_T_ohneKennlinie (einstellbar)
-    category: config
-    dps:
-      - id: 125
-        type: integer
-        name: value
-        unit: C
-        range:
-          min: 28
-          max: 55
-  - entity: number  # return flow to cool target value (delta temperature)
-    name: RLzuKuehlsoll_dT  # e_RL_zu_KuehlSoll_dT
+  - entity: number
+    name: Cooling hysteresis
     category: config
     dps:
       - id: 121
-        hidden: true
         type: integer
         name: value
         unit: C
         range:
           min: 2
           max: 18
-  - entity: number  # return flow to return flow target value (delta temp.)
-    name: RLzuRLsoll_dT  # e_RL_zu_RLsoll_dT
+  - entity: number
+    name: Heating hysteresis
     category: config
     dps:
       - id: 122
@@ -314,21 +342,8 @@ entities:
         range:
           min: 2
           max: 18
-  - entity: number  # cooling target value (temperature)
-    name: Kuehlsoll_T  # e_KuehlSoll_T
-    class: temperature
-    category: config
-    dps:
-      - id: 124
-        hidden: true
-        type: integer
-        unit: C
-        name: value
-        range:
-          min: 7
-          max: 30
-  - entity: number  # water compensation temperature
-    name: WasserAusgleich_T  # e_WasserAusgleich_T
+  - entity: number
+    name: Water temperature offset
     class: temperature
     category: config
     dps:
@@ -340,7 +355,7 @@ entities:
           min: -5
           max: 15
   - entity: number  # temperature offset of characteristic curve
-    name: Kennlinie_Offset_T  # ea_Offset_T
+    name: Characteristic curve offset
     class: temperature
     category: config
     dps:
@@ -351,8 +366,8 @@ entities:
         range:
           min: 0
           max: 40
-  - entity: number  # gradient of characteristic curve
-    name: Kennlinie_m_x10  # ea_Steigung_m_x10
+  - entity: number
+    name: Characteristic curve gradient
     category: config
     dps:
       - id: 134
@@ -361,21 +376,20 @@ entities:
         range:
           min: 1
           max: 30
-  - entity: select  # compressor frequency @ target temperature
-    name: Kompressor_f @Zieltemperatur  # ea_f_at_ZielTemp_str
+  - entity: select
+    name: Target temperature action
     category: config
     dps:
       - id: 135
         type: string
-        unit: Hz
         name: option
         mapping:
-          - dps_val: 0
-            value: FreqBeibehalten
-          - dps_val: 1
-            value: FreqReduktion
-  - entity: number  # pipe heater start temperature
-    name: RohrheizungStart_T  # ea_RohrheizungStart_T
+          - dps_val: "0"
+            value: Compressor off
+          - dps_val: "1"
+            value: Compressor reduced frequency
+  - entity: number
+    name: Pipe heating start temperature
     class: temperature
     category: config
     dps:
@@ -387,7 +401,7 @@ entities:
           min: -20
           max: 20
   - entity: number
-    name: WarmwasserStart_t  # hot water start time
+    name: Hot water start temperature
     category: config
     dps:
       - id: 137
@@ -397,8 +411,8 @@ entities:
         range:
           min: 0
           max: 60
-  - entity: select  # water pump stop config
-    name: Modus WP-Wasserpumpe  # ea_WasserpumpenStopp_str
+  - entity: select
+    name: Water pump stop mode
     category: config
     dps:
       - id: 138
@@ -406,11 +420,11 @@ entities:
         name: option
         mapping:
           - dps_val: 0
-            value: Stopp  # stop immediately
+            value: Immediate stop
           - dps_val: 1
-            value: Nachlauf  # stop after trail
+            value: Ramp down
   - entity: number  # defrost start temperature
-    name: Abtau_Tstart  # ew_AbtauenStart_T
+    name: Defrost start temperature
     class: temperature
     category: config
     dps:
@@ -421,8 +435,8 @@ entities:
         range:
           min: -15
           max: -1
-  - entity: number  # defrost stop temperature
-    name: Abtau_Tstopp  # ew_AbtauenEnde_T
+  - entity: number
+    name: Defrost stop temperature
     class: temperature
     category: config
     dps:
@@ -433,8 +447,8 @@ entities:
         range:
           min: 1
           max: 40
-  - entity: number  # defrost hysteresis (delta temperature)
-    name: Abtau_dT  # ew_Abtauen_dT (Hysterese)
+  - entity: number
+    name: Defrost hysteresis
     class: temperature
     category: config
     dps:
@@ -445,8 +459,8 @@ entities:
         range:
           min: 0
           max: 15
-  - entity: number  # compressor minimal frequency @ target temperature
-    name: Kompressor_fMin @Zieltemperatur  # ew_fMin_at_ZielTemp
+  - entity: number
+    name: Minimum compressor frequency
     class: frequency
     category: config
     dps:
@@ -457,8 +471,8 @@ entities:
         range:
           min: 30
           max: 120
-  - entity: number  # compressor maximal frequency @ target temperature
-    name: Kompressor_fMax @Zieltemperatur  # ew_fMax_at_ZielTemp
+  - entity: number
+    name: Maximum compressor frequency
     class: frequency
     category: config
     dps:
@@ -469,8 +483,8 @@ entities:
         range:
           min: 30
           max: 120
-  - entity: number  # compressor hot water frequency compensation
-    name: Kompressor_fWW-Kompensation  # ew_fWarmwasser_Kompensation
+  - entity: number
+    name: Compressor hot water frequency compensation
     class: frequency
     category: config
     dps:

--- a/custom_components/tuya_local/translations/bg.json
+++ b/custom_components/tuya_local/translations/bg.json
@@ -759,6 +759,23 @@
             "scene": {
                 "name": "Сцена"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Нагревател на вода",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Нагряване",
+                            "cool": "Охлаждане",
+                            "off": "Изключено",
+                            "hotwater": "Гореща вода",
+                            "hotwater_cool": "Гореща вода и охлаждане",
+                            "hotwater_heat": "Гореща вода и отопление"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/ca.json
+++ b/custom_components/tuya_local/translations/ca.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Escena"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Escalfador d'aigua",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Escalfament",
+                            "cool": "Refredament",
+                            "off": "Apagat",
+                            "hotwater": "Aigua calenta",
+                            "hotwater_cool": "Aigua calenta i refredament",
+                            "hotwater_heat": "Aigua calenta i escalfament"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/cz.json
+++ b/custom_components/tuya_local/translations/cz.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Scéna"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Ohřívač vody",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Ohřátí",
+                            "cool": "Chlazení",
+                            "off": "Vypnuto",
+                            "hotwater": "Horká voda",
+                            "hotwater_cool": "Horká voda chlazení",
+                            "hotwater_heat": "Horká voda ohřátí"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/de.json
+++ b/custom_components/tuya_local/translations/de.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Szene"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Wasserkocher",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Heizen",
+                            "cool": "Kühlen",
+                            "off": "Aus",
+                            "hotwater": "Warmwasser",
+                            "hotwater_cool": "Warmwasser Kühlen",
+                            "hotwater_heat": "Warmwasser Heizen"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/el.json
+++ b/custom_components/tuya_local/translations/el.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Σκηνή"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Θερμοσίφωνας",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Θέρμανση",
+                            "cool": "Ψύξη",
+                            "off": "Απενεργοποίηση",
+                            "hotwater": "Ζεστό νερό",
+                            "hotwater_cool": "Ζεστό νερό και ψύξη",
+                            "hotwater_heat": "Ζεστό νερό και θέρμανση"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/en.json
+++ b/custom_components/tuya_local/translations/en.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Scene"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Water heater",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "off": "Off",
+                            "heat": "Heat",
+                            "cool": "Cool",
+                            "hotwater": "Hot water",
+                            "hotwater_cool": "Hot water & Cool",
+                            "hotwater_heat": "Hot water & Heat"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/es.json
+++ b/custom_components/tuya_local/translations/es.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Escena"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Calentador de agua",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Calor",
+                            "cool": "Frío",
+                            "off": "Apagar",
+                            "hotwater": "Agua caliente",
+                            "hotwater_cool": "Agua caliente y frío",
+                            "hotwater_heat": "Agua caliente y calor"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/fr.json
+++ b/custom_components/tuya_local/translations/fr.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Scène"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Chauffe-eau",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Chauffage",
+                            "cool": "Refroidissement",
+                            "off": "Éteint",
+                            "hotwater": "Eau chaude",
+                            "hotwater_cool": "Eau chaude et refroidissement",
+                            "hotwater_heat": "Eau chaude et chauffage"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/hu.json
+++ b/custom_components/tuya_local/translations/hu.json
@@ -759,6 +759,23 @@
             "scene": {
                 "name": "Jelenet"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Vízmelegítő",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Fűtés",
+                            "cool": "Hűtés",
+                            "off": "Ki",
+                            "hotwater": "Meleg víz",
+                            "hotwater_cool": "Meleg víz és hűtés",
+                            "hotwater_heat": "Meleg víz és fűtés"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/id.json
+++ b/custom_components/tuya_local/translations/id.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Adegan"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Pemanas air",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Pemanas",
+                            "cool": "Pendingin",
+                            "off": "Mati",
+                            "hotwater": "Air panas",
+                            "hotwater_cool": "Pendingin air panas",
+                            "hotwater_heat": "Pemanas air panas"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/it.json
+++ b/custom_components/tuya_local/translations/it.json
@@ -759,6 +759,23 @@
             "scene": {
                 "name": "Scena"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Scaldabagno",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Riscaldamento",
+                            "cool": "Raffreddamento",
+                            "off": "Spento",
+                            "hotwater": "Acqua calda",
+                            "hotwater_cool": "Acqua calda e raffreddamento",
+                            "hotwater_heat": "Acqua calda e riscaldamento"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/ja.json
+++ b/custom_components/tuya_local/translations/ja.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "シーン"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "給湯器",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "加熱",
+                            "cool": "冷却",
+                            "off": "オフ",
+                            "hotwater": "給湯",
+                            "hotwater_cool": "給湯冷却",
+                            "hotwater_heat": "給湯加熱"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/no-NB.json
+++ b/custom_components/tuya_local/translations/no-NB.json
@@ -759,6 +759,23 @@
             "scene": {
                 "name": "Scene"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Vannvarmer",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Varm",
+                            "cool": "Kald",
+                            "off": "Av",
+                            "hotwater": "Varmt vann",
+                            "hotwater_cool": "Varmt vann og kald",
+                            "hotwater_heat": "Varmt vann og varmt"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/pl.json
+++ b/custom_components/tuya_local/translations/pl.json
@@ -759,6 +759,23 @@
             "scene": {
                 "name": "Scena"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Podgrzewacz wody",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Ogrzewanie",
+                            "cool": "Chłodzenie",
+                            "off": "Wyłączony",
+                            "hotwater": "Podgrzewanie wody",
+                            "hotwater_cool": "Podgrzewanie wody i chłodzenie",
+                            "hotwater_heat": "Podgrzewanie wody i ogrzewanie"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/pt-BR.json
+++ b/custom_components/tuya_local/translations/pt-BR.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Cena"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Aquecedor de água",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Aquecimento",
+                            "cool": "Resfriamento",
+                            "off": "Desligado",
+                            "hotwater": "Água quente",
+                            "hotwater_cool": "Água quente e resfriamento",
+                            "hotwater_heat": "Aquecimento de água quente"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/ru.json
+++ b/custom_components/tuya_local/translations/ru.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "Сцена"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Водонагреватель",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Нагрев",
+                            "cool": "Охлаждение",
+                            "off": "Выкл",
+                            "hotwater": "Горячая вода",
+                            "hotwater_cool": "Горячая вода и охлаждение",
+                            "hotwater_heat": "Горячая вода и нагрев"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/uk.json
+++ b/custom_components/tuya_local/translations/uk.json
@@ -761,6 +761,23 @@
             "scene": {
                 "name": "Сцена"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "Водонагрівач",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "Нагрівання",
+                            "cool": "Охолодження",
+                            "off": "Вимк",
+                            "hotwater": "Гаряча вода",
+                            "hotwater_cool": "Гаряча вода та охолодження",
+                            "hotwater_heat": "Гаряча вода та нагрівання"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/ur.json
+++ b/custom_components/tuya_local/translations/ur.json
@@ -761,6 +761,23 @@
             "scene": {
                 "name": "منظر"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "پانی کا ہیٹر",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "گرم",
+                            "cool": "ٹھنڈا",
+                            "off": "آف",
+                            "hotwater": "گرم پانی",
+                            "hotwater_cool": "گرم پانی اور ٹھنڈا",
+                            "hotwater_heat": "گرم پانی اور گرم"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/zh-Hans.json
+++ b/custom_components/tuya_local/translations/zh-Hans.json
@@ -758,6 +758,23 @@
             "scene": {
                 "name": "场景"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "热水器",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "加热",
+                            "cool": "制冷",
+                            "off": "关闭",
+                            "hotwater": "热水",
+                            "hotwater_cool": "热水制冷",
+                            "hotwater_heat": "热水加热"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/tuya_local/translations/zh-Hant.json
+++ b/custom_components/tuya_local/translations/zh-Hant.json
@@ -759,6 +759,23 @@
             "scene": {
                 "name": "場景"
             }
+        },
+        "water_heater": {
+            "water_air": {
+                "name": "熱水器",
+                "state_attributes": {
+                    "operation_mode": {
+                        "state": {
+                            "heat": "加熱",
+                            "cool": "冷卻",
+                            "off": "關",
+                            "hotwater": "熱水",
+                            "hotwater_cool": "熱水冷卻",
+                            "hotwater_heat": "熱水加熱"
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
https://www.powerworldhp.com/heat-pump/commerciale-heat-pump/r32-air-to-water-monoblock-inverter-heat-pump.html (z.B. PW040-DKZLRS-A)

https://michl.com/bilder/intern/downloads/Anleitung-SMP-Serie-08-2023.pdf