### PR TITLE
Add EUROM Wifi Thermostat

### DIFF
--- a/custom_components/tuya_local/devices/eurom_wifi_thermostat.yaml
+++ b/custom_components/tuya_local/devices/eurom_wifi_thermostat.yaml
@@ -1,4 +1,4 @@
-name: EUROM Wifi Thermostat
+name: Thermostat
 products:
   - id: jqzvke4b1nzjcr5n
     manufacturer: EUROM
@@ -30,6 +30,6 @@ entities:
         type: boolean
         mapping:
           - dps_val: true
-            value: "eco"
+            value: eco
           - dps_val: false
-            value: "none"
+            value: comfort


### PR DESCRIPTION
Add EUROM Wifi Thermostat

https://eurom.nl/en/product/permanent-heating/infrared-heaters-permanent/wifi-thermostat-usb-c/

Device specification:
```
[
  {
    "id": 1,
    "name": "switch",
    "type": "Boolean",
    "format": "{}",
    "enumMap": {}
  },
  {
    "id": 2,
    "name": "temp_set",
    "type": "Integer",
    "format": "{\"unit\":\"\\u00b0C\",\"min\":0,\"max\":37,\"scale\":0,\"step\":1}",
    "enumMap": {}
  },
  {
    "id": 3,
    "name": "temp_current",
    "type": "Integer",
    "format": "{\"unit\":\"\\u00b0C\",\"min\":-20,\"max\":50,\"scale\":0,\"step\":1}",
    "enumMap": {}
  },
  {
    "id": 6,
    "name": "eco",
    "type": "Boolean",
    "format": "{}",
    "enumMap": {}
  }
]
```
~~I've ignored the eco setting, because i don't know to what settings this should be mapped (and because I don't need it ;))~~

Sorry for not reading your documentation earlier. I've also added the eco setting now.