### PR TITLE
Add Clofte 400 Duo humidifier config

### DIFF
--- a/custom_components/tuya_local/devices/clofte_400_duo_humidifier.yaml
+++ b/custom_components/tuya_local/devices/clofte_400_duo_humidifier.yaml
@@ -1,0 +1,92 @@
+name: Humidifier
+products:
+  - id: aa8iuikeenvbsznx
+    manufacturer: CLOFTE
+    model: DUO 400
+    model_id: T3-CLOFTE
+entities:
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 111
+        type: integer
+        name: speed
+        range:
+          min: 0
+          max: 4
+        mapping:
+          - dps_val: 1
+            value: 1
+          - dps_val: 2
+            value: 2
+          - dps_val: 3
+            value: 3
+          - dps_val: 4
+            value: 4
+          - dps_val: 0
+            value: 0
+  - entity: switch
+    name: Sleep
+    translation_key: sleep
+    dps:
+      - id: 101
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Quiet
+    icon: mdi:volume-high
+    dps:
+      - id: 116
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Drying
+    dps:
+      - id: 105
+        name: switch
+        type: boolean
+  - entity: sensor
+    name: PM2.5
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: µg/m³
+  - entity: binary_sensor
+    translation_key: tank_empty
+    name: Water level low
+    category: diagnostic
+    dps:
+      - id: 108
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: high
+            value: false
+          - dps_val: low
+            value: true
+  - entity: button
+    translation_key: filter_reset
+    category: config
+    dps:
+      - id: 11
+        type: boolean
+        name: button
+  - entity: sensor
+    name: Filter left
+    icon: mdi:air-filter
+    category: diagnostic
+    dps:
+      - id: 16
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: switch
+    translation_key: uv_sterilization
+    dps:
+      - id: 9
+        type: boolean
+        name: switch

--- a/custom_components/tuya_local/devices/clofte_duo_400_humidifier.yaml
+++ b/custom_components/tuya_local/devices/clofte_duo_400_humidifier.yaml
@@ -1,8 +1,8 @@
 name: Humidifier
 products:
   - id: aa8iuikeenvbsznx
-    manufacturer: CLOFTE
-    model: DUO 400
+    manufacturer: Clofte
+    model: Duo 400
     model_id: T3-CLOFTE
 entities:
   - entity: fan
@@ -18,15 +18,14 @@ entities:
           min: 0
           max: 4
   - entity: switch
-    name: Sleep
     translation_key: sleep
     dps:
       - id: 101
         name: switch
         type: boolean
   - entity: switch
-    name: Quiet
-    icon: mdi:volume-high
+    name: Mute
+    icon: mdi:volume-mute
     dps:
       - id: 116
         name: switch
@@ -38,19 +37,25 @@ entities:
         name: switch
         type: boolean
   - entity: sensor
-    name: PM2.5
+    class: pm25
     dps:
       - id: 2
         type: integer
         name: sensor
         unit: µg/m³
   - entity: sensor
-    name: Water level
+    translation_key: water_level
+    class: enum
     category: diagnostic
     dps:
       - id: 108
         type: string
         name: sensor
+        mapping:
+          - dps_val: low
+            value: low
+          - dps_val: high
+            value: high
   - entity: button
     translation_key: filter_reset
     category: config
@@ -59,7 +64,7 @@ entities:
         type: boolean
         name: button
   - entity: sensor
-    name: Filter left
+    name: Filter life
     icon: mdi:air-filter
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/clofte_duo_400_humidifier.yaml
+++ b/custom_components/tuya_local/devices/clofte_duo_400_humidifier.yaml
@@ -17,17 +17,6 @@ entities:
         range:
           min: 0
           max: 4
-        mapping:
-          - dps_val: 1
-            value: 1
-          - dps_val: 2
-            value: 2
-          - dps_val: 3
-            value: 3
-          - dps_val: 4
-            value: 4
-          - dps_val: 0
-            value: 0
   - entity: switch
     name: Sleep
     translation_key: sleep
@@ -55,19 +44,13 @@ entities:
         type: integer
         name: sensor
         unit: µg/m³
