### PR TITLE
Add support for compatible Mirabella Genio RGBW Downlight CLXRGB60

### DIFF
--- a/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
@@ -27,6 +27,10 @@ products:
   - id: kw2oclsjnfal3mfv
     manufacturer: Beamlux
     name: BLX501
+  - id: csmd08jaltoa4n15
+    manufacturer: Mirabella Genio
+    model: CLXRGB60
+    name: Genio RGBW Downlight
 entities:
   - entity: light
     dps:


### PR DESCRIPTION
… device

Add support for compatible Mirabella Genio downlight (model: CLXRGB60) device

Preview:
<img width="326" alt="image" src="https://github.com/user-attachments/assets/f3de81da-a573-4fc3-90ef-45c9ae3c2af0" />
