### PR TITLE
add support for GW Motor Roller Blind

### DIFF
--- a/custom_components/tuya_local/devices/gw_motor_roller_blind.yaml
+++ b/custom_components/tuya_local/devices/gw_motor_roller_blind.yaml
@@ -1,0 +1,50 @@
+name: Roller blind
+products:
+  - id: slrxhmozdm3qq9cl
+    manufacturer: GW Motor
+    model: Roller blind
+    name: Sub-device roller blind (gateway)
+entities:
+  - entity: cover
+    class: blind
+    dps:
+      - id: 1
+        name: control
+        type: string
+        mapping:
+          - conditions:
+              - dps_val: ["0", "1", "2"]
+                mapping:
+                  - dps_val: "0"
+                    value: open
+                  - dps_val: "1"
+                    value: close
+                  - dps_val: "2"
+                    value: stop
+              # set options when there are non during startup
+              - dps_val: null
+                mapping:
+                  - dps_val: open
+                    value: open
+                  - dps_val: close
+                    value: close
+                  - dps_val: stop
+                    value: stop
+      - id: 2
+        # this is percent_control in API Explorer but we'll use it to get the
+        # last position set, as the device cannot report its current_position.
+        # will be incorrect when manually opening / closing.
+        name: current_position
+        type: integer
+        unit: "%"
+        optional: true
+        range:
+          min: 0
+          max: 100
+      - id: 101
+        name: position
+        type: integer
+        unit: "%"
+        range:
+          min: 0
+          max: 100


### PR DESCRIPTION
also _closes_ (has been closed already) #170 (there had been no general sub-device support back then)

Tuyas API Explorer output:

Device details
```
{
      "active_time": 1652036366,
      "bind_space_id": "123",
      "category": "cl",
      "create_time": 1652036366,
      "custom_name": "test",
      "icon": "smart/icon/ay1521165954459sVl6M/95ef6a9e597c0700f6898944e7132ed3.png",
      "id": "abc123",
      "ip": "",
      "is_online": true,
      "lat": "41.4054",
      "local_key": "",
      "lon": "2.1427",
      "model": "GW Motor",
      "name": "Roller blind 3",
      "product_id": "slrxhmozdm3qq9cl",
      "product_name": "Sub-device roller blinds (gateway)",
      "sub": true,
      "time_zone": "+02:00",
      "update_time": 1652036379,
      "uuid": "abc123"
    }
```
properties
```
 [
      {
        "code": "control",
        "custom_name": "",
        "dp_id": 1,
        "time": 1736675254772,
        "type": "enum",
        "value": "0"
      },
      {
        "code": "percent_control",
        "custom_name": "",
        "dp_id": 2,
        "time": 1652036366678,
        "type": "value",
        "value": 0
      },
      {
        "code": "percent_state",
        "custom_name": "",
        "dp_id": 3,
        "time": 1652036366678,
        "type": "value",
        "value": 0
      },
      {
        "code": "control_back",
        "custom_name": "",
        "dp_id": 5,
        "time": 1652036366678,
        "type": "enum",
        "value": "forward"
      },
      {
        "code": "work_state",
        "custom_name": "",
        "dp_id": 7,
        "time": 1652036366678,
        "type": "enum",
        "value": "opening"
      },
      {
        "code": "fault",
        "custom_name": "",
        "dp_id": 12,
        "time": 1652036366678,
        "type": "bitmap",
        "value": 0
      },
      {
        "code": "position_best",
        "custom_name": "",
        "dp_id": 19,
        "time": 1652036366678,
        "type": "value",
        "value": 0
      },
      {
        "code": "position",
        "custom_name": "",
        "dp_id": 101,
        "time": 1736675252842,
        "type": "value",
        "value": 75
      },
      {
        "code": "direction",
        "custom_name": "",
        "dp_id": 102,
        "time": 1652036366678,
        "type": "bool",
        "value": false
      },
      {
        "code": "border",
        "custom_name": "",
        "dp_id": 103,
        "time": 1652036366678,
        "type": "enum",
        "value": "1"
      },
      {
        "code": "state",
        "custom_name": "",
        "dp_id": 104,
        "time": 1652036366678,
        "type": "enum",
        "value": "0"
      },
      {
        "code": "curtain_AC_control",
        "custom_name": "",
        "dp_id": 105,
        "time": 1652036366678,
        "type": "enum",
        "value": "1"
      },
      {
        "code": "curtain_DC_control",
        "custom_name": "",
        "dp_id": 106,
        "time": 1652036366678,
        "type": "enum",
        "value": "1"
      },
      {
        "code": "curtain_type",
        "custom_name": "",
        "dp_id": 107,
        "time": 1652036366678,
        "type": "string",
        "value": ""
      },
      {
        "code": "report",
        "custom_name": "",
        "dp_id": 108,
        "time": 1652036366678,
        "type": "string",
        "value": ""
      },
      {
        "code": "borderState",
        "custom_name": "",
        "dp_id": 109,
        "time": 1652036369080,
        "type": "bool",
        "value": true
      },
      {
        "code": "surrenPosition",
        "custom_name": "",
        "dp_id": 110,
        "time": 1652036366678,
        "type": "value",
        "value": 0
      },
      {
        "code": "style",
        "custom_name": "",
        "dp_id": 111,
        "time": 1652036366678,
        "type": "enum",
        "value": "0"
      },
      {
        "code": "tilt_move",
        "custom_name": "",
        "dp_id": 112,
        "time": 1652036366678,
        "type": "enum",
        "value": "0"
      },
      {
        "code": "light_state",
        "custom_name": "",
        "dp_id": 113,
        "time": 1652036366678,
        "type": "enum",
        "value": "0"
      },
      {
        "code": "lightness",
        "custom_name": "",
        "dp_id": 114,
        "time": 1652036366678,
        "type": "enum",
        "value": "0"
      },
      {
        "code": "light_percent",
        "custom_name": "",
        "dp_id": 115,
        "time": 1652036366678,
        "type": "value",
        "value": 0
      }
    ]
```

