### PR TITLE
Added "configured current" to goodcell_ev_charger.yaml

### DIFF
--- a/custom_components/tuya_local/devices/goodcell_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/goodcell_ev_charger.yaml
@@ -346,4 +346,4 @@ entities:
         unit: A
         class: measurement
         mapping:
-          - scale: 1 
+          - scale: 1

--- a/custom_components/tuya_local/devices/goodcell_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/goodcell_ev_charger.yaml
@@ -335,3 +335,15 @@ entities:
         type: boolean
         name: switch
         optional: true
+  - entity: sensor
+    name: Configured Current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 125
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+        mapping:
+          - scale: 1 


### PR DESCRIPTION
Added DP 125
For the Feyree charging cable, DP 125 is described as:
设置电流显示 → "Set Current Display" – it displays the configured current.

According to the Tuya API Explorer, the code for 125 is "set60a", but this does not make much sense (also, it is read-only).

This value is useful because you can lower the charging limit below 8 A, which is not officially supported. If you try to do so using "set charge current" (and set it to 6 A or 7 A), the value jumps back to 8 A.
Therefore, you can use "set charge current" to set the current and validate the actual setting via this new value.