### PR TITLE
feat(devices): add `cover_switch_with_backlight.yaml`

### DIFF
--- a/custom_components/tuya_local/devices/cover_switch_with_backlight.yaml
+++ b/custom_components/tuya_local/devices/cover_switch_with_backlight.yaml
@@ -1,8 +1,7 @@
-name: Cover Switch with Backlight
+name: Cover switch with backlight
 products:
   - id: fthu3wguzoqdayzp
     model: CST_WB_V1
-    model_id: 000001xhgh
 entities:
   - entity: cover
     class: shutter

--- a/custom_components/tuya_local/devices/cover_switch_with_backlight.yaml
+++ b/custom_components/tuya_local/devices/cover_switch_with_backlight.yaml
@@ -1,0 +1,45 @@
+name: Cover Switch with Backlight
+products:
+  - id: fthu3wguzoqdayzp
+    model: CST_WB_V1
+    model_id: 000001xhgh
+entities:
+  - entity: cover
+    class: shutter
+    dps:
+      - id: 1
+        type: string
+        name: control
+        mapping:
+          - dps_val: open
+            value: open
+          - dps_val: close
+            value: close
+          - dps_val: stop
+            value: stop
+      - id: 2
+        type: integer
+        name: position
+        range:
+          min: 0
+          max: 100
+  - entity: select
+    name: Calibration
+    icon: "mdi:arrow-collapse-vertical"
+    category: config
+    dps:
+      - id: 3
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: start
+            value: Start
+          - dps_val: end
+            value: End
+  - entity: light
+    translation_key: backlight
+    dps:
+      - id: 7
+        type: boolean
+        name: switch


### PR DESCRIPTION
This PR adds a `Cover Switch with Backlight` device for product ID `fthu3wguzoqdayzp` & model `CST_WB_V1` (`000001xhgh`).

Unfortunately those devices are already a few years old and I no longer know, what manufacturer I got them from.

Please let me know, if I should be using / adapting a different device `.yaml` instead.