-  - entity: binary_sensor
-    translation_key: tank_empty
-    name: Water level low
+  - entity: sensor
+    name: Water level
     category: diagnostic
     dps:
       - id: 108
-        type: bitfield
+        type: string
         name: sensor
-        mapping:
-          - dps_val: high
-            value: false
-          - dps_val: low
-            value: true
   - entity: button
     translation_key: filter_reset
     category: config


### PR DESCRIPTION
### Clofte DUO 400
#### Type: Humidifier

<details>
  <summary>Device diagnostic data from official Tuya integration (click to open spoiler)</summary>

  ```json
  {
"data": {
    "device_config": {
      "device_id": "bfc3fe2a1e09988f0fkior",
      "dps_strings": [
        "1 ( code: switch , value: True )",
        "2 ( code: pm25 , value: 0, cloud pull )",
        "7 ( code: lock , value: False )",
        "9 ( code: uv , value: True )",
        "11 ( code: filter_reset , value: False, cloud pull )",
        "16 ( code: filter_days , value: 91 )",
        "101 ( code: sleep , value: True )",
        "102 ( code: humidifier , value: False )",
        "103 ( code: humidity_current , value: 55 )",
        "104 ( code: alarm_lock , value: mon_err, cloud pull )",
        "105 ( code: drying , value: False )",
        "106 ( code: work_mode , value: null )",
        "107 ( code: main_title , value: 0, cloud pull )",
        "108 ( code: water_level , value: high )",
        "109 ( code: sound , value: False, cloud pull )",
        "110 ( code: auto , value: False )",
        "111 ( code: fan_speed , value: 0 )",
        "112 ( code: mos_temp , value: 25 )",
        "113 ( code: fan_countdown , value: 0 )",
        "114 ( code: auto_enum , value: A0 )",
        "115 ( code: switch_led , value: False )",
        "116 ( code: quiet , value: False )"
      ],
      "enable_debug": false,
      "entities": [
        {
          "entity_category": "None",
          "fan_direction_forward": "forward",
          "fan_direction_reverse": "reverse",
          "fan_dps_type": "int",
          "fan_speed_control": "111",
          "fan_speed_max": 100,
          "fan_speed_min": 1,
          "fan_speed_ordered_list": "disabled",
          "friendly_name": "Fan",
          "icon": "mdi:fan",
          "id": "1",
          "platform": "fan"
        },
        {
          "device_class": "pm25",
          "entity_category": "None",
          "friendly_name": "",
          "icon": "mdi:molecule",
          "id": "2",
          "platform": "sensor",
          "state_class": "measurement"
        },
        {
          "entity_category": "config",
          "friendly_name": "Child Lock",
          "icon": "mdi:account-lock",
          "id": "7",
          "platform": "switch"
        },
        {
          "entity_category": "config",
          "friendly_name": "UV Sterilization",
          "icon": "mdi:minus-circle-outline",
          "id": "9",
          "platform": "switch"
        },
        {
          "entity_category": "config",
          "friendly_name": "Reset Filter Cartridge_",
          "icon": "mdi:filter",
          "id": "11",
          "platform": "switch"
        }
      ],
      "friendly_name": "CLOFTE DUO 400",
      "host": "192.168.1.2",
      "local_key": ">M",
      "model": "T3-CLOFTE",
      "node_id": null,
      "product_key": "aa8iuikeenvbsznx",
      "protocol_version": "3.4"
    },
    "device_cloud_info": {
      "active_time": 1732981271,
      "biz_type": 0,
      "category": "kj",
      "create_time": 1732981271,
      "icon": "smart/icon/bay1657599523714O4jd/f8dc40b4e5e313a60d6608f681b33df5.png",
      "id": "bfc3fe2a1e09988f0fkior",
      "ip": "7...8",
      "lat": "",
      "local_key": ">EH...?vM",
      "lon": "",
      "model": "T3-CLOFTE",
      "name": "CLOFTE DUO 400",
      "online": true,
      "owner_id": "191675710",
      "product_id": "aa8iuikeenvbsznx",
      "product_name": "CLOFTE DUO 400",
      "status": [
        {
          "code": "switch",
          "value": false
        },
        {
          "code": "pm25",
          "value": 0
        },
        {
          "code": "lock",
          "value": false
        },
        {
          "code": "uv",
          "value": true
        },
        {
          "code": "filter_reset",
          "value": false
        },
        {
          "code": "filter_days",
          "value": 83
        }
      ],
      "sub": false,
      "time_zone": "+01:00",
      "uid": "eu1...tCM",
      "update_time": 1735773386,
      "uuid": "b019012a3aab0fe9",
      "dps_data": {
        "1": {
          "code": "switch",
          "custom_name": "",
          "dp_id": 1,
          "time": 1735897232459,
          "type": "Boolean",
          "value": false,
          "values": "{\"type\": \"bool\"}",
          "id": 1,
          "accessMode": "rw"
        },
        "2": {
          "code": "pm25",
          "custom_name": "",
          "dp_id": 2,
          "time": 1732981271694,
          "type": "value",
          "value": 0,
          "id": 2,
          "accessMode": "ro",
          "values": "{\"type\": \"value\", \"max\": 999, \"min\": 0, \"scale\": 0, \"step\": 1, \"unit\": \"ug/m3\"}"
        },
        "7": {
          "code": "lock",
          "custom_name": "",
          "dp_id": 7,
          "time": 1735773389006,
          "type": "Boolean",
          "value": false,
          "values": "{\"type\": \"bool\"}",
          "id": 7,
          "accessMode": "rw"
        },
        "9": {
          "code": "uv",
          "custom_name": "",
          "dp_id": 9,
          "time": 1735773389006,
          "type": "Boolean",
          "value": true,
          "values": "{\"type\": \"bool\"}",
          "id": 9,
          "accessMode": "rw"
        },
        "11": {
          "code": "filter_reset",
          "custom_name": "",
          "dp_id": 11,
          "time": 1732981271694,
          "type": "Boolean",
          "value": false,
          "values": "{\"type\": \"bool\"}",
          "id": 11,
          "accessMode": "rw"
        },
        "16": {
          "code": "filter_days",
          "custom_name": "",
          "dp_id": 16,
          "time": 1735892449130,
          "type": "value",
          "value": 83,
          "id": 16,
          "accessMode": "ro",
          "values": "{\"type\": \"value\", \"max\": 100, \"min\": 0, \"scale\": 0, \"step\": 1, \"unit\": \"%\"}"
        },
        "101": {
          "code": "sleep",
          "custom_name": "",
          "dp_id": 101,
          "time": 1735782870609,
          "type": "bool",
          "value": true,
          "id": 101,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        },
        "102": {
          "code": "humidifier",
          "custom_name": "",
          "dp_id": 102,
          "time": 1735773389006,
          "type": "bool",
          "value": false,
          "id": 102,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        },
        "103": {
          "code": "humidity_current",
          "custom_name": "",
          "dp_id": 103,
          "time": 1735938592101,
          "type": "value",
          "value": 36,
          "id": 103,
          "accessMode": "ro",
          "values": "{\"type\": \"value\", \"max\": 100, \"min\": 0, \"scale\": 0, \"step\": 1, \"unit\": \"%\"}"
        },
        "104": {
          "code": "alarm_lock",
          "custom_name": "",
          "dp_id": 104,
          "time": 1732981271694,
          "type": "enum",
          "value": "mon_err",
          "id": 104,
          "accessMode": "ro",
          "values": "{\"type\": \"enum\", \"range\": [\"mon_err\", \"door_open\", \"ht_sensor_err\", \"pm25_sensor_err\", \"water_sensor_err\", \"water_high\", \"water_low\", \"no_bucket\", \"filter_alert\", \"show_off_app\"]}"
        },
        "105": {
          "code": "drying",
          "custom_name": "",
          "dp_id": 105,
          "time": 1735773389006,
          "type": "bool",
          "value": false,
          "id": 105,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        },
        "106": {
          "code": "work_mode",
          "custom_name": "",
          "dp_id": 106,
          "time": 1735782870616,
          "type": "enum",
          "value": "null",
          "id": 106,
          "accessMode": "rw",
          "values": "{\"type\": \"enum\", \"range\": [\"40\", \"50\", \"60\", \"null\"]}"
        },
        "107": {
          "code": "main_title",
          "custom_name": "",
          "dp_id": 107,
          "time": 1732981271694,
          "type": "value",
          "value": 0,
          "id": 107,
          "accessMode": "rw",
          "values": "{\"type\": \"value\", \"max\": 3, \"min\": 0, \"scale\": 0, \"step\": 1, \"unit\": \"\"}"
        },
        "108": {
          "code": "water_level",
          "custom_name": "",
          "dp_id": 108,
          "time": 1735773389006,
          "type": "enum",
          "value": "high",
          "id": 108,
          "accessMode": "ro",
          "values": "{\"type\": \"enum\", \"range\": [\"low\", \"high\"]}"
        },
        "109": {
          "code": "sound",
          "custom_name": "",
          "dp_id": 109,
          "time": 1732981271694,
          "type": "bool",
          "value": false,
          "id": 109,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        },
        "110": {
          "code": "auto",
          "custom_name": "",
          "dp_id": 110,
          "time": 1735782870602,
          "type": "bool",
          "value": false,
          "id": 110,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        },
        "111": {
          "code": "fan_speed",
          "custom_name": "",
          "dp_id": 111,
          "time": 1735782869618,
          "type": "value",
          "value": 0,
          "id": 111,
          "accessMode": "rw",
          "values": "{\"type\": \"value\", \"max\": 4, \"min\": 0, \"scale\": 0, \"step\": 1, \"unit\": \"\"}"
        },
        "112": {
          "code": "mos_temp",
          "custom_name": "",
          "dp_id": 112,
          "time": 1735939791122,
          "type": "value",
          "value": 27,
          "id": 112,
          "accessMode": "ro",
          "values": "{\"type\": \"value\", \"max\": 150, \"min\": -40, \"scale\": 0, \"step\": 1, \"unit\": \"\u2103\"}"
        },
        "113": {
          "code": "fan_countdown",
          "custom_name": "",
          "dp_id": 113,
          "time": 1735773389006,
          "type": "value",
          "value": 0,
          "id": 113,
          "accessMode": "rw",
          "values": "{\"type\": \"value\", \"max\": 8, \"min\": 0, \"scale\": 0, \"step\": 1, \"unit\": \"h\"}"
        },
        "114": {
          "code": "auto_enum",
          "custom_name": "",
          "dp_id": 114,
          "time": 1735773389006,
          "type": "enum",
          "value": "A0",
          "id": 114,
          "accessMode": "rw",
          "values": "{\"type\": \"enum\", \"range\": [\"A0\", \"A1\", \"A2\", \"A3\", \"A4\"]}"
        },
        "115": {
          "code": "switch_led",
          "custom_name": "",
          "dp_id": 115,
          "time": 1735943088599,
          "type": "bool",
          "value": false,
          "id": 115,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        },
        "116": {
          "code": "quiet",
          "custom_name": "",
          "dp_id": 116,
          "time": 1735773389006,
          "type": "bool",
          "value": false,
          "id": 116,
          "accessMode": "rw",
          "values": "{\"type\": \"bool\"}"
        }
      }
    }
  }
  }
  ```
  
</details>


<details>
  <summary>Screenshots</summary>
  
![Arc 2025-01-08 14 41 32](https://github.com/user-attachments/assets/d95bdb23-1c33-4c6f-90d2-0d19df418c3e)
![image](https://github.com/user-attachments/assets/006fc47b-453d-4df1-99bf-826467ecacbb)
![Arc 2025-01-08 14 44 43](https://github.com/user-attachments/assets/f837c288-28da-4b05-9dbe-6848deba46a5)


  
</details>


#### Notes:
- PM2.5 sensor is available in the API but returns no value. I guess it will be updated in the future with a new firmware
- The device is not recognized automatically and you must choose a match from the dropdown. I don't know if it is expected behaviour or not.