### PR TITLE
Update smart_powerstrip_3_outlet_energy.yaml

### DIFF
--- a/custom_components/tuya_local/devices/smart_powerstrip_3_outlet_energy.yaml
+++ b/custom_components/tuya_local/devices/smart_powerstrip_3_outlet_energy.yaml
@@ -3,6 +3,10 @@ products:
   - id: y3vaekzobpkbcj0j
     manufacturer: Eightree
     model: ET43
+  - id: b9dvdzeuteph24th
+    manufacturer: ANTELA
+    model: Smart Power Strip Energy Monitoring
+    model_id: SPS-W-TY-PM-UK-RY
 entities:
   - entity: switch
     class: outlet


### PR DESCRIPTION
Added additional product for better match of Antela power strip. 

Without this, the best match was dual_power_monitor_smartplugv2 with quality of 88%, which only has 2 outlets while the device has 3