### PR TITLE
Sefaul Q9 Dehumidifier

### DIFF
--- a/custom_components/tuya_local/devices/sefaul_q9_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/sefaul_q9_dehumidifier.yaml
@@ -1,0 +1,68 @@
+name: Dehumidifier
+products:
+  - id: e8c9gukirorvyhk8
+    manufacturer: Sefaul
+    model: Q9 Dehumidifier
+
+entities:
+  - entity: light
+    class: light
+    name: Light
+    dps:
+      - id: 11
+        name: switch
+        type: boolean
+  - entity: fan
+    class: fan
+    name: Purifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: "low"
+            value: "Low"
+          - dps_val: "high"
+            value: "High"
+  - entity: switch
+    name: Dehumidifier
+    dps:
+      - id: 101
+        name: switch
+        type: boolean
+  - entity: select
+    name: Timer Set
+    dps:
+      - id: 17
+        name: option
+        type: string
+        mapping:
+          - dps_val: "cancel"
+            value: "Cancel"
+          - dps_val: "2h"
+            value: "2H"
+          - dps_val: "4H"
+            value: "4H"
+          - dps_val: "8H"
+            value: "8H"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: min
+        class: measurement
+  - entity: binary_sensor
+    class: problem
+    dps:
+      - id: 19
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 2
+            value: "Tank Full"

--- a/custom_components/tuya_local/devices/sefaul_q9_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/sefaul_q9_dehumidifier.yaml
@@ -2,18 +2,15 @@ name: Dehumidifier
 products:
   - id: e8c9gukirorvyhk8
     manufacturer: Sefaul
-    model: Q9 Dehumidifier
-
+    model: Q9
 entities:
   - entity: light
-    class: light
-    name: Light
     dps:
       - id: 11
         name: switch
         type: boolean
   - entity: fan
-    class: fan
+    translation_key: fan_with_presets
     name: Purifier
     dps:
       - id: 1
@@ -23,10 +20,10 @@ entities:
         type: string
         name: preset_mode
         mapping:
-          - dps_val: "low"
-            value: "Low"
-          - dps_val: "high"
-            value: "High"
+          - dps_val: low
+            value: low
+          - dps_val: high
+            value: high
   - entity: switch
     name: Dehumidifier
     dps:
@@ -34,23 +31,25 @@ entities:
         name: switch
         type: boolean
   - entity: select
-    name: Timer Set
+    translation_key: timer
+    category: config
     dps:
       - id: 17
         name: option
         type: string
         mapping:
           - dps_val: "cancel"
-            value: "Cancel"
+            value: "cancel"
           - dps_val: "2h"
-            value: "2H"
+            value: "2h"
           - dps_val: "4H"
-            value: "4H"
+            value: "4h"
           - dps_val: "8H"
-            value: "8H"
+            value: "8h"
   - entity: sensor
     translation_key: time_remaining
     class: duration
+    category: diagnostic
     dps:
       - id: 18
         type: integer
@@ -59,10 +58,27 @@ entities:
         class: measurement
   - entity: binary_sensor
     class: problem
+    category: diagnostic
+    dps:
+      - id: 19
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 2
+            value: false
+          - value: true
+      - id: 19
+        type: bitfield
+        name: fault_code
+  - entity: binary_sensor
+    translation_key: tank_full
     dps:
       - id: 19
         type: bitfield
         name: sensor
         mapping:
           - dps_val: 2
-            value: "Tank Full"
+            value: true
+          - value: false


### PR DESCRIPTION
Unfortunately this isn't the most intuitive device - neither via the Smartlife App nor the device's control panel.  The device doesn't have a humidity sensor, so the dehumidifier cant natively be triggered that way, and it has a separate air purifier component that gets automatically turned on, so I couldn't really make it work as a dehumidifier the way HA expects.  Perhaps someone with more experience would have a different approach.  But, this config does work the same way as the device's control panel.  

https://www.amazon.com/dp/B0D7959FJX

(Also my first time contributing to a project using github, so apologies if I've done something wrong)