### PR TITLE
Update rgbcw_lightbulb.yaml with Arlec 6w RGB+CCT downlight 

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -616,6 +616,7 @@ of device.
 - Unbranded 1CH dimmer module
 - Unbranded dual dimmer module
 - A60 1800-2700K RGBWW light
+- Arlec Grid Connect 6w RGB+CCT Downlight(Under Generic RGBCW/RGBWW lightbulb)
 - Asahom S105A-C outdoor lighting
 - Atomi smart color string light
 - Blitzwolf BW-LT31 LED strip

--- a/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
@@ -19,6 +19,10 @@ products:
   - id: gshkqhi4fx9qqwrr
     manufacturer: ANWIO
     model: BR30 RGB+CCT 13W
+  - id: 1wyg8eca64whbtcd
+    manufacturer: Arlec
+    name: Grid Connect 6w led RGB+CCT downlight
+    model_id: ALD275HA
 entities:
   - entity: light
     dps:


### PR DESCRIPTION
Addition of Arlec Grid Connect 6w led RGB+CCT downlight. Tested and working with this config. https://www.bunnings.com.au/arlec-6w-70mm-grid-connect-smart-rgb-cct-led-downlight_p0549119