### PR TITLE
Expose room humidity as a sensor. Fix typo in device name

### DIFF
--- a/custom_components/tuya_local/devices/inventor_atmospherexl_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/inventor_atmospherexl_dehumidifier.yaml
@@ -1,4 +1,4 @@
-name: Inventor Atomsphere XL dehumidifier
+name: Inventor Atmosphere XL
 entities:
   - entity: humidifier
     class: dehumidifier
@@ -113,6 +113,15 @@ entities:
         type: integer
         name: sensor
         unit: C
+        class: measurement
+  - entity: sensor
+    class: humidity
+    name: Room humidity
+    dps:  
+      - id: 6
+        type: integer
+        name: sensor
+        unit: "%"
         class: measurement
   - entity: switch
     category: config


### PR DESCRIPTION
While the room temperature is exposed as a sensor in HA, humidity does not has it's own sensor. This patch exposes a similar sensor.

Also: fix typo in the device name: atomsphere -> atmosphere. I choose to ommit the 'dehumidifier' string to avoid HA creating very long entity names