### PR TITLE
Add support for Homebase 12" Oscillating Smart Fan

### DIFF
--- a/custom_components/tuya_local/devices/homebase_oscillating_fan.yaml
+++ b/custom_components/tuya_local/devices/homebase_oscillating_fan.yaml
@@ -1,12 +1,12 @@
-name: Oscillating Smart Fan
+name: Oscillating fan
 products:
   - id: rastwarkmv7aa3oo
     manufacturer: Homebase
-    model: DC FAN XJ-30-5SDC-W # product_name
-    model_id: XJ-35-1SDC # model
+    model: DC fan XJ-30-5SDC-W
+    model_id: XJ-35-1SDC
 entities:
   - entity: fan
-    translation_key: fan_with_presets
+    translation_only_key: fan_with_presets
     dps:
       - id: 1
         name: switch
@@ -49,6 +49,7 @@ entities:
         class: measurement
   - entity: select
     translation_key: timer
+    category: config
     dps:
       - id: 22
         type: string


### PR DESCRIPTION
Adds support for the Homebase 12" Oscillating Smart Fan.

Tested and working (I own the device).
Full device listing via tinytuya:

```json
{
  "name": "DC FAN XJ-30-5SDC-W",
  "id": "foo",
  "key": "foo",
  "mac": "foo",
  "uuid": "foo",
  "sn": "foo",
  "category": "fs",
  "product_name": "DC FAN XJ-30-5SDC-W",
  "product_id": "rastwarkmv7aa3oo",
  "biz_type": 462888,
  "model": "XJ-35-1SDC",
  "sub": false,
  "icon": "https://images.tuyaeu.com/smart/icon/bay1627719653955Xfi2/5b4150087703e7ec71a3d660b419da62.png",
  "mapping": {
    "1": {
      "code": "switch",
      "type": "Boolean",
      "values": {}
    },
    "2": {
      "code": "mode",
      "type": "Enum",
      "values": {
        "range": [
          "nature",
          "sleep",
          "smart"
        ]
      }
    },
    "3": {
      "code": "fan_speed_percent",
      "type": "Integer",
      "values": {
        "unit": "",
        "min": 1,
        "max": 12,
        "scale": 0,
        "step": 1
      }
    },
    "4": {
      "code": "switch_vertical",
      "type": "Boolean",
      "values": {}
    },
    "5": {
      "code": "switch_horizontal",
      "type": "Boolean",
      "values": {}
    },
    "21": {
      "code": "temp_current",
      "type": "Integer",
      "values": {
        "unit": "°C",
        "min": 0,
        "max": 50,
        "scale": 0,
        "step": 1
      }
    },
    "22": {
      "code": "countdown_set",
      "type": "Enum",
      "values": {
        "range": [
          "cancel",
          "1h",
          "2h",
          "3h",
          "4h",
          "5h",
          "6h"
        ]
      }
    }
  }
}
```

Some notes:
- the model name in the manual is the same as the `product_name` field which is _similar_ yet different to the `model` field so I've opted to use `model_id` here as the slightly different string might be confusing for other users...
- the manufacturer is listed as "HHGL Limited" in the instruction manual but "Homebase" is used in the branding so I've used Homebase here
- not sure if this is something I've messed up (maybe in a previous attempt at adding this?) but when adding the fan as `bedroom fan` the fan entity becomes `bedroom fan None` (with `fan.bedroom_fan_none` as the entity id)
- I've followed the `Vertical oscillation` switch pattern from another device here to try and keep at least some consistency between different devices
- for the same reason I've stuck with using `smart` for the last `preset_mode` even though the manual refers to it as `ECO`
- I've added `normal` as a preset_mode as even though it's not listed in the output from the Tuya API, the DP is set to that value in manual mode

Thanks for the integration and for making it so easy to add new devices!