### PR TITLE
Added support for compatible ARLEC Twin Smart Plug PC287HA

### DIFF
--- a/custom_components/tuya_local/devices/dual_power_monitor_smartplugv2.yaml
+++ b/custom_components/tuya_local/devices/dual_power_monitor_smartplugv2.yaml
@@ -13,6 +13,9 @@ products:
   - id: gijt75s5nj2lmlup
     manufacturer: FreshLink
     model: Smart socket with USB
+  - id: r03i57pimbyua3ev
+    manufacturer: ARLEC
+    model: PC287HA
 entities:
   - entity: switch
     translation_key: outlet_x


### PR DESCRIPTION
- Added support for compatible ARLEC Twin Smart Plug PC287HA

Preview:
<img width="234" alt="image" src="https://github.com/user-attachments/assets/3162ae86-13d8-4da4-bf29-f2e14fbbf8e4" />
