### PR TITLE
Update breville_lad208_dehumidifier.yaml

### DIFF
--- a/custom_components/tuya_local/devices/breville_lad208_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/breville_lad208_dehumidifier.yaml
@@ -118,15 +118,6 @@ entities:
           - dps_val: "24"
             value: "24h"
   - entity: sensor
-    deprecated: humidifier.current_humidity
-    class: humidity
-    dps:
-      - id: 104
-        type: integer
-        name: sensor
-        unit: "%"
-        class: measurement
-  - entity: sensor
     class: temperature
     dps:
       - id: 103


### PR DESCRIPTION
Remove deprecated entity for humidity sensor.

Due to related log message:

```
2025-01-04 11:36:56.103 WARNING (MainThread) [custom_components.tuya_local.helpers.config] The use of sensor for Dehumidifier is deprecated and should be replaced by humidifier.current_humidity.
```