### PR TITLE
Adds more product_ids observed for Treatlife DS03 devices

### DIFF
--- a/custom_components/tuya_local/devices/treatlife_ds03_fan_light.yaml
+++ b/custom_components/tuya_local/devices/treatlife_ds03_fan_light.yaml
@@ -6,9 +6,6 @@ products:
   - id: gvfmw8c8n92umpax
     manufacturer: Treatlife
     model: DS03
-  - id: ea88zei7auxu48s6
-    manufacturer: Treatlife
-    model: DS03
 entities:
   - entity: fan
     dps:


### PR DESCRIPTION
I own a couple three Treatlife DS03 switches; one of them associates correctly with the `treatlife_ds03_fan_light.yaml` profile even though its `product_id` is `gvfmw8c8n92umpax`, I assume because its productKey is somehow matching the profile.

My other two switches that have a `product_id` of `ea88zei7auxu48s6` don't associate with the profile, so I can't make them be recognized as a DS03 when I add them. This ID has also been observed in #3211.

This PR adds the two product IDs I've observed, `gvfmw8c8n92umpax` and `ea88zei7auxu48s6`, to the profile for the DS03.
