### PR TITLE
Fix support for Vevor EV Charger 3.7kw 

### DIFF
--- a/custom_components/tuya_local/devices/vevor_3_7kw_evcharger.yaml
+++ b/custom_components/tuya_local/devices/vevor_3_7kw_evcharger.yaml
@@ -62,6 +62,7 @@ entities:
     name: Single phase power
     class: power
     category: diagnostic
+    hidden: true
     dps:
       - id: 5
         type: integer
@@ -75,6 +76,7 @@ entities:
     name: Phase A power
     class: power
     category: diagnostic
+    hidden: true
     dps:
       - id: 6
         type: base64
@@ -231,9 +233,9 @@ entities:
           - value: false
             hidden: true
   - entity: number
-    name: Delay time
+    name: Delay
+    class: duration
     category: config
-    icon: "mdi:clock"
     dps:
       - id: 28
         type: integer

--- a/custom_components/tuya_local/devices/vevor_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/vevor_ev_charger.yaml
@@ -6,9 +6,6 @@ products:
   - id: w7lvyyxyevpwf20e
     manufacturer: Vevor
     model: SS US 7kW
-  - id: ypdfdnwauasb8rje
-    manufacturer: Vevor
-    model: SS EU Mode2 3.7kW
 entities:
   - entity: sensor
     translation_key: status

--- a/custom_components/tuya_local/devices/vevor_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/vevor_ev_charger.yaml
@@ -65,6 +65,7 @@ entities:
     name: Single phase power
     class: power
     category: diagnostic
+    hidden: true
     dps:
       - id: 5
         type: integer
@@ -78,6 +79,7 @@ entities:
     name: Phase A power
     class: power
     category: diagnostic
+    hidden: true
     dps:
       - id: 6
         type: base64
@@ -234,9 +236,9 @@ entities:
           - value: false
             hidden: true
   - entity: number
-    name: Delay time
+    name: Delay
+    class: duration
     category: config
-    icon: "mdi:clock"
     dps:
       - id: 28
         type: integer

--- a/custom_components/tuya_local/devices/vevor_ev_charger_3_7kw.yaml
+++ b/custom_components/tuya_local/devices/vevor_ev_charger_3_7kw.yaml
@@ -1,0 +1,245 @@
+name: Portable EV charger
+products:
+  - id: ypdfdnwauasb8rje
+    manufacturer: Vevor
+    model: SS EU Mode2 3.7kW
+entities:
+  - entity: sensor
+    translation_key: status
+    class: enum
+    icon: "mdi:ev-station"
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: charger_free
+            value: available
+          - dps_val: charger_insert
+            value: plugged_in
+          - dps_val: charger_free_fault
+            value: fault_unplugged
+          - dps_val: charger_wait
+            value: waiting
+          - dps_val: charger_charging
+            value: charging
+          - dps_val: charger_pause
+            value: paused
+          - dps_val: charger_end
+            value: charged
+          - dps_val: charger_fault
+            value: fault
+      - id: 23
+        type: string
+        name: system_version
+      - id: 33
+        type: string
+        optional: true
+        name: mode_set
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Charge current
+    category: config
+    class: current
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: A
+        range:
+          min: 6
+          max: 16
+  - entity: sensor
+    name: Single phase power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        optional: true
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Phase A power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        optional: true
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Connection state
+    class: enum
+    icon: "mdi:ev-plug-type2"
+    category: diagnostic
+    dps:
+      - id: 13
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: controlpi_12v
+            value: Standby
+          - dps_val: controlpi_12v_pwn
+            value: Communication initialising
+          - dps_val: controlpi_9v
+            value: Vehicle detected
+          - dps_val: controlpi_9v_pwm
+            value: Vehicle connected
+          - dps_val: controlpi_6v
+            value: Ready to charge
+          - dps_val: controlpi_6v_pwm
+            value: Charging
+          - dps_val: controlpi_error
+            value: Error
+  - entity: select
+    name: Mode
+    icon: "mdi:ev-station"
+    category: config
+    dps:
+      - id: 14
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: Immediate
+          - dps_val: charge_pct
+            value: Charge to percent
+          - dps_val: charge_energy
+            value: Fixed charge
+          - dps_val: charge_schedule
+            value: Scheduled charge
+          - dps_val: charge_delay
+            value: Delayed charge
+  - entity: button
+    name: Clear energy
+    class: restart
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        optional: true
+        name: button
+  - entity: switch
+    icon: "mdi:power"
+    dps:
+      - id: 18
+        type: boolean
+        name: switch
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Last charge
+    category: diagnostic
+    dps:
+      - id: 25
+        type: integer
+        optional: true
+        name: sensor
+        unit: kWh
+        mapping:
+          - scale: 100
+
+  - entity: switch
+    category: config
+    name: Live updates
+    icon: "mdi:chart-bar"
+    dps:
+      - id: 27
+        type: string
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: online
+            value: true
+          - dps_val: offline
+            value: false
+          - value: false
+            hidden: true
+  - entity: number
+    name: Delay time
+    category: config
+    icon: "mdi:clock"
+    dps:
+      - id: 28
+        type: integer
+        optional: true
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 12


### PR DESCRIPTION
On device id ypdfdnwauasb8rje the charge current values where not the same has 7kw chargers, on 3.7 kw can go from 6A to 16A and not from 8A to 32A