### PR TITLE
YAML for the Casafan Eco Genuino

### DIFF
--- a/custom_components/tuya_local/devices/casafan_ceiling_fan.yaml
+++ b/custom_components/tuya_local/devices/casafan_ceiling_fan.yaml
@@ -1,0 +1,42 @@
+name: Ceiling fan
+products:
+  - id: 000001nbqb
+    name: Casafan Eco Genuino
+primary_entity:
+  entity: fan
+  translation_only_key: fan_with_presets
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: string
+      name: preset_mode
+    - id: 3
+      type: integer
+      name: speed
+      range:
+        min: 1
+        max: 6
+    - id: 8
+      type: string
+      name: direction
+secondary_entities:
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "off"
+          - dps_val: "1hour"
+            value: "1h"
+          - dps_val: "2hour"
+            value: "2h"
+          - dps_val: "4hour"
+            value: "4h"
+          - dps_val: "8hour"
+            value: "8h"


### PR DESCRIPTION
Here is a tested version of a device YAML file for the Casafan Eco Genuino fan models (I have the 1.8 meters model, I assume this will work on other diameters, possibly with different model ids). It has different DPs and DP values than the existing "casafan with light" device.

Information has been extracted from Tuya cloud platform.