### PR TITLE
Update TYTE-D1 to support auto-work

### DIFF
--- a/custom_components/tuya_local/devices/tyte_d1_thermostat.yaml
+++ b/custom_components/tuya_local/devices/tyte_d1_thermostat.yaml
@@ -1,19 +1,14 @@
-name: Thermostat
+name: Thermostat switch
 products:
   - id: key7rucurh5teh9w
     model: TYTE-D1
 entities:
   - entity: switch
-    name: Switch
+    name: Manual override
     dps:
       - id: 2
         type: boolean
         name: switch
-        mapping:
-          - dps_val: false
-            icon: "mdi:power-plug-off"
-          - dps_val: true
-            icon: "mdi:power-plug"
   - entity: climate
     dps:
       - id: 2
@@ -49,9 +44,6 @@ entities:
         type: string
         name: work_mode
         hidden: true
-      - id: 9
-        type: boolean
-        name: customize_mode_switch
       - id: 19
         type: integer
         name: test_bit
@@ -187,9 +179,9 @@ entities:
           - dps_val: f
             value: fahrenheit
   - entity: number
-    name: Temperature Range
+    name: Temperature hysteresis
     category: config
-    icon: "mdi:format-paragraph-spacing"
+    icon: "mdi:thermometer-plus"
     dps:
       - id: 29
         type: integer
@@ -203,7 +195,7 @@ entities:
   - entity: number
     name: Temperature correction
     category: config
-    icon: "mdi:format-vertical-align-center"
+    icon: "mdi:thermometer-check"
     dps:
       - id: 30
         type: integer
@@ -244,7 +236,7 @@ entities:
           - dps_val: 32
             value: LS Power
   - entity: number
-    name: Cold delay
+    name: Turn on delay
     category: config
     class: duration
     icon: "mdi:camera-timer"
@@ -257,7 +249,7 @@ entities:
           min: 0
           max: 10
   - entity: switch
-    name: Cold delay switch
+    name: Turn on delay
     category: config
     icon: "mdi:camera-timer"
     dps:

--- a/custom_components/tuya_local/devices/tyte_d1_thermostat.yaml
+++ b/custom_components/tuya_local/devices/tyte_d1_thermostat.yaml
@@ -1,8 +1,35 @@
-name: RYRA TYTE-D1 thermostat
+name: Thermostat
+products:
+  - id: key7rucurh5teh9w
+    model: TYTE-D1
 entities:
+  - entity: switch
+    name: Switch
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+        mapping:
+          - dps_val: false
+            icon: "mdi:power-plug-off"
+          - dps_val: true
+            icon: "mdi:power-plug"
   - entity: climate
     dps:
       - id: 2
+        type: boolean
+        name: hvac_action
+        mapping:
+          - dps_val: false
+            value: idle
+          - dps_val: true
+            constraint: work_mode
+            conditions:
+              - dps_val: hot
+                value: heating
+              - dps_val: colding
+                value: cooling
+      - id: 9
         type: boolean
         name: hvac_mode
         mapping:
@@ -15,10 +42,6 @@ entities:
                 value: heat
               - dps_val: colding
                 value: cool
-              - dps_val: dehumidify
-                value: dry
-              - dps_val: wet
-                value: dry
       - id: 7
         type: string
         name: cycle_time
@@ -164,9 +187,9 @@ entities:
           - dps_val: f
             value: fahrenheit
   - entity: number
-    name: Vibration
+    name: Temperature Range
     category: config
-    icon: "mdi:volume-vibrate"
+    icon: "mdi:format-paragraph-spacing"
     dps:
       - id: 29
         type: integer


### PR DESCRIPTION
Updates TYTE-D1.

Changes climate hvac_mode to based on auto-work and hvac_action to be based on the switch. This enables auto-work functioning with this integration.

Adds a manual option for the switch.

The vibration option was renamed temperature range to match what the app uses for English.

Removes the dehumidify option since it does nothing and the app does not support it.

Some pictures of the app along side the integration:
<img width="233" alt="image" src="https://github.com/user-attachments/assets/99eb43e9-3909-40e0-82d3-bff131d45f42" />
<img width="239" alt="image" src="https://github.com/user-attachments/assets/c1fc3e1a-220e-4650-903d-ef85239e794d" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c6b3feff-f561-41b3-a3e1-bc5e7d110079" />
