### PR TITLE
Moebot S: add Hedgehog protection

### DIFF
--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -305,3 +305,4 @@ entities:
       - id: 118
         type: boolean
         name: switch
+        optional: true

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -297,3 +297,11 @@ entities:
         type: boolean
         name: sensor
         optional: true
+  - entity: switch
+    name: Hedgehog protection
+    icon: "mdi:account-group"
+    category: config
+    dps:
+      - id: 118
+        type: boolean
+        name: switch


### PR DESCRIPTION
Parkside PMRDA introduced a hedgehog protection configuration.

from tuya cloud explorer:
{\"abilityId\":118,\"accessMode\":\"rw\",\"code\":\"boolreserved03\",\"description\":\"刺猬保护功能，0.是关，1是开\",\"extensions\":{\"scope\":\"\"}

the description in english:
Hedgehog protection function, 0 is off, 1 is on