### PR TITLE
feat: add airx h8 humidifier

### DIFF
--- a/custom_components/tuya_local/devices/airx_h8_humidifier.yaml
+++ b/custom_components/tuya_local/devices/airx_h8_humidifier.yaml
@@ -1,0 +1,124 @@
+name: Humidifier
+products:
+  - id: orypuo7ksduqze3x
+    name: airx纯净加湿器H8Pro
+primary_entity:
+  entity: humidifier
+  class: humidifier
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+      mapping:
+        - dps_val: true
+          icon: "mdi:air-humidifier"
+        - dps_val: false
+          icon: "mdi:air-humidifier-off"
+    - id: 13
+      name: humidity
+      type: integer
+      range:
+        min: 30
+        max: 80
+    - id: 14
+      name: current_humidity
+      type: integer
+    - id: 24
+      type: string
+      name: mode
+      mapping:
+        - dps_val: AUTO
+          value: auto
+        - dps_val: LOW
+          value: eco
+        - dps_val: MIDDLE
+          value: normal
+        - dps_val: HIGH
+          value: boost
+        - dps_val: SLEEP
+          value: sleep
+secondary_entities:
+  - entity: alarm_control_panel
+    category: diagnostic
+    name: 机头分离告警
+    dps:
+      - id: 22
+        type: string
+        name: alarm_state
+        mapping:
+          - dps_val: 0
+            value: disarmed
+          - dps_val: 1
+            value: armed
+  - entity: switch
+    name: 除菌
+    dps:
+      - id: 21
+        type: integer
+        name: switch
+  - entity: switch
+    translation_key: evaporator_cleaning
+    category: config
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: uv_sterilization
+    category: config
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+  # tuya提供了面板灯光设置，但H8Pro实测不生效
+  - entity: light
+    translation_key: display
+    category: config
+    dps:
+      - id: 5
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: keytone
+    category: config
+    dps:
+      - id: 8
+        type: boolean
+        name: switch
+  - entity: sensor
+    name: 水位
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 101
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: No_water
+            value: "缺水"
+            icon: "mdi:water-off"
+          - dps_val: Low_water
+            value: "低水位"
+            icon: "mdi:water-minus"
+          - dps_val: Middle_water
+            value: "中水位"
+            icon: "mdi:water-opacity"
+          - dps_val: High_water
+            value: "高水位"
+            icon: "water-plus"
+          - dps_val: Full_water
+            value: "满水"
+            icon: "mdi:water"
+  - entity: switch
+    translation_key: ionizer
+    dps:
+      - id: 25
+        name: switch
+        type: boolean
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 29
+        type: boolean
+        name: lock


### PR DESCRIPTION
Hello,

This is my first time submitting a PR. Currently, the device I'm using, the "airx纯净加湿器H8Pro" is not fully compatible. Therefore, I have added a new device configuration file. Based on my tests, all the data points (dp) are working very well. For the specific dp definitions, I have tried to use the standard definition types as much as possible. For the ones that didn't have predefined types, I created custom state values and selected appropriate icons. If there are any issues, please feel free to point them out. Thank you.

Best regards,
李余通
<img width="706" alt="iShot_2024-12-30_10 17 06" src="https://github.com/user-attachments/assets/a66090e9-58ec-4632-a707-51d5585110dd" />
