### PR TITLE
Add ZY-M100-WIFI24G V2

### DIFF
--- a/custom_components/tuya_local/devices/zym100w_v2_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym100w_v2_presence_sensor.yaml
@@ -1,7 +1,7 @@
 name: mmWave presence sensor
 products:
   - id: 5lld8pgsoynvctqa
-    name: ZY-M100-WIFI24G V2
+    model: ZY-M100-WIFI24G V2
 entities:
   - entity: binary_sensor
     class: motion

--- a/custom_components/tuya_local/devices/zym100w_v2_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zym100w_v2_presence_sensor.yaml
@@ -1,0 +1,115 @@
+name: mmWave presence sensor
+products:
+  - id: 5lld8pgsoynvctqa
+    name: ZY-M100-WIFI24G V2
+entities:
+  - entity: binary_sensor
+    class: motion
+    dps:
+      - id: 1
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: move
+            value: true
+          - value: false
+  - entity: number
+    name: Sensitivity
+    category: config
+    icon: "mdi:motion-sensor"
+    dps:
+      - id: 2
+        type: integer
+        name: value
+        optional: true
+        range:
+          min: 1
+          max: 10
+  - entity: number
+    name: Minimum distance
+    category: config
+    icon: "mdi:arrow-collapse-left"
+    dps:
+      - id: 3
+        type: integer
+        name: value
+        unit: m
+        range:
+          min: 0
+          max: 825
+        mapping:
+          - scale: 100
+            step: 75
+  - entity: number
+    name: Maximum distance
+    category: config
+    icon: "mdi:arrow-collapse-right"
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: m
+        range:
+          min: 75
+          max: 900
+        mapping:
+          - scale: 100
+            step: 75
+  - entity: sensor
+    class: distance
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: m
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: number
+    name: Presence sensitivity
+    category: config
+    icon: "mdi:motion-sensor"
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        optional: true
+        range:
+          min: 1
+          max: 10
+  - entity: sensor
+    class: illuminance
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: lx
+        class: measurement
+  - entity: binary_sensor
+    class: occupancy
+    dps:
+      - id: 1
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: presence
+            value: true
+          - dps_val: move
+            value: true
+          - value: false
+      - id: 104
+        type: string
+        name: manned
+  - entity: number
+    name: Delay
+    category: config
+    class: duration
+    icon: "mdi:camera-timer"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 5
+          max: 15000


### PR DESCRIPTION
Refs https://github.com/make-all/tuya-local/pull/2611#issuecomment-2572950015

@make-all, this is my `tinytuya` device information:

```json
    {
        "name": "Presence sensor",
        "id": "redacted",
        "key": "redacted",
        "mac": "redacted",
        "uuid": "redacted",
        "sn": "redacted",
        "category": "hps",
        "product_name": "ZY-M100-WIFI24G\u5b58\u5728\u4f20\u611f\u5668V2",
        "product_id": "5lld8pgsoynvctqa",
        "biz_type": 0,
        "model": "",
        "sub": false,
        "icon": "https://images.tuyaus.com/smart/icon/ay15431316572284AcPZ/51bdad4264cd4894214d790a99c39ca8.png",
        "mapping": {
            "1": {
                "code": "presence_state",
                "type": "Enum",
                "values": {
                    "range": [
                        "none",
                        "presence"
                    ]
                }
            },
            "2": {
                "code": "sensitivity",
                "type": "Integer",
                "values": {
                    "unit": "",
                    "min": 1,
                    "max": 10,
                    "scale": 0,
                    "step": 1
                }
            },
            "3": {
                "code": "near_detection",
                "type": "Integer",
                "values": {
                    "unit": "M",
                    "min": 0,
                    "max": 825,
                    "scale": 2,
                    "step": 75
                }
            },
            "4": {
                "code": "far_detection",
                "type": "Integer",
                "values": {
                    "unit": "M",
                    "min": 75,
                    "max": 900,
                    "scale": 2,
                    "step": 75
                }
            },
            "9": {
                "code": "target_dis_closest",
                "type": "Integer",
                "values": {
                    "unit": "M",
                    "min": 0,
                    "max": 100,
                    "scale": 1,
                    "step": 1
                }
            },
            "103": {
                "code": "illuminance_value",
                "type": "Integer",
                "values": {
                    "unit": "lux",
                    "min": 0,
                    "max": 10000,
                    "scale": 0,
                    "step": 1
                }
            }
        },
        "ip": "redacted",
        "version": "3.3"
    },
```

I believe this is indeed a different device, given the name has `V2` at the end.

And I believe the product ID can be used to disambiguate in this case.

The only changes I did were in the product ID and name, and also in the minimum and maximum distance ranges.

Everything else is exactly the same as the previous profile.