### PR TITLE
Neo-A Duoqu Cat Litter Box Support

### DIFF
--- a/custom_components/tuya_local/devices/duoqu_selfcleaning_litterbox.yaml
+++ b/custom_components/tuya_local/devices/duoqu_selfcleaning_litterbox.yaml
@@ -11,7 +11,7 @@ entities:
         type: boolean
         name: switch
   - entity: select
-    name: Working Mode
+    name: Mode
     icon: "mdi:broom"
     category: config
     dps:
@@ -67,14 +67,6 @@ entities:
       - id: 9
         type: boolean
         name: button
-#  - entity: button
-#    translation_key: factory_reset
-#    category: config
-#    dps:
-#      - id: 23
-#        type: boolean
-#        optional: true
-#        name: button
   - entity: sensor
     name: Visit count
     category: diagnostic
@@ -84,7 +76,7 @@ entities:
         name: sensor
         unit: times
   - entity: light
-    name: Backlight
+    translation_key: backlight
     dps:
       - id: 107
         type: integer
@@ -115,56 +107,8 @@ entities:
       - id: 103
         type: integer
         name: sensor
-#  - entity: event
-#    name: Notification
-#    dps:
-#      - id: 104
-#        type: integer
-#        name: event
-#        optional: true
-#        mapping:
-#          - dps_val: 0
-#            value: null
-#          - dps_val: null
-#            value: null
-#          - value: toilet
-#      - id: 104
-#        type: integer
-#        optional: true
-#        name: value
-#        mapping:
-#          - scale: 10
-#      - id: 108
-#        type: string
-#        name: log
-#  - entity: binary_sensor
-#    class: problem
-#    category: diagnostic
-#    dps:
-#      - id: 105
-#        type: string
-#        name: sensor
-#        mapping:
-#          - dps_val: "0"
-#            value: false
-#          - value: true
-#      - id: 105
-#        type: string
-#        name: fault_code
-#      - id: 105
-#        type: string
-#        name: description
-#        mapping:
-#          - dps_val: "0"
-#            value: ok
-#          - dps_val: "1"
-#            value: door
-#          - dps_val: "2"
-#            value: bin
-#          - dps_val: "3"
-#            value: pressure
   - entity: number
-    name: Flow Set
+    name: Flow
     category: config
     icon: "mdi:timer-pause"
     dps:

--- a/custom_components/tuya_local/devices/duoqu_selfcleaning_litterbox.yaml
+++ b/custom_components/tuya_local/devices/duoqu_selfcleaning_litterbox.yaml
@@ -1,0 +1,218 @@
+name: Litter box
+products:
+  - id: ah3vg6gvftgdl0sb
+    manufacturer: Duoqu
+    model: NEO-A
+entities:
+  - entity: switch
+    name: Reset
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+  - entity: select
+    name: Working Mode
+    icon: "mdi:broom"
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: auto_clean
+            value: Auto
+          - dps_val: manual_clean
+            value: Manual
+  - entity: button
+    name: Empty
+    icon: "mdi:play"
+    dps:
+      - id: 3
+        type: boolean
+        name: button
+  - entity: number
+    name: Cleaning delay
+    category: config
+    icon: "mdi:timer-pause"
+    dps:
+      - id: 5
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 60
+  - entity: sensor
+    class: weight
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: kg
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Last usage
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: s
+  - entity: button
+    name: Clean
+    icon: "mdi:broom"
+    dps:
+      - id: 9
+        type: boolean
+        name: button
+#  - entity: button
+#    translation_key: factory_reset
+#    category: config
+#    dps:
+#      - id: 23
+#        type: boolean
+#        optional: true
+#        name: button
+  - entity: sensor
+    name: Visit count
+    category: diagnostic
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: times
+  - entity: light
+    name: Backlight
+    dps:
+      - id: 107
+        type: integer
+        name: brightness
+        range:
+          min: 0
+          max: 255
+      - id: 102
+        type: string
+        name: named_color
+        mapping:
+          - dps_val: red
+            value: red
+          - dps_val: greed
+            value: green
+          - dps_val: blue
+            value: blue
+          - dps_val: yellow
+            value: yellow
+          - dps_val: purple
+            value: purple
+          - dps_val: white
+            value: white
+  - entity: sensor
+    name: Cleans in bin
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+#  - entity: event
+#    name: Notification
+#    dps:
+#      - id: 104
+#        type: integer
+#        name: event
+#        optional: true
+#        mapping:
+#          - dps_val: 0
+#            value: null
+#          - dps_val: null
+#            value: null
+#          - value: toilet
+#      - id: 104
+#        type: integer
+#        optional: true
+#        name: value
+#        mapping:
+#          - scale: 10
+#      - id: 108
+#        type: string
+#        name: log
+#  - entity: binary_sensor
+#    class: problem
+#    category: diagnostic
+#    dps:
+#      - id: 105
+#        type: string
+#        name: sensor
+#        mapping:
+#          - dps_val: "0"
+#            value: false
+#          - value: true
+#      - id: 105
+#        type: string
+#        name: fault_code
+#      - id: 105
+#        type: string
+#        name: description
+#        mapping:
+#          - dps_val: "0"
+#            value: ok
+#          - dps_val: "1"
+#            value: door
+#          - dps_val: "2"
+#            value: bin
+#          - dps_val: "3"
+#            value: pressure
+  - entity: number
+    name: Flow Set
+    category: config
+    icon: "mdi:timer-pause"
+    dps:
+      - id: 106
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 255
+  - entity: sensor
+    translation_key: status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 110
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: Standby
+            value: standby
+          - dps_val: Wait_Cluster
+            value: caking
+          - dps_val: Clean_Pause
+            value: paused
+          - dps_val: Clean_Start
+            value: starting
+          - dps_val: Cleaning
+            value: cleaning
+          - dps_val: Empty_Pause
+            value: paused
+          - dps_val: Empty_Start
+            value: starting
+          - dps_val: Emptying
+            value: emptying
+          - dps_val: Reset_Pause
+            value: paused
+          - dps_val: Reset_Start
+            value: starting
+          - dps_val: Resetting
+            value: resetting
+          - dps_val: Abnormal
+            value: fault
+          - dps_val: Reverse_rotation
+            value: reverse
+          - dps_val: Drawers_open
+            value: door_open
+          - dps_val: Cat_into
+            value: occupied
+      - id: 109
+        type: string
+        name: trigger


### PR DESCRIPTION
This litter box is very simliar to the Vevor 76L configurations.   


I have made some changes to adjust

1.  Removed Factory Reset - This option doesn't seem to work in the Tuya app there is a confirmation after pressing. 
2.  For the backlight feature the api has green spelled as greed adjusted for this
3.  Renamed 'Cleaning' to 'Work Mode' to match Tuya App
4.  Renamed 'Start' to match Tuya App ('Emptry')
5.  Removed Child lock as this is not an option with this model
6.  Set label name to the Main Switch as this is actual the 'Reset' Litter option in the Tuya App
7.  Got rid of duplicate congurations for dps 7 and relabeled to 'Daily Usage' to match Tuya App
8.  Added label for Backlight
9.  Removed Notification and Problem DPS as mine don't seem to update in the API.  The api always says there is a pressure issue but the app doesn't.  
10. Backlight corected to this devices DPS
11. added 'Flow Set' option - Not sure on this it does nothing to my device but the changes show up in the app