### PR TITLE
Add Support for Drexma WiStat thermostat ET7AW

### DIFF
--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -165,7 +165,6 @@ entities:
         name: lock
   - entity: select
     name: Location
-    type: string
     category: config
     icon: "mdi:map-marker-multiple-outline"
     hidden: true
@@ -215,7 +214,6 @@ entities:
             icon: "mdi:thermometer"
   - entity: number
     category: config
-    type: integer
     name: Room temperature calibration
     icon: "mdi:tune-vertical-variant"
     dps:
@@ -245,7 +243,6 @@ entities:
             value: °F
   - entity: number
     category: config
-    type: integer
     name: Floor temperature calibration
     icon: "mdi:tune-variant"
     dps:

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -282,7 +282,7 @@ entities:
       - id: 116
         type: integer
         name: value
-        unit: w
+        unit: W
         range:
           min: 0
           max: 4500

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -274,9 +274,9 @@ entities:
           - dps_val: true
             value: °F
   - entity: number
-    category: config
     name: Heater Wattage
-    icon: "mdi:lightning-bolt-circle"
+    class: power
+    category: config
     hidden: true
     dps:
       - id: 116

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -238,9 +238,9 @@ entities:
         type: boolean
         mapping:
           - dps_val: false
-            value: °C
+            value: °
           - dps_val: true
-            value: °F
+            value: °
   - entity: number
     category: config
     name: Floor temperature calibration
@@ -267,9 +267,9 @@ entities:
         type: boolean
         mapping:
           - dps_val: false
-            value: °C
+            value: °
           - dps_val: true
-            value: °F
+            value: °
   - entity: number
     name: Heater Wattage
     class: power

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -1,8 +1,9 @@
-name: Drexma WiStat Thermostat
+name: Thermostat
 products:
   - id: 1oi7spyvsihkwrrr
     manufacturer: Drexma Industries inc.
-    model: "ET-7AW"
+    model: "WiStat"
+    model_id: "ET-7AW"
 entities:
   - entity: climate
     dps:

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -294,7 +294,7 @@ entities:
       - id: 117
         type: integer
         name: sensor
-        unit: day
+        unit: d
         mapping:
           - scale: 2
   - entity: number

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -80,26 +80,32 @@ entities:
             value: heating
           - dps_val: false
             value: idle
-  - entity: select
-    class: sensor
-    type: string
-    readonly: true
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
-    name: Sensor Error
-    icon: "mdi:thermometer-alert"
     dps:
       - id: 104
         type: bitfield
-        name: option
+        name: sensor
         mapping:
           - dps_val: 0
-            value: None
+            value: false
+          - value: true
+      - id: 104
+        type: bitfield
+        name: fault_code
+      - id: 104
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
           - dps_val: 1
-            value: Room
+            value: Room sensor fault
           - dps_val: 2
-            value: Floor
+            value: Floor sensor fault
           - dps_val: 4
-            value: GFCI
+            value: GFCI fault
   - entity: sensor
     name: Room temperature
     class: temperature

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -37,11 +37,11 @@ entities:
         name: preset_mode
         mapping:
           - dps_val: "Smart"
-            value: Program
+            value: program
           - dps_val: "Manual"
-            value: Manual
+            value: manual
           - dps_val: "Anti_frozen"
