### PR TITLE
Update ustellar_ut99911_rgb.yaml

### DIFF
--- a/custom_components/tuya_local/devices/ustellar_ut99911_rgb.yaml
+++ b/custom_components/tuya_local/devices/ustellar_ut99911_rgb.yaml
@@ -35,16 +35,18 @@ entities:
         name: switch
       - id: 21
         type: string
-        name: color_mode
+        name: work_mode
         mapping:
           - dps_val: dynamic_mod
             value: Dynamic
           - dps_val: color
-            value: hs
+            value: Color
           - dps_val: scene_mod
             value: Scene
           - dps_val: music
             value: Music
+          - dps_val: white
+            value: White
       - id: 24
         name: rgbhsv
         type: hex


### PR DESCRIPTION
Change incorrectly named ID for DP 21 `color_mode` ID to `work_mode`. This stops the following log entry:

```
2025-01-04 16:30:55.116 WARNING (MainThread) [homeassistant.components.light] light.liam_s_monitor_light_bar_rear_rgb_led (<class 'custom_components.tuya_local.light.TuyaLocalLight'>) set to unsupported color mode white, expected one of {<ColorMode.HS: 'hs'>}, this will stop working in Home Assistant Core 2025.3, please create a bug report at https://github.com/make-all/tuya-local/issues
```

DP 21 is a string that changes when you select a different tab in the Smart Life app for the light. With this change it now shows as an attribute properly (screenshot below) and updates when I page through the different tabs in the app:

```
{\"abilityId\":21,\"accessMode\":\"rw\",\"code\":\"work_mode\",\"description\":\"调色场景、动态模式、场景模式、音乐场景，白光模式\",\"extensions\":{\"iconName\":\"icon-dp_mode\"},\"name\":\"模式\",\"typeSpec\":{\"range\":[\"color\",\"dynamic_mod\",\"scene_mod\",\"music\",\"white\"],\"type\":\"enum\",\"typeDefaultValue\":\"color\"}},
```

<img width="563" alt="image" src="https://github.com/user-attachments/assets/9e91c68e-5cd8-45a6-a5f4-e2434a2b4a9f" />
