### PR TITLE
Vevor EV charger: expose online_state as a switch rather than sensor"

### DIFF
--- a/custom_components/tuya_local/devices/vevor_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/vevor_ev_charger.yaml
@@ -219,19 +219,23 @@ entities:
         unit: kWh
         mapping:
           - scale: 100
-  - entity: binary_sensor
-    class: connectivity
-    category: diagnostic
+
+  - entity: switch
+    category: config
+    name: Live updates
+    icon: "mdi:chart-bar"
     dps:
       - id: 27
         type: string
-        name: sensor
+        name: switch
         optional: true
         mapping:
           - dps_val: online
             value: true
           - dps_val: offline
             value: false
+          - value: false
+            hidden: true
   - entity: number
     name: Delay time
     category: config


### PR DESCRIPTION
Just as in commit a5ca25fa17f1 ("Tongou QCB2: expose online_state as a switch rather than sensor"), online_state is used to trigger the updates of dps 6 (power, current, voltage). Once set, updates are happening about every 5 secondes. This needs to be renewed every 2 minutes.

The following HA automation works:

alias: EV charger stats refresh
description: ""
triggers:
  - trigger: state entity_id: - switch.portable_ev_charger to: "on"
  - trigger: state entity_id:
      - timer.ev_charger_stats from: active to: idle conditions: []
actions:
  - action: switch.turn_on target: entity_id: switch.portable_ev_charger_live_updates data: {}
  - condition: state entity_id: switch.portable_ev_charger state: "on"
  - action: timer.start target: entity_id: timer.ev_charger_stats data: duration: "00:02:00" mode: single