-            value: Away
+            value: away
       - id: 105
         type: integer
         name: current_temperature

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -1,0 +1,324 @@
+name: Drexma WiStat Thermostat
+products:
+  - id: 1oi7spyvsihkwrrr
+    manufacturer: Drexma Industries inc.
+    model: "ET-7AW"
+entities:
+  - entity: climate
+    dps:
+      - id: 101
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "Smart"
+                value: auto
+              - dps_val: "Manual"
+                value: heat
+              - dps_val: "Anti_frozen"
+                value: away
+      - id: 102
+        type: integer
+        name: temperature
+        range:
+          min: 50
+          max: 400
+        mapping:
+          - scale: 10
+            step: 5
+            constraint: temperature_unit
+            conditions:
+              - dps_val: true
+                step: 10
+                range:
+                  min: 410
+                  max: 1040
+      - id: 103
+        type: string
+        name: mode
+        hidden: true
+      - id: 105
+        type: integer
+        name: current_temperature
+        mapping:
+          - constraint: sensor
+            conditions:
+              - dps_val: "0"
+                scale: 10
+              - dps_val: "1"
+                value_redirect: floor_temperature
+              - dps_val: "2"
+                scale: 10
+      - id: 106
+        type: integer
+        name: floor_temperature
+        hidden: true
+        mapping:
+          - scale: 10
+      - id: 107
+        name: temperature_unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F
+      - id: 111
+        type: string
+        name: sensor
+        hidden: true
+      - id: 118
+        type: boolean
+        name: hvac_action
+        mapping:
+          - dps_val: true
+            value: heating
+          - dps_val: false
+            value: idle
+  - entity: select
+    class: sensor
+    type: string
+    readonly: true
+    category: diagnostic
+    name: Sensor Error
+    icon: "mdi:thermometer-alert"
+    dps:
+      - id: 104
+        type: bitfield
+        name: option
+        mapping:
+          - dps_val: 0
+            value: None
+          - dps_val: 1
+            value: Room
+          - dps_val: 2
+            value: Floor
+          - dps_val: 4
+            value: GFCI
+  - entity: sensor
+    name: Room temperature
+    class: temperature
+    icon: "mdi:home-thermometer"
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        class: measurement
+        mapping:
+          - scale: 10
+      - id: 107
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F
+  - entity: sensor
+    name: Floor temperature
+    class: temperature
+    icon: "mdi:thermometer-lines"
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        class: measurement
+        mapping:
+          - scale: 10
+      - id: 107
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F
+  - entity: select
+    category: config
+    translation_key: temperature_unit
+    dps:
+      - id: 107
+        name: option
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: celsius
+          - dps_val: true
+            value: fahrenheit
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 108
+        type: boolean
+        name: lock
+  - entity: select
+    name: Location
+    type: string
+    category: config
+    icon: "mdi:map-marker-multiple-outline"
+    hidden: true
+    dps:
+      - id: 109
+        name: option
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: Home
+          - dps_val: true
+            value: Office
+  - entity: select
+    category: config
+    name: Auto schedule
+    icon: "mdi:calendar-sync"
+    dps:
+      - id: 110
+        type: integer
+        name: option
+        mapping:
+          - dps_val: 0
+            value: "7"
+          - dps_val: 1
+            value: "5+1+1"
+          - dps_val: 2
+            value: "7 (Adaptive)"
+          - dps_val: 3
+            value: "5+1+1 (Adaptive)"
+  - entity: select
+    category: config
+    name: Temperature sensor
+    icon: "mdi:thermometer-check"
+    dps:
+      - id: 111
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "Room"
+            icon: "mdi:home-thermometer"
+          - dps_val: "1"
+            value: "Floor"
+            icon: "mdi:heating-coil"
+          - dps_val: "2"
+            value: "Both"
+            icon: "mdi:thermometer"
+  - entity: number
+    category: config
+    class: temperature
+    type: integer
+    name: Room temperature calibration
+    icon: "mdi:tune-vertical-variant"
+    dps:
+      - id: 112
+        type: integer
+        name: value
+        range:
+          min: -50
+          max: 50
+        mapping:
+          - scale: 10
+            step: 5
+            constraint: unit
+            conditions:
+              - dps_val: true
+                step: 10
+                range:
+                  min: -90
+                  max: 90
+      - id: 107
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F
+  - entity: number
+    category: config
+    class: temperature
+    type: integer
+    name: Floor temperature calibration
+    icon: "mdi:tune-variant"
+    dps:
+      - id: 113
+        type: integer
+        name: value
+        range:
+          min: -50
+          max: 50
+        mapping:
+          - scale: 10
+            step: 5
+            constraint: unit
+            conditions:
+              - dps_val: true
+                step: 10
+                range:
+                  min: -90
+                  max: 90
+      - id: 107
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F
+  - entity: number
+    category: config
+    name: Heater Wattage
+    icon: "mdi:lightning-bolt-circle"
+    hidden: true
+    dps:
+      - id: 116
+        type: integer
+        name: value
+        unit: w
+        range:
+          min: 0
+          max: 4500
+  - entity: sensor
+    name: Runtime
+    icon: "mdi:chart-timeline-variant-shimmer"
+    hidden: true
+    dps:
+      - id: 117
+        type: integer
+        name: sensor
+        unit: day
+        mapping:
+          - scale: 2
+  - entity: number
+    category: config
+    class: temperature
+    name: Room temperature limit
+    icon: "mdi:thermometer-chevron-down"
+    dps:
+      - id: 121
+        type: integer
+        name: value
+        range:
+          min: 100
+          max: 400
+        mapping:
+          - scale: 10
+            step: 5
+            constraint: unit
+            conditions:
+              - dps_val: true
+                step: 30
+                range:
+                  min: 120
+                  max: 750
+      - id: 107
+        name: unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: C
+          - dps_val: true
+            value: F

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -215,7 +215,6 @@ entities:
             icon: "mdi:thermometer"
   - entity: number
     category: config
