### PR TITLE
Update wilfa_haze_hu400bc_humidifier.yaml

### DIFF
--- a/custom_components/tuya_local/devices/wilfa_haze_hu400bc_humidifier.yaml
+++ b/custom_components/tuya_local/devices/wilfa_haze_hu400bc_humidifier.yaml
@@ -157,7 +157,7 @@ entities:
           - dps_val: "12"
             value: "12h"
   - entity: switch
-    name: Air clean
+    name: Heat
     category: config
     icon: "mdi:air-purifier"
     dps:


### PR DESCRIPTION
The "air clean" switch toggles the units heating mode. The actual plasma/ion feature is toggled via the Ionizer switch, that is the only air cleaning feature this device has.

![image](https://github.com/user-attachments/assets/4db98d62-a5a7-4498-8c5a-bb41fa7b1cf3)


![Screenshot_20250105_170958_Smart Life](https://github.com/user-attachments/assets/1b3fae53-e363-481e-b0ad-87d2ea9c5095)