instruction set

```
"result": {
    "category": "cl",
    "functions": [
      {
        "code": "control",
        "desc": "control",
        "name": "control",
        "type": "Enum",
        "values": "{\"range\":[\"open\",\"stop\",\"close\",\"continue\"]}"
      },
      {
        "code": "percent_control",
        "desc": "percent control",
        "name": "percent control",
        "type": "Integer",
        "values": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
      }
    ]
```
data model
```
{
  "result":{
     "model":"{
      \"modelId\":\"0000004dba\",
      \"services\":[{
        \"actions\":[],
        \"code\":\"\",
        \"description\":\"\",
        \"events\":[],
        \"name\":\"Default Services\",
        \"properties\":[
        {
          \"abilityId\":1,
          \"accessMode\":\"rw\",
          \"code\":\"control\",
          \"description\":\"0-up; 1-down; 2-stop; 3-continue\",
          \"name\":\"Curtain control\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"0\",\"1\",\"2\",\"3\"]
          }
        },
        {
          \"abilityId\":2,
          \"accessMode\":\"rw\",
          \"code\":\"percent_control\",
          \"description\":\"If the curtain motor can monitor the current position of the curtain, for example, the curtain is now half open, that is, 50%, then the curtain position can be customized through this DP point. Control the use of this DP point. If this DP point is selected, you must select "Open percentage status display". The value range parameter of this DP point cannot be modified, and it cannot be increased or decreased.\",
          \"name\":\"Enable percentage control\",
          \"typeSpec\":{
            \"type\":\"value\",
            \"max\":100,
            \"min\":0,
            \"scale\":0,
            \"step\":1,
            \"unit\":\"%\"
          }
        },
        {
          \"abilityId\":3,
          \"accessMode\":\"ro\",
          \"code\":\"percent_state\",
          \"description\":\"This DP point is used in conjunction with the ""Opening percentage status control". This DP point is used to display the actual curtain position. The value range parameter of this DP point is not allowed to be modified, and it is not allowed to increase or decrease.\",
          \"name\":\"Open percentage status\",
          \"typeSpec\":{
            \"type\":\"value\",
            \"max\":100,
            \"min\":0,
            \"scale\":0,
            \"step\":1,
            \"unit\":\"%\"
          }
        },
        {
          \"abilityId\":5,
          \"accessMode\":\"rw\",
          \"code\":\"control_back\",
          \"description\":\"Used to set the direction of the motor, clockwise or counterclockwise, forward represents clockwise, back represents counterclockwise\",
          \"name\":\"Motor reverse\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"forward\",\"back\"]
          }
        },
        {
          \"abilityId\":7,
          \"accessMode\":\"ro\"
          ,\"code\":\"work_state\",
          \"description\":\"[Required] Used to display the current working status of the motor. The DP point enumeration value parameter is not allowed to be modified, and it is not allowed to increase or decrease. If you need to modify the content displayed in the APP panel, you can go to the expansion center in the fourth step, multi-language management to modify the representative value. The content represented by the newly added enumeration value is also modified in the multi-language.\",
          \"name\":\"Working state\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"opening\",\"closing\"]
          }
        },
        {
          \"abilityId\":12,
          \"accessMode\":\"ro\",
          \"code\":\"fault\",
          \"description\":\"[Required] The device reports the fault value. The enumeration value of this DP point can be increased or decreased, but the name of the enumeration value cannot be modified. For example, motor_fault can be deleted and other values ​​can be added. If it is not selected, this function will not be displayed. If you need to modify the content displayed in the APP panel, you can go to the expansion center in the fourth step, multi-language management to modify the representative value. The content represented by the newly added enumeration value is also modified in the multi-language representative value.\",
          \"name\":\"Fault alarm\",
          \"typeSpec\":{
            \"type\":\"bitmap\",
            \"label\":[\"motor_fault\"],
            \"maxlen\":1
          }
        },
        {
          \"abilityId\":19,
          \"accessMode\":\"rw\",
          \"code\":\"position_best\",
          \"description\":\"\",
          \"extensions\":{
            \"attribute\":\"128\"
          },
          \"name\":\"Best location\",
          \"typeSpec\":{
            "type\":\"value\",
            \"max\":100,
            \"min\":0,
            \"scale\":0,
            \"step\":1,
            \"unit\":\"%\"
          }
        },
        {
          \"abilityId\":101,
          \"accessMode\":\"rw\",
          \"code\":\"position\",
          \"description\":\"\",
          \"name\":\"Best location\",
          \"typeSpec\":{
            \"type\":\"value\",
            \"max\":100,
            \"min\":0,
            \"scale\":0,
            \"step\":1,
            \"unit\":\"%\"
          }
        },
        {
          \"abilityId\":102,
          \"accessMode\":\"rw\",
          \"code\":\"direction\",
          \"description\":\"0: default direction \\n1: reverse direction\",
          \"name\":\"Setting Direction\",
          \"typeSpec\":{
            \"type\":\"bool\"
          }
        },
        {
          \"abilityId\":103,
          \"accessMode\":\"rw\",
          \"code\":\"border\",
          \"description\":\"\",
          \"name\":\"Setting Limits\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"1\",\"2\",\"3\",\"4\",\"5\"]
          }
        },
        {
          \"abilityId\":104,
          \"accessMode\":\"rw\",
          \"code\":\"state\",
          \"description\":\"【Reserved item, not used yet】\",
          \"name\":\"Motor status\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"0\",\"1\",\"2\",\"3\"]
          }
        },
        {
          \"abilityId\":105,
          \"accessMode\":\"rw\",
          \"code\":\"curtain_AC_control\",
          \"description\":\"【Reserved item, not used yet】\",
          \"name\":\"Motor power control method\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"1\",\"2\",\"3\",\"4\"]
          }
        },
        {
          \"abilityId\":106,
          \"accessMode\":\"rw\",
          \"code\":\"curtain_DC_control\",
          \"description\":\"【Reserved item, not used yet】\",
          \"name\":\"Motor weak current control mode\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"1\",\"2\",\"3\",\"4\"]
          }
        },
        {
          \"abilityId\":107,
          \"accessMode\":\"rw\",
          \"code\":\"curtain_type\",
          \"description\":\"【Reserved item, not used yet】\",
          \"name\":\"Motor Type\",
          \"typeSpec\":{
            \"type\":\"string\",
            \"maxlen\":255
          }
        },
        {
          \"abilityId\":108,
          \"accessMode\":\"rw\",
          \"code\":\"report\",
          \"description\":\"【Reserved item, not used yet】\",
          \"name\":\"Motor information reporting\",
          \"typeSpec\":{
            \"type\":\"string\",
            \"maxlen\":255
          }
        },
        {
          \"abilityId\":109,
          \"accessMode\":\"rw\",
          \"code\":\"borderState\",
          \"description\":\"0: Motor limit is not set\\n1: Motor limit is set\\nPercentage control cannot be performed when the motor limit is not set\",
          \"name\":\"Motor travel status\",
          \"typeSpec\":{
            \"type\":\"bool\"
          }
        },
        {
          \"abilityId\":110,
          \"accessMode\":\"rw\",
          \"code\":\"surrenPosition\",
          \"description\":\"【Reserved item, not used yet】\",
          \"name\":\"Query the current position of the motor\",
          \"typeSpec\":{
            \"type\":\"value\",
            \"max\":100,
            \"min\":0,
            \"scale\":0,
            \"step\":1,
            \"unit\":\"%\"
          }
        },
        {
          \"abilityId\":111,
          \"accessMode\":\"rw\",
          \"code\":\"style\",
          \"description\":\"0: Venetian blinds\\n1: Shangri-La curtains\\n2: Roller blinds\\n3: Roman blinds\\n4: Soft gauze curtains\\n5: Honeycomb blinds\\n6: Pleated blinds\\n7: Roller shutters\\n8: Awnings\\n9: Opening and closing curtains\\n10: Roman rods\\n11: Roller windows\\n12: Flip leaf roller blinds\\n13: Awnings (light control dimming)\",
          \"name\":\"Curtain Style\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\",\"9\",\"10\",\"11\",\"12\",\"13\"]
          }
        },
        {
          \"abilityId\":112,
          \"accessMode\":\"rw\",
          \"code\":\"tilt_move\",
          \"description\":\"Leaf-flip roller blind function: 0-upward leaf-flip; 1-downward leaf-flip; 2-standard leaf-flip position\",
          \"name\":\"Leaf flap control\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"0\",\"1\",\"2\"]
          }
        },
        {
          \"abilityId\":113,
          \"accessMode\":\"rw\",
          \"code\":\"light_state\",
          \"description\":\"Awning lighting function: 0-light off; 1-light on\",
          \"name\":\"Light status control\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"0\",\"1\"]
          }
        },
        {
          \"abilityId\":114,
          \"accessMode\":\"rw\",
          \"code\":\"lightness\",
          \"description\":\"Awning lighting brightness adjustment: 0-dim; 1-brighten\",
          \"name\":\"Light brightness adjustment\",
          \"typeSpec\":{
            \"type\":\"enum\",
            \"range\":[\"0\",\"1\"]
          }
        },
        {
          \"abilityId\":115,
          \"accessMode\":\"rw\",
          \"code\":\"light_percent\",
          \"description\":\"Awning lighting brightness percentage adjustment\",
          \"name\":\"Light percentage control\",
          \"typeSpec\":{
            \"type\":\"value\",
            \"max\":100,
            \"min\":0,
            \"scale\":0,
            \"step\":1,
            \"unit\":\"%\"
          }
        }
      ]}
    ]}"
  },
  "success":true,
  "t":1736711905697,
  "tid":"95a3fef4d11f11efa76ab217c6c149bc"
}
```
status reply
```
{
  "result": [
    {
      "code": "control",
      "value": "stop"
    },
    {
      "code": "percent_control",
      "value": 100
    }
  ],
  "success": true,
  "t": 1736844689527,
  "tid": ""
}
```