-    class: temperature
     type: integer
     name: Room temperature calibration
     icon: "mdi:tune-vertical-variant"
@@ -241,12 +240,11 @@ entities:
         type: boolean
         mapping:
           - dps_val: false
-            value: C
+            value: °C
           - dps_val: true
-            value: F
+            value: °F
   - entity: number
     category: config
-    class: temperature
     type: integer
     name: Floor temperature calibration
     icon: "mdi:tune-variant"
@@ -272,9 +270,9 @@ entities:
         type: boolean
         mapping:
           - dps_val: false
-            value: C
+            value: °C
           - dps_val: true
-            value: F
+            value: °F
   - entity: number
     category: config
     name: Heater Wattage

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -297,15 +297,15 @@ entities:
   - entity: number
     category: config
     class: temperature
-    name: Room temperature limit
+    name: Floor temperature limit
     icon: "mdi:thermometer-chevron-down"
     dps:
       - id: 121
         type: integer
         name: value
         range:
-          min: 100
-          max: 400
+          min: 200
+          max: 500
         mapping:
           - scale: 10
             step: 5
@@ -314,8 +314,8 @@ entities:
               - dps_val: true
                 step: 10
                 range:
-                  min: 120
-                  max: 750
+                  min: 680
+                  max: 1220
       - id: 107
         name: unit
         type: boolean

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -6,6 +6,7 @@ products:
     model_id: "ET-7AW"
 entities:
   - entity: climate
+    translation_key: thermostat
     dps:
       - id: 101
         type: boolean
@@ -14,14 +15,7 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            constraint: mode
-            conditions:
-              - dps_val: "Smart"
-                value: auto
-              - dps_val: "Manual"
-                value: heat
-              - dps_val: "Anti_frozen"
-                value: away
+            value: heat
       - id: 102
         type: integer
         name: temperature
@@ -40,8 +34,14 @@ entities:
                   max: 1040
       - id: 103
         type: string
-        name: mode
-        hidden: true
+        name: preset_mode
+        mapping:
+          - dps_val: "Smart"
+            value: Program
+          - dps_val: "Manual"
+            value: Manual
+          - dps_val: "Anti_frozen"
+            value: Away
       - id: 105
         type: integer
         name: current_temperature

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -288,7 +288,7 @@ entities:
           max: 4500
   - entity: sensor
     name: Runtime
-    icon: "mdi:chart-timeline-variant-shimmer"
+    class: duration
     hidden: true
     dps:
       - id: 117

--- a/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/drexma_et7aw_thermostat.yaml
@@ -312,7 +312,7 @@ entities:
             constraint: unit
             conditions:
               - dps_val: true
-                step: 30
+                step: 10
                 range:
                   min: 120
                   max: 750


### PR DESCRIPTION
Add support for Drexma WiStat thermostat (model: ET-7AW), which is used for floor heating. Product details can be found [here](https://www.amazon.com/WarmAll-Thermostat-Electric-Heating-Network/dp/B0CP9ZNBRC). I also added its document and DPs retrieved via the Tuya IoT API in [docs folder](https://github.com/Kevin-0u/tuya-local/tree/docs/custom_components/tuya_local/devices/docs) in my fork so it can be referenced if anyone wants to modify or develop this farther.