### PR TITLE
Update gratkit_filament_dryer.yaml

### DIFF
--- a/custom_components/tuya_local/devices/gratkit_filament_dryer.yaml
+++ b/custom_components/tuya_local/devices/gratkit_filament_dryer.yaml
@@ -237,3 +237,19 @@ entities:
       - id: 108
         type: boolean
         name: sensor
+  - entity: switch
+    icon: "mdi:volume-high"
+    name: Speaker
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+
+  - entity: light
+    icon: "mdi:fit-to-screen"
+    name: LCD Panel
+    dps:
+      - id: 110
+        type: boolean
+        name: switch


### PR DESCRIPTION
Added two missing entities to the Gratkit Filament Dryer device (The speaker switch and the LCD backlight switch)