### PR TITLE
Create support for PC321-W-TY (Bidirectional) Energy Meter

### DIFF
--- a/custom_components/tuya_local/devices/pc321wty_bidirectional_energy_meter.yaml
+++ b/custom_components/tuya_local/devices/pc321wty_bidirectional_energy_meter.yaml
@@ -1,0 +1,262 @@
+name: Power Clamp Meter
+products:
+  - id: gqmmtjclqb7reg5p
+    model: PC321-W-TY (Bi-Directional)
+entities:
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 131
+        type: integer
+        name: sensor
+        mapping:
+          - scale: 100
+        unit: kWh
+        class: total_increasing
+  - entity: sensor
+    name: Total Generation
+    class: energy
+    dps:
+      - id: 139
+        name: sensor
+        type: integer
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    translation_key: voltage_x
+    translation_placeholders:
+      x: A
+    class: voltage
+    dps:
+      - id: 101
+        name: sensor
+        type: integer
+        unit: V
+        class: measurement
+        force: true
+        mapping:
+          - scale: 10
+  - entity: sensor
+    category: diagnostic
+    class: current
+    translation_key: current_x
+    translation_placeholders:
+      x: A
+    dps:
+      - id: 102
+        name: sensor
+        type: integer
+        unit: A
+        class: measurement
+        force: true
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    category: diagnostic
+    class: power
+    translation_key: power_x
+    translation_placeholders:
+      x: A
+    dps:
+      - id: 103
+        name: sensor
+        type: integer
+        unit: W
+        force: true
+        class: measurement
+  - entity: sensor
+    category: diagnostic
+    class: power_factor
+    name: Power factor A
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    name: Energy A
+    dps:
+      - id: 106
+        name: sensor
+        type: integer
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    translation_key: voltage_x
+    translation_placeholders:
+      x: B
+    class: voltage
+    dps:
+      - id: 111
+        name: sensor
+        type: integer
+        unit: V
+        class: measurement
+        force: true
+        mapping:
+          - scale: 10
+  - entity: sensor
+    category: diagnostic
+    class: current
+    translation_key: current_x
+    translation_placeholders:
+      x: B
+    dps:
+      - id: 112
+        name: sensor
+        type: integer
+        unit: A
+        class: measurement
+        force: true
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    category: diagnostic
+    class: power
+    translation_key: power_x
+    translation_placeholders:
+      x: B
+    dps:
+      - id: 113
+        name: sensor
+        type: integer
+        force: true
+        unit: W
+        class: measurement
+  - entity: sensor
+    category: diagnostic
+    class: power_factor
+    name: Power factor B
+    dps:
+      - id: 114
+        name: sensor
+        type: integer
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    name: Energy B
+    dps:
+      - id: 116
+        name: sensor
+        type: integer
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    translation_key: voltage_x
+    translation_placeholders:
+      x: C
+    class: voltage
+    dps:
+      - id: 121
+        name: sensor
+        type: integer
+        unit: V
+        class: measurement
+        force: true
+        mapping:
+          - scale: 10
+  - entity: sensor
+    category: diagnostic
+    class: current
+    translation_key: current_x
+    translation_placeholders:
+      x: C
+    dps:
+      - id: 122
+        name: sensor
+        type: integer
+        unit: A
+        class: measurement
+        force: true
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    category: diagnostic
+    class: power
+    translation_key: power_x
+    translation_placeholders:
+      x: C
+    dps:
+      - id: 123
+        name: sensor
+        type: integer
+        force: true
+        class: measurement
+        unit: W
+  - entity: sensor
+    category: diagnostic
+    class: power_factor
+    name: Power factor C
+    dps:
+      - id: 124
+        name: sensor
+        type: integer
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    name: Energy C
+    dps:
+      - id: 126
+        name: sensor
+        type: integer
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    class: current
+    name: Total current
+    dps:
+      - id: 132
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+        force: true
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    category: diagnostic
+    class: power
+    name: Total active power
+    dps:
+      - id: 133
+        type: integer
+        name: sensor
+        unit: W
+        force: true
+        class: measurement
+  - entity: sensor
+    category: diagnostic
+    class: frequency
+    dps:
+      - id: 135
+        type: integer
+        name: sensor
+        unit: Hz
+        class: measurement
+  - entity: sensor
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 136
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10


### PR DESCRIPTION
this code has been running for my PC321-W-TY (Bidirectional) energy Meter. The difference between this code and pc321ty (which also runs well for my device) is the support for "Total Generation." The pc321zty_energy_meter (which has the same product code) does not work for my device as the dp's are different.