### PR TITLE
Resolve warnings of logger library

### DIFF
--- a/custom_components/tuya_local/cloud.py
+++ b/custom_components/tuya_local/cloud.py
@@ -87,7 +87,7 @@ class Cloud:
     async def async_login(self) -> bool:
         """Login to the Tuya cloud."""
         if not self.__user_code or not self.__qr_code:
-            _LOGGER.warn("Login attempted without successful QR scan")
+            _LOGGER.warning("Login attempted without successful QR scan")
             return False, {}
 
         success, info = await self.__hass.async_add_executor_job(


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```