### PR TITLE
Added support for ALMEVO/Powerworld monoblock water heat pumps HPHTXXXXXXXPW.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.vs/
 /.vscode/
 /.env/
 /*.egg-info/

--- a/custom_components/tuya_local/devices/almevo_hpht_waterheatpump.yaml
+++ b/custom_components/tuya_local/devices/almevo_hpht_waterheatpump.yaml
@@ -1,0 +1,509 @@
+name: ALMEVO monoblock water heat pump
+products:
+   - id: hd8ubtj2bz38vuak
+     manufacturer: ALMEVO
+     model: HPHTXXXXXXXPW
+entities:
+  - entity: water_heater
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: work_mode
+            conditions:
+              - dps_val: wth
+                value: Hot water
+              - dps_val: heat
+                value: Heating
+              - dps_val: cool
+                value: Cooling
+              - dps_val: wth_heat
+                value: Hot water + heating
+              - dps_val: wth_cool
+                value: Hot water + cooling
+      - id: 5
+        type: string
+        name: work_mode
+        hidden: true
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+      - id: 108
+        type: integer
+        name: current_temperature
+  - entity: climate
+    translation_key: heater
+    dps:
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: smart
+            value: comfort
+          - dps_val: strong
+            value: boost
+          - dps_val: mute
+            value: silent
+      - id: 5
+        type: string
+        name: hvac_mode
+        mapping:
+          - dps_val: wth
+            value: "off"
+          - dps_val: heat
+            value: heat
+            hidden: true
+          - dps_val: cool
+            value: cool
+            hidden: true
+          - dps_val: wth_heat
+            value: heat
+          - dps_val: wth_cool
+            value: cool
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+      - id: 103
+        type: integer
+        optional: true
+        name: current_temperature
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 6
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 15
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Inlet temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Outlet temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Exhaust temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Return temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Outer coil temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Cooling coil temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Main EEV opening
+    category: diagnostic
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        unit: P
+        class: measurement
+  - entity: sensor
+    name: Secondary EEV opening
+    category: diagnostic
+    dps:
+      - id: 111
+        type: integer
+        name: sensor
+        unit: P
+        class: measurement
+  - entity: sensor
+    name: Compressor current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+  - entity: sensor
+    name: Heat sink temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 113
+        type: integer
+        name: sensor
+        class: measurement
+      - id: 6
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: DC bus voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        unit: V
+        class: measurement
+  - entity: sensor
+    name: Compressor frequency
+    class: frequency
+    category: diagnostic
+    dps:
+      - id: 115
+        type: integer
+        name: sensor
+        unit: Hz
+        class: measurement
+  - entity: sensor
+    name: Fan 1 speed
+    category: diagnostic
+    dps:
+      - id: 116
+        type: integer
+        name: sensor
+        unit: rpm
+        class: measurement
+  - entity: sensor
+    name: Fan 2 speed
+    category: diagnostic
+    dps:
+      - id: 117
+        type: integer
+        name: sensor
+        unit: rpm
+        class: measurement
+  - entity: button
+    translation_key: factory_reset
+    category: config
+    dps:
+      - id: 125
+        type: boolean
+        optional: true
+        name: button
+  - entity: sensor
+    name: Heating capacity
+    class: power
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        name: sensor
+        unit: kW
+        mapping:
+          - scale: 10
+        mask: "FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"
+  - entity: sensor
+    name: Current water flow rate
+    class: volume_flow_rate
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        optional: true
+        name: sensor
+        unit: m³/h
+        mask: "00000000\
+		       FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Current of the entire machine
+    class: current
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        optional: true
+        name: sensor
+        unit: A
+        mask: "00000000\
+		       00000000\
+		       FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Voltage of the entire machine
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        optional: true
+        name: sensor
+        unit: V
+        mask: "00000000\
+		       00000000\
+		       00000000\
+		       FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"
+  - entity: sensor
+    name: Power of the entire machine
+    class: power
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        optional: true
+        name: sensor
+        unit: W
+        mask: "00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"
+  - entity: sensor
+    name: Coefficient of performance
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        optional: true
+        name: sensor
+        mask: "00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Energy today
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 140
+        type: base64
+        optional: true
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mask: "00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       FFFFFFFF\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+		       00000000\
+               00000000"


### PR DESCRIPTION
ALMEVO HPHTXXXXXXXPW are similar to Powerworld PW0XX-DKZLRS monoblock water heat pumps.
https://www.almevo.eu/shop/
https://www.powerworldhp.com/heat-pump/home-heat-pump/low-gwp-r290-monoblock-heat-pumps.html
This YAML is based on powerworld_pw58330_waterheater.yaml and powerworld_pw58410_waterheater.yaml, but with correct product ID and extended with power measurement.