### PR TITLE
Add support for OGACFO 9L Floor Ultrasonic Humidifier

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -392,6 +392,7 @@
 - Inkbird IHC-200 humidity controller
 - Klarta Humea humidifier
 - Kyvol EA200 humidifier
+- OGACFO LFHM055 floor humidifier
 - RZTK Aqua Pro humidifier
 - Stadler Eva humidifier
 - Stadler Form Karl/Karl Big humidifier

--- a/custom_components/tuya_local/devices/ogacfo_ultrasonic_floor_humidifier.yaml
+++ b/custom_components/tuya_local/devices/ogacfo_ultrasonic_floor_humidifier.yaml
@@ -1,0 +1,102 @@
+name: Humidifier
+products:
+  - id: 4wilpf0amoade7i3
+    manufacturer: OGACFO
+    model: LFHM055
+entities:
+  - entity: humidifier
+    class: humidifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 101
+        name: humidity
+        type: integer
+        range:
+          min: 30
+          max: 80
+        mapping:
+          - step: 5
+      - id: 14
+        name: current_humidity
+        type: integer
+      - id: 23
+        type: string
+        name: mode
+        mapping:
+          - dps_val: level_1
+            value: eco
+          - dps_val: level_2
+            value: normal
+          - dps_val: level_3
+            value: boost
+  - entity: switch
+    translation_key: uv_sterilization
+    category: config
+    dps:
+      - id: 5
+        name: switch
+        type: boolean
+  - entity: switch
+    translation_key: sleep
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    translation_key: tank_empty
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: TimeOff
+            value: cancel
+          - dps_val: "1H"
+            value: "1h"
+          - dps_val: "2H"
+            value: "2h"
+          - dps_val: "3H"
+            value: "3h"
+          - dps_val: "4H"
+            value: "4h"
+          - dps_val: "5H"
+            value: "5h"
+          - dps_val: "6H"
+            value: "6h"
+          - dps_val: "7H"
+            value: "7h"
+          - dps_val: "8H"
+            value: "8h"
+          - dps_val: "9H"
+            value: "9h"
+          - dps_val: "10H"
+            value: "10h"
+          - dps_val: "11H"
+            value: "11h"
+          - dps_val: "12H"
+            value: "12h"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    icon: "mdi:timer"
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: h


### PR DESCRIPTION
Adds support for OGACFO 9L Floor Ultrasonic Humidifiers. Tested working for several days.

Output from TinyTuya:
```
Upstairs Humidifier   Product ID = 4wilpf0amoade7i3  [Valid Broadcast]:
    Address = xxx   Device ID = xxx (len:22)  Local Key = xxx  Version = 3.4  Type = default, MAC = 
    Status: {'1': True, '5': True, '14': 30, '16': False, '19': 'cancel', '22': 0, '23': 'level_3', '101': '00', '102': 0}
```

![image](https://github.com/user-attachments/assets/01b2a9ee-985c-4560-b1d9-8ff07e1be7e2)
