### PR TITLE
Add support for Kogan 2.6kW split aircon

### DIFF
--- a/custom_components/tuya_local/devices/kogan_air_conditioner_2k6w.yaml
+++ b/custom_components/tuya_local/devices/kogan_air_conditioner_2k6w.yaml
@@ -1,0 +1,401 @@
+# Protocol 3.5
+name: Kogan Smart AC
+products:
+  - id: 2mixrhxp38ehekxx
+    manufacturer: Kogan
+    model: "01"
+entities:
+  - translation_only_key: aircon_extra
+    entity: climate
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: auto
+                value: heat_cool
+              - dps_val: cold
+                value: cool
+              - dps_val: wind
+                value: fan_only
+              - dps_val: wet
+                value: dry
+              - dps_val: hot
+                value: heat
+      - id: 2
+        name: temperature
+        type: integer
+        range:
+          min: 160
+          max: 310
+        mapping:
+          - scale: 10
+            step: 5
+        unit: C
+      - id: 3
+        name: current_temperature
+        type: integer
+      - id: 4
+        name: mode
+        type: string
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: mute
+            value: quiet
+          - dps_val: low
+            value: low
+          - dps_val: mid_low
+            value: medlow
+          - dps_val: mid
+            value: medium
+          - dps_val: mid_high
+            value: medhigh
+          - dps_val: high
+            value: high
+          - dps_val: strong
+            value: strong
+      - id: 110
+        name: functions_available
+        type: bitfield
+        # Used to indicate whether this function is available.
+        #   0. Whether the temperature is adjustable in dehumidification mode
+        #   1. Whether the temperature is adjustable in air supply mode
+        #   2. Whether the temperature is adjustable in automatic mode
+        #   3. Fresh air volume mark
+        #   4. Vector air supply (implemented on Set vertical direction)
+        #   5. Left and right sweeping air (implemented on horizontal sweep)
+        #   6. Photosensitive
+        #   7. Intelligent dehumidification and anti-mildew
+        #   8. Humidity sensor
+        #   9. Evaporator cleaning
+        #   10. Save money and see it (implemented on Energy saving)
+        #   11. Power statistics
+        #   12. Generator mode (implemented on Generator mode)
+        #   13. High temperature wind/cool wind (implemented on Hot cold wind)
+        #   14. Air quality detection function (implemented on Air quality)
+        #   15. Set to empty (original: humidity function)
+        #   16. Set to empty (original: equipment operation saves money and
+        #       visible temperature curve display)
+        #   17. 8℃ heating
+        #   18. Filter dirty and clogged function (implemented on Dirty filter)
+        #   ??? - 19 is missing in Tuya json
+        #   20. presence or absence of PM2.5 (implemented on PM25)
+        #   21. temperature scale switching, 1 is Fahrenheit, 0 is Celsius
+        #   22. soft wind (implemented on Sleep)
+        #   23. left and right wide-angle air supply (implemented on Set
+        #       horizontal direction)
+      - id: 123
+        name: boolCode
+        type: hex
+      - id: 133
+        name: swing_mode
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: horizontal
+            available: hswing_available
+          - dps_val: "2"
+            value: vertical
+          - dps_val: "3"
+            value: both
+            available: hswing_available
+      - id: 134
+        name: work_time
+        type: string
+  - translation_key: display
+    entity: light
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0008"
+  - name: Buzzer
+    entity: switch
+    category: config
+    icon: "mdi:volume-high"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0010"
+  - name: Anti-mildew
+    entity: switch
+    category: config
+    icon: "mdi:water-off-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0100"
+  - name: Health
+    entity: switch
+    category: config
+    icon: "mdi:heart-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0020"
+  - translation_key: anti_frost
+    entity: switch
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "1000"
+  - name: Eco mode
+    entity: switch
+    category: config
+    icon: "mdi:leaf"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0001"
+  - name: Self cleaning
+    entity: switch
+    category: config
+    icon: "mdi:spray-bottle"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0004"
+        mapping:
+          - dps_val: false
+            value: "Off"
+          - dps_val: true
+            constraint: power
+            conditions:
+              - dps_val: true
+                invalid: true
+              - dps_val: false
+                value: Cleaning
+
+      - id: 1
+        name: power
+        type: boolean
+
+  - class: problem
+    entity: binary_sensor
+    category: diagnostic
+    icon: "mdi:wrench"
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        name: fault_code
+        type: bitfield
+      - id: 122
+        name: fault2
+        type: bitfield
+  - name: Sleep
+    entity: select
+    category: config
+    icon: "mdi:weather-night"
+    dps:
+      - id: 105
+        name: option
+        type: string
+        mapping:
+          - dps_val: "off"
+            value: "Off"
+            default: true
+          - dps_val: normal
+            value: Normal
+          - dps_val: old
+            value: Elderly
+          - dps_val: child
+            value: Child
+      - id: 110
+        type: bitfield
+        name: available
+        mapping:
+          - dps_val: 4194394
+            value: true
+          - value: false
+  - name: Vertical sweep
+    entity: select
+    category: config
+    icon: "mdi:arrow-up-down-bold"
+    dps:
+      - id: 113
+        name: option
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: None
+            default: true
+          - dps_val: "1"
+            value: Upper and lower
+          - dps_val: "2"
+            value: Upper
+          - dps_val: "3"
+            value: Lower
+  - name: Horizontal sweep
+    entity: select
+    category: config
+    icon: "mdi:arrow-left-right-bold"
+    dps:
+      - id: 114
+        name: option
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+            default: true
+          - dps_val: "1"
+            value: Left and Right
+          - dps_val: "2"
+            value: Left
+          - dps_val: "3"
+            value: Middle
+          - dps_val: "4"
+            value: Right
+      - id: 110
+        type: bitfield
+        name: available
+        mapping:
+          - dps_val: 32
+            value: true
+          - value: false
+  - translation_key: air_quality
+    entity: sensor
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 125
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: great
+            value: Great (or lying)
+          - dps_val: good
+            value: Good
+          - dps_val: middle
+            value: Average
+          - dps_val: bad
+            value: Bad
+          - dps_val: verybad
+            value: Very bad
+
+      # Data is returned, but the bitfield says it's not supported.
+      # Lets monitor it anyway
+      # - id: 110
+      #   name: available
+      #   type: bitfield
+      #   mapping:
+      #     - dps_val: 16384
+      #       value: true
+      #     - value: false
+
+  - name: Vertical fixed
+    entity: select
+    category: config
+    icon: "mdi:unfold-more-horizontal"
+    dps:
+      - id: 126
+        name: option
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: Freeze Current Position
+            default: true
+          - dps_val: "1"
+            value: Top
+          - dps_val: "2"
+            value: Slightly Up
+          - dps_val: "3"
+            value: Middle
+          - dps_val: "4"
+            value: Slightly Down
+          - dps_val: "5"
+            value: Down
+      - id: 110
+        type: bitfield
+        name: available
+        mapping:
+          - dps_val: 16
+            value: true
+          - value: false
+  - name: Horizontal fixed
+    entity: select
+    category: config
+    icon: "mdi:unfold-more-vertical"
+    dps:
+      - id: 127
+        name: option
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: Freeze current position
+            default: true
+          - dps_val: "1"
+            value: Left
+          - dps_val: "2"
+            value: Slightly left
+          - dps_val: "3"
+            value: Middle
+          - dps_val: "4"
+            value: Slightly right
+          - dps_val: "5"
+            value: Right
+
+      # Says not supported according to my bitfield, but it is
+      # - id: 110
+      #   type: bitfield
+      #   name: available
+      #   mapping:
+      #     - dps_val: 8388608
+      #       value: true
+      #     - value: false
+
+  - name: Power saving temperature
+    entity: number
+    category: config
+    class: temperature
+    dps:
+      - id: 130
+        name: value
+        type: integer
+        unit: C
+        range:
+          min: 26
+          max: 31
+  - name: Dirty filter
+    entity: binary_sensor
+    class: problem
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 131
+        type: boolean
+        name: sensor
+
+      # Mine says not available according to bitfield, but returns false...
+      # Monitor and see if it ever changes?
+      # - id: 110
+      #   type: bitfield
+      #   name: available
+      #   mapping:
+      #     - dps_val: 262144
+      #       value: true
+      #     - value: false


### PR DESCRIPTION
Based on fisher_summer

Adds support for:
- Anti-frost
- Anti-mildew
- Buzzer on/off
- Display on/off
- Eco mode on/off
- Health (UV and Ioniser)
- Self cleaning

Fixes
- Horizontal fixed position, not supported according to bitfield but it is and works
- Removed "Power" setting (1kWh/2kWh etc.), which does nothing
- Removed Running time, as it always reports 1s
- Added appropriate icons
- Removed "wide" swing modes (not supported)
- Removed Hot cold wind
- Removed Generator mode
- Removed Energy saving

Caveats
- Customised for this specific model/id, so optional DPS removed (avoids unavailable entities, which aren't disabled by default)
- Air quality & Dirty filter probably aren't supported (they just report Great and OK), so they're in diagnostic