### PR TITLE
Added a device YAML file for the lightless Casafan Eco Genuino

### DIFF
--- a/custom_components/tuya_local/devices/casafan_ceiling_fan.yaml
+++ b/custom_components/tuya_local/devices/casafan_ceiling_fan.yaml
@@ -1,0 +1,42 @@
+name: Ceiling fan
+products:
+  - id: 000001nbqb
+    name: Casafan Eco Genuino
+primary_entity:
+  entity: fan
+  translation_only_key: fan_with_presets
+  dps:
+    - id: 1
+      type: boolean
+      name: switch
+    - id: 2
+      type: string
+      name: preset_mode
+    - id: 3
+      type: integer
+      name: speed
+      range:
+        min: 1
+        max: 6
+    - id: 8
+      type: string
+      name: direction
+secondary_entities:
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "off"
+          - dps_val: "1hour"
+            value: "1h"
+          - dps_val: "2hour"
+            value: "2h"
+          - dps_val: "4hour"
+            value: "4h"
+          - dps_val: "8hour"
+            value: "8h"

--- a/custom_components/tuya_local/devices/casafan_ceiling_fan.yaml
+++ b/custom_components/tuya_local/devices/casafan_ceiling_fan.yaml
@@ -12,6 +12,13 @@ primary_entity:
     - id: 2
       type: string
       name: preset_mode
+      mapping:
+        - dps_val: normal
+          value: normal
+        - dps_val: sleep
+          value: sleep
+        - dps_val: nature
+          value: nature
     - id: 3
       type: integer
       name: speed


### PR DESCRIPTION
The YAML file has been tested with the corresponding model (1.8 meters diameter model, it's possible that other diameters have different model ids). The information has been extracted from Tuya Cloud Platform.

