### PR TITLE
Add anti-frost mode support for rotenso_ronix_heatpump

### DIFF
--- a/custom_components/tuya_local/devices/rotenso_ronix_heatpump.yaml
+++ b/custom_components/tuya_local/devices/rotenso_ronix_heatpump.yaml
@@ -231,6 +231,15 @@ entities:
         type: hex
         name: switch
         mask: "0001"
+  - entity: switch
+    name: Anti-frost mode
+    category: config
+    icon: "mdi:snowflake-thermometer"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "1000"
   - entity: binary_sensor
     class: problem
     category: diagnostic

--- a/custom_components/tuya_local/devices/rotenso_ronix_heatpump.yaml
+++ b/custom_components/tuya_local/devices/rotenso_ronix_heatpump.yaml
@@ -232,9 +232,8 @@ entities:
         name: switch
         mask: "0001"
   - entity: switch
-    name: Anti-frost mode
+    translation_key: anti_frost
     category: config
-    icon: "mdi:snowflake-thermometer"
     dps:
       - id: 123
         type: hex


### PR DESCRIPTION
The entity for the 8° heater mode was missing. Added it as Anti-frost mode entity.