### PR TITLE
Moebot S: add Start and Pause mowing

### DIFF
--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -88,6 +88,28 @@ entities:
           - dps_val: StartFixedMowing
             value: true
   - entity: button
+    name: Start mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: StartMowing
+            value: true
+  - entity: button
+    name: Pause mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: PauseWork
+            value: true
+  - entity: button
     name: Cancel mowing
     icon: "mdi:mower"
     dps:


### PR DESCRIPTION
I have added a "Start mowing" and "Pause mowing" button, as at least for the Parkside PMRDA mower, these are the most common commands, and were missing.
(sidenote: fixed mowing is basically the "spot mode" where you need to place the mower somewhere on the lawn, it will not exit the docking station)