### PR TITLE
Add Coredy R750 to compatible vacuums

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -744,6 +744,7 @@ of device.
 
 - Abir X8 vacuum cleaner
 - Airrobo P20 vacuum cleaner
+- Coredy R750 vacuum cleaner (shows as Mellerware City Move in config)
 - iHome Autoac Nova vacuum cleaner
 - Kabum Smart 500 vacuum cleaner
 - Kabum Smart 700 vacuum cleaner (also sold as Liectroux XR500[T2] and maybe others)


### PR DESCRIPTION
Added the Coredy R750 to the list as I just added and tested my own and it works perfectly with all variables and controls showing as they should under the "Mellerware City Move" vacuum config when setting up the device.

![chrome_2025-02-05_01-31-16](https://github.com/user-attachments/assets/699f35a5-e3aa-4668-a76b-d6ea9230390a)
