### PR TITLE
Added support for KIMEX motorized cinema screen (tuya)

### DIFF
--- a/custom_components/tuya_local/devices/KIMEX_tuya_cinema_screen.yaml
+++ b/custom_components/tuya_local/devices/KIMEX_tuya_cinema_screen.yaml
@@ -27,7 +27,15 @@ entities:
             value: stop
           - dps_val: close
             value: closed
+  - entity: select
+    icon: "mdi:arrow-u-left-bottom"
+    category: config
+    dps:
       - id: 8
-        name: control_back_mode
+        name: control_back
         type: string
-        category: config
+        mapping:
+          - dps_val: forward
+            value: "forward"
+          - dps_val: back
+            value: "reverse"

--- a/custom_components/tuya_local/devices/KIMEX_tuya_cinema_screen.yaml
+++ b/custom_components/tuya_local/devices/KIMEX_tuya_cinema_screen.yaml
@@ -1,0 +1,28 @@
+name: Simple curtain switch
+products:
+  - id: 000003th5e
+    manufacturer: KIMEX
+    model: KIMEX 048-1511W
+  -
+entities:
+  - entity: cover
+    class: blind
+    dps:
+      - id: 1
+        name: control
+        type: string
+        mapping:
+         - dps_val: open
+           value: open
+         - dps_val: close
+           value: close
+         - dps_val: stop
+           value: stop
+      - id: 8
+        name: control_back
+        type: string
+        mapping:
+         - dps_val: forward
+           value: forward
+         - dps_val: backward
+           value: backward   

--- a/custom_components/tuya_local/devices/KIMEX_tuya_cinema_screen.yaml
+++ b/custom_components/tuya_local/devices/KIMEX_tuya_cinema_screen.yaml
@@ -1,9 +1,8 @@
-name: Simple curtain switch
+name: KIMEX cimema screen
 products:
-  - id: 000003th5e
+  - id: hpg7erxfe5ypgh20
     manufacturer: KIMEX
-    model: KIMEX 048-1511W
-  -
+    model: THM-02
 entities:
   - entity: cover
     class: blind
@@ -12,17 +11,23 @@ entities:
         name: control
         type: string
         mapping:
-         - dps_val: open
-           value: open
-         - dps_val: close
-           value: close
-         - dps_val: stop
-           value: stop
-      - id: 8
-        name: control_back
+          - dps_val: open
+            value: open
+          - dps_val: stop
+            value: stop
+          - dps_val: close
+            value: close
+      - id: 1
+        name: action
         type: string
         mapping:
-         - dps_val: forward
-           value: forward
-         - dps_val: backward
-           value: backward   
+          - dps_val: open
+            value: opened
+          - dps_val: stop
+            value: stop
+          - dps_val: close
+            value: closed
+      - id: 8
+        name: control_back_mode
+        type: string
+        category: config

--- a/custom_components/tuya_local/devices/kimex_cinemascreen.yaml
+++ b/custom_components/tuya_local/devices/kimex_cinemascreen.yaml
@@ -1,11 +1,12 @@
-name: KIMEX cimema screen
+name: Cinema screen
 products:
   - id: hpg7erxfe5ypgh20
-    manufacturer: KIMEX
+    manufacturer: Kimex
     model: THM-02
 entities:
   - entity: cover
     class: blind
+    name: Screen
     dps:
       - id: 1
         name: control
@@ -32,10 +33,10 @@ entities:
     category: config
     dps:
       - id: 8
-        name: control_back
+        name: option
         type: string
         mapping:
           - dps_val: forward
-            value: "forward"
+            value: forward
           - dps_val: back
-            value: "reverse"
+            value: reverse


### PR DESCRIPTION
It used to add as a loratap curtain, but it could not see its status, therefore fixed here.

So it adds support for motorized cinema screens using the same mechanism (control and state)

![Captura de pantalla 2025-04-30 012948](https://github.com/user-attachments/assets/528b689c-9621-4822-90f4-0452d7197d89)

![Captura de pantalla 2025-04-30 013013](https://github.com/user-attachments/assets/9b01f093-c16d-4a86-b80e-10c0af173cdf)
