### PR TITLE
Added unit % to 'Coefficient of performance' of powerworld_pw58330_waterheater

### DIFF
--- a/custom_components/tuya_local/devices/powerworld_pw58330_waterheater.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw58330_waterheater.yaml
@@ -452,7 +452,7 @@ entities:
         type: base64
         optional: true
         name: sensor
-        unit: '%'
+        class: measurement
         mapping:
           - scale: 10
         mask: "0000000000000000000000000000000000000000FFFFFFFF\

--- a/custom_components/tuya_local/devices/powerworld_pw58330_waterheater.yaml
+++ b/custom_components/tuya_local/devices/powerworld_pw58330_waterheater.yaml
@@ -452,6 +452,7 @@ entities:
         type: base64
         optional: true
         name: sensor
+        unit: '%'
         mapping:
           - scale: 10
         mask: "0000000000000000000000000000000000000000FFFFFFFF\


### PR DESCRIPTION
powerworld_pw58330_waterheater: Added unit % to 'Coefficient of performance' to have a propper graph and not only a changing string. Actualy it is a factor but I didn't find a unit for that.