### PR TITLE
add suport for GW Motor Roller blind (Gateway sub-device)

### DIFF
--- a/custom_components/tuya_local/devices/gw_motor_roller_blind.yaml
+++ b/custom_components/tuya_local/devices/gw_motor_roller_blind.yaml
@@ -1,0 +1,50 @@
+name: Roller blind
+products:
+  - id: slrxhmozdm3qq9cl
+    manufacturer: GW Motor
+    model: Roller blind
+    name: Sub-device roller blind (gateway)
+entities:
+  - entity: cover
+    class: blind
+    dps:
+      - id: 1
+        name: control
+        type: string
+        mapping:
+          - conditions:
+              - dps_val: ["0", "1", "2"]
+                mapping:
+                  - dps_val: "0"
+                    value: open
+                  - dps_val: "1"
+                    value: close
+                  - dps_val: "2"
+                    value: stop
+              # set options when there are non during startup
+              - dps_val: null
+                mapping:
+                  - dps_val: open
+                    value: open
+                  - dps_val: close
+                    value: close
+                  - dps_val: stop
+                    value: stop
+      - id: 2
+        # this is percent_control in the API Explorer but we'll use it to get the
+        # last position set, as the device cannot report its current_position.
+        # will be incorrect when manually opening / closing.
+        name: percent_control
+        type: integer
+        unit: "%"
+        optional: true
+        range:
+          min: 0
+          max: 100
+      - id: 101
+        name: position
+        type: integer
+        unit: "%"
+        range:
+          min: 0
+          max: 100

--- a/custom_components/tuya_local/devices/gw_motor_roller_blind.yaml
+++ b/custom_components/tuya_local/devices/gw_motor_roller_blind.yaml
@@ -31,10 +31,10 @@ entities:
                   - dps_val: stop
                     value: stop
       - id: 2
-        # this is percent_control in the API Explorer but we'll use it to get the
+        # this is percent_control in API Explorer but we'll use it to get the
         # last position set, as the device cannot report its current_position.
         # will be incorrect when manually opening / closing.
-        name: percent_control
+        name: current_position
         type: integer
         unit: "%"
         optional: true


### PR DESCRIPTION
also _closes_ (has been closed already) #170 (there had been no general sub-device support back then)