### PR TITLE
Fix missing device_class: energy

### DIFF
--- a/custom_components/tuya_local/devices/smartplugv2_energyv3.yaml
+++ b/custom_components/tuya_local/devices/smartplugv2_energyv3.yaml
@@ -53,6 +53,7 @@ entities:
   - entity: sensor
     category: diagnostic
     name: Energy
+    class: energy
     dps:
       - id: 17
         name: sensor


### PR DESCRIPTION
Needed to add to HA energy monitoring: https://www.home-assistant.io/docs/energy/faq/#troubleshooting-missing-entities

Example of missing device_class:
![image](https://github.com/user-attachments/assets/550a099f-8696-4664-898d-6de66ea1e357)
