### PR TITLE
Add Gosund WP9-RTL 3 outlet + USB with child lock and state memory

### DIFF
--- a/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
+++ b/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
@@ -1,4 +1,4 @@
-name: Gosund 3-Outlet + USB Powerstrip with Child Lock and State Memory
+name: Triple powerstrip with USB
 products:
   - id: rccfczzprrjvkpiz
     manufacturer: Gosund
@@ -128,8 +128,9 @@ entities:
   - entity: number
     category: config
     class: duration
-    name: USB timer
-    translation_key: timer
+    translation_key: timer_x
+    translation_placeholders:
+      - x: USB
     dps:
       - id: 15
         name: value

--- a/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
+++ b/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
@@ -1,0 +1,166 @@
+name: Gosund 3-Outlet + USB Powerstrip with Child Lock and State Memory
+products:
+  - id: 000002uovo
+    manufacturer: Gosund
+    model: WP9_RTL
+entities:
+  - entity: switch
+    translation_key: outlet_x
+    translation_placeholders:
+      x: "1"
+    class: outlet
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 41
+        name: cycle_time
+        type: string
+      - id: 42
+        name: random_time
+        type: string
+      - id: 43
+        name: inching
+        type: string
+  - entity: switch
+    translation_key: outlet_x
+    translation_placeholders:
+      x: "2"
+    class: outlet
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+      - id: 41
+        name: cycle_time
+        type: string
+      - id: 42
+        name: random_time
+        type: string
+      - id: 43
+        name: inching
+        type: string
+  - entity: switch
+    translation_key: outlet_x
+    translation_placeholders:
+      x: "3"
+    class: outlet
+    dps:
+      - id: 3
+        type: boolean
+        name: switch
+      - id: 41
+        name: cycle_time
+        type: string
+      - id: 42
+        name: random_time
+        type: string
+      - id: 43
+        name: inching
+        type: string
+  - entity: switch
+    name: USB switch
+    class: switch
+    dps:
+      - id: 7
+        type: boolean
+        name: switch
+      - id: 41
+        name: cycle_time
+        type: string
+      - id: 42
+        name: random_time
+        type: string
+      - id: 43
+        name: inching
+        type: string
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders:
+      x: "1"
+    dps:
+      - id: 9
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders:
+      x: "2"
+    dps:
+      - id: 10
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders:
+      x: "3"
+    dps:
+      - id: 11
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: number
+    category: config
+    class: duration
+    name: USB timer
+    translation_key: timer
+    dps:
+      - id: 15
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: lock
+    translation_key: child_lock
+    icon: "mdi:account-lock"
+    category: config
+    dps:
+      - id: 40
+        type: boolean
+        name: lock
+  - entity: select
+    translation_key: initial_state
+    name: "Power on behavior"
+    category: config
+    dps:
+      - id: 38
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "on"
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "2"
+            value: memory

--- a/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
+++ b/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
@@ -59,7 +59,7 @@ entities:
         name: inching
         type: string
   - entity: switch
-    name: USB switch
+    name: USB
     class: switch
     dps:
       - id: 7
@@ -130,7 +130,7 @@ entities:
     class: duration
     translation_key: timer_x
     translation_placeholders:
-      - x: USB
+      x: USB
     dps:
       - id: 15
         name: value

--- a/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
+++ b/custom_components/tuya_local/devices/gosund_wp9rtl_3_outlet_usb_child_lock_and_state.yaml
@@ -1,6 +1,6 @@
 name: Gosund 3-Outlet + USB Powerstrip with Child Lock and State Memory
 products:
-  - id: 000002uovo
+  - id: rccfczzprrjvkpiz
     manufacturer: Gosund
     model: WP9_RTL
 entities:


### PR DESCRIPTION
This is also GHome, or at least what was marketed on Amazon but the devices themselves sport a Gosund logo. It's different from the other Gosund triple outlet device listed here in that it doesn't have power monitoring but does have child lock and last-state memory. I have tested these features and observed that they work.

However, I am not sure how the cycle_time, random_time, and inching values are supposed to work, following patterns of other devices here and can see them added to the switches as attributes, but don't see how to manipulate the values.

Amazon product page for reference:
https://www.amazon.com/gp/product/B09JZ398R8/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1

First round at this Tuya stuff, so hopefully in the area code of what you are looking for in these PRs. And thanks for making this cool thing that I can use to define my devices and get them off the cloud!