### PR TITLE
Add STB3L-125WJ 3-Phase smart breaker

### DIFF
--- a/custom_components/tuya_local/devices/stb3l-125wj_breaker.yaml
+++ b/custom_components/tuya_local/devices/stb3l-125wj_breaker.yaml
@@ -1,0 +1,327 @@
+name: STB3L-125WJ Circuit breaker energy meter
+products:
+  - id: sh45wydgedautxda
+    name: STB3L-125WJ
+entities:
+  - entity: switch
+    icon: "mdi:fuse"
+    dps:
+      - id: 16
+        name: switch
+        type: boolean
+
+  - entity: sensor
+    name: "Active Alarm"
+    icon: "mdi:alert-octagon"
+    category: diagnostic
+    class: enum
+    dps:
+      - id: 9
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0  # Bit 0
+            value: "Normal"
+          - dps_val: 1  # Bit 0
+            value: "Short Circuit Alarm"
+          - dps_val: 2  # Bit 1
+            value: "Surge Alarm"
+          - dps_val: 4  # Bit 2
+            value: "Overload (kW) Alarm"
+          - dps_val: 8  # Bit 3
+            value: "Earth Fault/Leak Alarm"
+          - dps_val: 16  # Bit 4
+            value: "Hi Temperature Alarm"
+          - dps_val: 32  # Bit 5
+            value: "Fire Alarm"
+          - dps_val: 64  # Bit 6
+            value: "High Current Alarm"
+          - dps_val: 128  # Bit 7
+            value: "Self-Test Alarm"
+          - dps_val: 256  # Bit 8
+            value: "Overcurrent Limit Alarm"
+          - dps_val: 512  # Bit 9
+            value: "Unbalance Alarm"
+          - dps_val: 1024  # Bit 10
+            value: "Overvoltage Alarm"
+          - dps_val: 2048  # Bit 11
+            value: "Undervoltage Alarm"
+          - dps_val: 4096  # Bit 12
+            value: "Missing Phase Alarm"
+          - dps_val: 8192  # Bit 13
+            value: "Outage Alarm"
+          - dps_val: 16384  # Bit 14
+            value: "Magnetic Interference Alarm"
+          - dps_val: 32768  # Bit 15
+            value: "Low Credit Alarm"
+          - dps_val: 65536  # Bit 16
+            value: "No Balance Alarm"
+
+  - entity: sensor
+    name: "Breaker ID"
+    icon: "mdi:identifier"
+    category: diagnostic
+    dps:
+      - id: 19
+        name: sensor
+        type: string
+
+  #
+  # =========== General Controls/Config ===========
+  #
+  - entity: switch
+    name: "Prepayment"
+    icon: "mdi:cash-multiple"
+    category: config
+    dps:
+      - id: 11
+        type: boolean
+        name: switch
+
+  - entity: button
+    name: "Energy Reset"
+    icon: "mdi:recycle"
+    class: restart
+    category: config
+    dps:
+      - id: 12
+        type: boolean
+        name: button
+        optional: true
+
+  - entity: number
+    name: "Auto-off Countdown"
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 1
+
+  #
+  # =========== Energy / Current / Voltage / Power ===========
+  #
+  - entity: sensor
+    name: "Balance Energy"
+    icon: "mdi:gauge"
+    category: diagnostic
+    class: energy_storage
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: kWh
+        mapping:
+          - scale: 10
+
+  - entity: number
+    name: "Charge Energy"
+    icon: "mdi:cash-plus"
+    category: config
+    class: energy_storage
+    dps:
+      - id: 14
+        type: integer
+        name: value
+        optional: true
+        unit: kWh
+        range:
+          min: 0
+          max: 999999
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: "Leakage Current"
+    icon: "mdi:current-ac"
+    class: current
+    category: diagnostic
+    dps:
+      - id: 15
+        type: integer
+        name: sensor
+        unit: mA
+        class: measurement
+        optional: true
+
+  - entity: button
+    name: "Earth Leak Test"
+    icon: "mdi:flash-alert"
+    category: config
+    dps:
+      - id: 21
+        type: boolean
+        name: button
+        optional: true
+
+  - entity: sensor
+    class: energy
+    name: "Total Forward Energy"
+    icon: "mdi:counter"
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: "Voltage A"
+    icon: "mdi:flash"
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: "Current A"
+    icon: "mdi:current-ac"
+    class: current
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: "Power A"
+    icon: "mdi:flash-outline"
+    class: power
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: "Voltage B"
+    icon: "mdi:flash"
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: "Current B"
+    icon: "mdi:current-ac"
+    class: current
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: "Power B"
+    icon: "mdi:flash-outline"
+    class: power
+    category: diagnostic
+    dps:
+      - id: 7
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: "Voltage C"
+    icon: "mdi:flash"
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 8
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: "Current C"
+    icon: "mdi:current-ac"
+    class: current
+    category: diagnostic
+    dps:
+      - id: 8
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: "Power C"
+    icon: "mdi:flash-outline"
+    class: power
+    category: diagnostic
+    dps:
+      - id: 8
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+
+  #
+  # =========== Temperature ===========
+  #
+  - entity: sensor
+    name: "Temperature"
+    icon: "mdi:thermometer"
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 10


### PR DESCRIPTION
Adding 3-Phase a smart metering breaker.
Its known under many different brands, one of them is SMTONOFF
The data model is attached.
Request to add device was also added to upstream
[Things Data Model.txt](https://github.com/user-attachments/files/18468177/Things.Data.Model.txt)
