### PR TITLE
Adding support to EV Charger DCHS-K7 (Dowell iOneAIO ESS - 32A - 7kW)

### DIFF
--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -9,7 +9,7 @@ entities:
     icon: "mdi:ev-station"
     class: enum
     dps:
-      - id: 3  # work_state
+      - id: 3 # work_state
         type: string
         name: sensor
         mapping:
@@ -32,22 +32,22 @@ entities:
   - entity: sensor
     name: meter_id
     category: diagnostic
-    dps:            
-      - id: 22  # meter_id
+    dps:
+      - id: 22 # meter_id
         type: string
         name: sensor
   - entity: sensor
     category: diagnostic
     name: system_version
-    dps:               
-      - id: 23  # system_version
+    dps:
+      - id: 23 # system_version
         type: string
         name: sensor
   - entity: sensor
     name: Total electricity consumption
     class: energy
     dps:
-      - id: 1  # forward_energy_total
+      - id: 1 # forward_energy_total
         type: integer
         name: sensor
         class: total_increasing
@@ -55,10 +55,10 @@ entities:
         mapping:
           - scale: 100
   - entity: sensor
-    category: diagnostic  
+    category: diagnostic
     class: battery
     dps:
-      - id: 2  # battery_percentage
+      - id: 2 # battery_percentage
         type: integer
         optional: true
         name: sensor
@@ -70,7 +70,7 @@ entities:
     mode: box
     icon: "mdi:current-ac"
     dps:
-      - id: 4  # charge_cur_set
+      - id: 4 # charge_cur_set
         type: integer
         name: value
         unit: A
@@ -84,10 +84,10 @@ entities:
     name: Household load balancing
     category: config
     class: current
-    mode: box    
+    mode: box
     icon: "mdi:current-ac"
     dps:
-      - id: 107  # dlb_cur_set
+      - id: 107 # dlb_cur_set
         type: integer
         name: value
         unit: A
@@ -101,7 +101,7 @@ entities:
     class: power
     category: diagnostic
     dps:
-      - id: 9  # power_total
+      - id: 9 # power_total
         type: integer
         optional: true
         name: sensor
@@ -113,17 +113,17 @@ entities:
     class: problem
     category: diagnostic
     dps:
-      - id: 10  # fault
+      - id: 10 # fault
         type: bitfield
         name: sensor
         mapping:
           - dps_val: 0
             value: false
           - value: true
-      - id: 10  # fault
+      - id: 10 # fault
         type: bitfield
         name: fault_code
-      - id: 10  # fault
+      - id: 10 # fault
         type: bitfield
         name: description
         mapping:
@@ -165,7 +165,7 @@ entities:
     class: enum
     category: diagnostic
     dps:
-      - id: 13  # connection_state
+      - id: 13 # connection_state
         type: string
         name: sensor
         mapping:
@@ -188,7 +188,7 @@ entities:
     icon: "mdi:ev-station"
     category: config
     dps:
-      - id: 14  # work_mode
+      - id: 14 # work_mode
         type: string
         optional: true
         name: option
@@ -205,7 +205,7 @@ entities:
       x: A
     class: voltage
     dps:
-      - id: 6  # phase_a
+      - id: 6 # phase_a
         type: base64
         name: sensor
         optional: true
@@ -219,7 +219,7 @@ entities:
       x: A
     class: current
     dps:
-      - id: 6  # phase_a
+      - id: 6 # phase_a
         type: base64
         name: sensor
         optional: true
@@ -233,7 +233,7 @@ entities:
       x: A
     class: power
     dps:
-      - id: 6  # phase_a
+      - id: 6 # phase_a
         type: base64
         name: sensor
         optional: true
@@ -247,7 +247,7 @@ entities:
       x: B
     class: voltage
     dps:
-      - id: 7  # phase_b
+      - id: 7 # phase_b
         type: base64
         name: sensor
         optional: true
@@ -261,7 +261,7 @@ entities:
       x: B
     class: current
     dps:
-      - id: 7  # phase_b
+      - id: 7 # phase_b
         type: base64
         name: sensor
         optional: true
@@ -275,7 +275,7 @@ entities:
       x: B
     class: power
     dps:
-      - id: 7  # phase_b
+      - id: 7 # phase_b
         type: base64
         name: sensor
         optional: true
@@ -289,7 +289,7 @@ entities:
       x: C
     class: voltage
     dps:
-      - id: 8  # phase_c
+      - id: 8 # phase_c
         type: base64
         name: sensor
         optional: true
@@ -303,7 +303,7 @@ entities:
       x: C
     class: current
     dps:
-      - id: 8  # phase_c
+      - id: 8 # phase_c
         type: base64
         name: sensor
         optional: true
@@ -317,7 +317,7 @@ entities:
       x: C
     class: power
     dps:
-      - id: 8  # phase_c
+      - id: 8 # phase_c
         type: base64
         name: sensor
         optional: true
@@ -329,7 +329,7 @@ entities:
     class: temperature
     category: diagnostic
     dps:
-      - id: 24  # temp_current
+      - id: 24 # temp_current
         type: integer
         name: sensor
         unit: C
@@ -339,7 +339,7 @@ entities:
     category: diagnostic
     class: energy_storage
     dps:
-      - id: 15  # balance_energy
+      - id: 15 # balance_energy
         type: integer
         optional: true
         name: value
@@ -354,7 +354,7 @@ entities:
     category: diagnostic
     class: energy_storage
     dps:
-      - id: 17  # energy_charge
+      - id: 17 # energy_charge
         type: integer
         optional: true
         name: value
@@ -363,14 +363,14 @@ entities:
           min: 1
           max: 20000000
         mapping:
-          - scale: 100          
+          - scale: 100
   - entity: number
     name: Charge time
     category: config
     class: duration
     icon: "mdi:timer"
     dps:
-      - id: 19  # charge_time
+      - id: 19 # charge_time
         type: integer
         optional: true
         name: value
@@ -382,10 +382,10 @@ entities:
     name: Charge energy
     class: energy_storage
     dps:
-      - id: 25  # charge_energy_once
+      - id: 25 # charge_energy_once
         type: integer
         optional: true
-        name: value
+        name: sensor
         unit: kWh
         range:
           min: 1
@@ -395,7 +395,7 @@ entities:
   - entity: switch
     icon: "mdi:ev-station"
     dps:
-      - id: 18  # switch
+      - id: 18 # switch
         type: boolean
         name: switch
   - entity: sensor
@@ -457,7 +457,7 @@ entities:
     class: restart
     category: config
     dps:
-      - id: 16  # clear_energy
+      - id: 16 # clear_energy
         type: boolean
         optional: true
         name: button
@@ -484,11 +484,11 @@ entities:
         name: switch
   - entity: switch
     name: pen_enable
-    category: config    
+    category: config
     dps:
       - id: 108 # pen_enable
         type: boolean
-        optional: true        
+        optional: true
         name: switch
   - entity: binary_sensor
     class: safety
@@ -545,7 +545,7 @@ entities:
     name: car_binding
     category: config
     dps:
-      - id: 21  # car_binding
+      - id: 21 # car_binding
         type: string
         optional: true
         name: value

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -85,7 +85,7 @@ entities:
     mode: box
     icon: "mdi:current-ac"
     dps:
-      - id: 107    # dlb_cur_set - Actual Load = Set value - 5A 
+      - id: 107    # dlb_cur_set - Actual Load = Set value - 5A
         type: integer
         name: value
         unit: A

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -1,8 +1,9 @@
 name: EV charger
 products:
-  - id: bf2dedfe80f14bc81czzwo
+  - id: rpbvcwf70qtilaxt
     manufacturer: Dowell Technology Co., Ltd.
-    model: DCHS-K7    # (Dowell iOneAIO ESS - 32A - 7kW)
+    model: DCHS-K7    #(Dowell iOneAIO ESS - 32A - 7kW)
+    name: EV_Charger_15_2023
 entities:
   - entity: sensor
     translation_key: status
@@ -44,7 +45,6 @@ entities:
         type: string
         name: sensor
   - entity: sensor
-    name: Total electricity consumption
     class: energy
     dps:
       - id: 1    # forward_energy_total
@@ -77,9 +77,7 @@ entities:
         optional: true
         range:
           min: 6
-          max: 80
-        mapping:
-          - scale: 1
+          max: 32   # 80 default config is higher in Tuya API
   - entity: number
     name: Household load balancing
     category: config
@@ -87,16 +85,14 @@ entities:
     mode: box
     icon: "mdi:current-ac"
     dps:
-      - id: 107    # dlb_cur_set
+      - id: 107    # dlb_cur_set - Actual Load = Set value - 5A 
         type: integer
         name: value
         unit: A
         optional: true
         range:
           min: 10
-          max: 140
-        mapping:
-          - scale: 1
+          max: 32   # 140 default config is higher in Tuya API
   - entity: sensor
     class: power
     category: diagnostic
@@ -461,6 +457,8 @@ entities:
         type: boolean
         optional: true
         name: button
+#  - entity: binary_sensor
+#    class: connectivity
   - entity: select
     name: online_state
     category: diagnostic

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -2,7 +2,7 @@ name: EV charger
 products:
   - id: bf2dedfe80f14bc81czzwo
     manufacturer: Dowell Technology Co., Ltd.
-    model: DCHS-K7    #(Dowell iOneAIO ESS - 32A - 7kW)
+    model: DCHS-K7    # (Dowell iOneAIO ESS - 32A - 7kW)
 entities:
   - entity: sensor
     translation_key: status

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -2,7 +2,7 @@ name: EV charger
 products:
   - id: rpbvcwf70qtilaxt
     manufacturer: Dowell Technology Co., Ltd.
-    model: DCHS-K7    #(Dowell iOneAIO ESS - 32A - 7kW)
+    model: DCHS-K7    # (Dowell iOneAIO ESS - 32A - 7kW)
     name: EV_Charger_15_2023
 entities:
   - entity: sensor
@@ -457,8 +457,6 @@ entities:
         type: boolean
         optional: true
         name: button
-#  - entity: binary_sensor
-#    class: connectivity
   - entity: select
     name: online_state
     category: diagnostic

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -2,14 +2,14 @@ name: EV charger
 products:
   - id: bf2dedfe80f14bc81czzwo
     manufacturer: Dowell Technology Co., Ltd.
-    model: DCHS-K7 #(Dowell iOneAIO ESS - 32A - 7kW)
+    model: DCHS-K7    #(Dowell iOneAIO ESS - 32A - 7kW)
 entities:
   - entity: sensor
     translation_key: status
     icon: "mdi:ev-station"
     class: enum
     dps:
-      - id: 3 # work_state
+      - id: 3    # work_state
         type: string
         name: sensor
         mapping:
@@ -33,21 +33,21 @@ entities:
     name: meter_id
     category: diagnostic
     dps:
-      - id: 22 # meter_id
+      - id: 22    # meter_id
         type: string
         name: sensor
   - entity: sensor
     category: diagnostic
     name: system_version
     dps:
-      - id: 23 # system_version
+      - id: 23    # system_version
         type: string
         name: sensor
   - entity: sensor
     name: Total electricity consumption
     class: energy
     dps:
-      - id: 1 # forward_energy_total
+      - id: 1    # forward_energy_total
         type: integer
         name: sensor
         class: total_increasing
@@ -58,7 +58,7 @@ entities:
     category: diagnostic
     class: battery
     dps:
-      - id: 2 # battery_percentage
+      - id: 2    # battery_percentage
         type: integer
         optional: true
         name: sensor
@@ -70,7 +70,7 @@ entities:
     mode: box
     icon: "mdi:current-ac"
     dps:
-      - id: 4 # charge_cur_set
+      - id: 4    # charge_cur_set
         type: integer
         name: value
         unit: A
@@ -87,7 +87,7 @@ entities:
     mode: box
     icon: "mdi:current-ac"
     dps:
-      - id: 107 # dlb_cur_set
+      - id: 107    # dlb_cur_set
         type: integer
         name: value
         unit: A
@@ -101,7 +101,7 @@ entities:
     class: power
     category: diagnostic
     dps:
-      - id: 9 # power_total
+      - id: 9    # power_total
         type: integer
         optional: true
         name: sensor
@@ -113,17 +113,17 @@ entities:
     class: problem
     category: diagnostic
     dps:
-      - id: 10 # fault
+      - id: 10    # fault
         type: bitfield
         name: sensor
         mapping:
           - dps_val: 0
             value: false
           - value: true
-      - id: 10 # fault
+      - id: 10    # fault
         type: bitfield
         name: fault_code
-      - id: 10 # fault
+      - id: 10    # fault
         type: bitfield
         name: description
         mapping:
@@ -165,7 +165,7 @@ entities:
     class: enum
     category: diagnostic
     dps:
-      - id: 13 # connection_state
+      - id: 13    # connection_state
         type: string
         name: sensor
         mapping:
@@ -188,7 +188,7 @@ entities:
     icon: "mdi:ev-station"
     category: config
     dps:
-      - id: 14 # work_mode
+      - id: 14    # work_mode
         type: string
         optional: true
         name: option
@@ -205,7 +205,7 @@ entities:
       x: A
     class: voltage
     dps:
-      - id: 6 # phase_a
+      - id: 6    # phase_a
         type: base64
         name: sensor
         optional: true
@@ -219,7 +219,7 @@ entities:
       x: A
     class: current
     dps:
-      - id: 6 # phase_a
+      - id: 6    # phase_a
         type: base64
         name: sensor
         optional: true
@@ -233,7 +233,7 @@ entities:
       x: A
     class: power
     dps:
-      - id: 6 # phase_a
+      - id: 6    # phase_a
         type: base64
         name: sensor
         optional: true
@@ -247,7 +247,7 @@ entities:
       x: B
     class: voltage
     dps:
-      - id: 7 # phase_b
+      - id: 7    # phase_b
         type: base64
         name: sensor
         optional: true
@@ -261,7 +261,7 @@ entities:
       x: B
     class: current
     dps:
-      - id: 7 # phase_b
+      - id: 7    # phase_b
         type: base64
         name: sensor
         optional: true
@@ -275,7 +275,7 @@ entities:
       x: B
     class: power
     dps:
-      - id: 7 # phase_b
+      - id: 7    # phase_b
         type: base64
         name: sensor
         optional: true
@@ -289,7 +289,7 @@ entities:
       x: C
     class: voltage
     dps:
-      - id: 8 # phase_c
+      - id: 8    # phase_c
         type: base64
         name: sensor
         optional: true
@@ -303,7 +303,7 @@ entities:
       x: C
     class: current
     dps:
-      - id: 8 # phase_c
+      - id: 8    # phase_c
         type: base64
         name: sensor
         optional: true
@@ -317,7 +317,7 @@ entities:
       x: C
     class: power
     dps:
-      - id: 8 # phase_c
+      - id: 8    # phase_c
         type: base64
         name: sensor
         optional: true
@@ -329,7 +329,7 @@ entities:
     class: temperature
     category: diagnostic
     dps:
-      - id: 24 # temp_current
+      - id: 24    # temp_current
         type: integer
         name: sensor
         unit: C
@@ -339,7 +339,7 @@ entities:
     category: diagnostic
     class: energy_storage
     dps:
-      - id: 15 # balance_energy
+      - id: 15    # balance_energy
         type: integer
         optional: true
         name: value
@@ -354,7 +354,7 @@ entities:
     category: diagnostic
     class: energy_storage
     dps:
-      - id: 17 # energy_charge
+      - id: 17    # energy_charge
         type: integer
         optional: true
         name: value
@@ -370,7 +370,7 @@ entities:
     class: duration
     icon: "mdi:timer"
     dps:
-      - id: 19 # charge_time
+      - id: 19    # charge_time
         type: integer
         optional: true
         name: value
@@ -382,7 +382,7 @@ entities:
     name: Charge energy
     class: energy_storage
     dps:
-      - id: 25 # charge_energy_once
+      - id: 25    # charge_energy_once
         type: integer
         optional: true
         name: sensor
@@ -395,14 +395,14 @@ entities:
   - entity: switch
     icon: "mdi:ev-station"
     dps:
-      - id: 18 # switch
+      - id: 18    # switch
         type: boolean
         name: switch
   - entity: sensor
     name: Charging time
     class: duration
     dps:
-      - id: 101 # charging_time1
+      - id: 101    # charging_time1
         type: base64
         name: sensor
         optional: true
@@ -413,7 +413,7 @@ entities:
     icon: "mdi:cogs"
     category: config
     dps:
-      - id: 102 # mode
+      - id: 102    # mode
         type: string
         optional: true
         name: option
@@ -431,7 +431,7 @@ entities:
     class: current
     category: diagnostic
     dps:
-      - id: 103 # current_limit
+      - id: 103    # current_limit
         type: base64
         optional: true
         name: sensor
@@ -444,7 +444,7 @@ entities:
     class: current
     category: diagnostic
     dps:
-      - id: 103 # current_limit
+      - id: 103    # current_limit
         type: base64
         optional: true
         name: sensor
@@ -457,7 +457,7 @@ entities:
     class: restart
     category: config
     dps:
-      - id: 16 # clear_energy
+      - id: 16    # clear_energy
         type: boolean
         optional: true
         name: button
@@ -465,7 +465,7 @@ entities:
     name: online_state
     category: diagnostic
     dps:
-      - id: 27 # online_state
+      - id: 27    # online_state
         type: string
         optional: true
         name: option
@@ -478,7 +478,7 @@ entities:
     name: rf_enable
     category: config
     dps:
-      - id: 110 # rf_enable
+      - id: 110    # rf_enable
         type: boolean
         optional: true
         name: switch
@@ -486,7 +486,7 @@ entities:
     name: pen_enable
     category: config
     dps:
-      - id: 108 # pen_enable
+      - id: 108    # pen_enable
         type: boolean
         optional: true
         name: switch
@@ -494,17 +494,17 @@ entities:
     class: safety
     category: diagnostic
     dps:
-      - id: 106 # safety_notice
+      - id: 106    # safety_notice
         type: bitfield
         name: sensor
         mapping:
           - dps_val: 0
             value: false
           - value: true
-      - id: 106 # safety_notice
+      - id: 106    # safety_notice
         type: bitfield
         name: fault_code
-      - id: 106 # safety_notice
+      - id: 106    # safety_notice
         type: bitfield
         name: description
         mapping:
@@ -520,7 +520,7 @@ entities:
     name: occp_ip
     category: config
     dps:
-      - id: 104 # occp_ip
+      - id: 104    # occp_ip
         type: string
         optional: true
         name: value
@@ -528,7 +528,7 @@ entities:
     name: occp_port
     category: config
     dps:
-      - id: 105 # occp_port
+      - id: 105    # occp_port
         type: string
         optional: true
         name: value
@@ -536,7 +536,7 @@ entities:
     name: password
     category: config
     dps:
-      - id: 109 # password
+      - id: 109    # password
         type: string
         hidden: true
         optional: true
@@ -545,21 +545,21 @@ entities:
     name: car_binding
     category: config
     dps:
-      - id: 21 # car_binding
+      - id: 21    # car_binding
         type: string
         optional: true
         name: value
   - entity: sensor
     name: alarm_set_1
     dps:
-      - id: 11 # alarm_set_1
+      - id: 11    # alarm_set_1
         type: base64
         name: sensor
         optional: true
   - entity: sensor
     name: alarm_set_2
     dps:
-      - id: 12 # alarm_set_2
+      - id: 12    # alarm_set_2
         type: base64
         name: sensor
         optional: true

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -1,9 +1,9 @@
 name: EV charger
 products:
   - id: rpbvcwf70qtilaxt
-    manufacturer: Dowell Technology Co., Ltd.
-    model: DCHS-K7    # (Dowell iOneAIO ESS - 32A - 7kW)
-    name: EV_Charger_15_2023
+    manufacturer: Dowell
+    model: iOneAIO ESS
+    model_id: DCHS-K7
 entities:
   - entity: sensor
     translation_key: status
@@ -30,20 +30,12 @@ entities:
             value: charged
           - dps_val: charger_fault
             value: fault
-  - entity: sensor
-    name: meter_id
-    category: diagnostic
-    dps:
-      - id: 22    # meter_id
+      - id: 22
         type: string
-        name: sensor
-  - entity: sensor
-    category: diagnostic
-    name: system_version
-    dps:
-      - id: 23    # system_version
+        name: meter_id
+      - id: 23
         type: string
-        name: sensor
+        name: system_version
   - entity: sensor
     class: energy
     dps:
@@ -467,11 +459,11 @@ entities:
         name: sensor
         mapping:
           - dps_val: offline
-            value: off
+            value: false
           - dps_val: online
-            value: on
+            value: true
   - entity: switch
-    name: rf_enable
+    name: RF enable
     category: config
     dps:
       - id: 110    # rf_enable
@@ -479,7 +471,7 @@ entities:
         optional: true
         name: switch
   - entity: switch
-    name: pen_enable
+    name: Pen enable
     category: config
     dps:
       - id: 108    # pen_enable
@@ -513,7 +505,7 @@ entities:
           - dps_val: 4
             value: software_change
   - entity: text
-    name: occp_ip
+    name: OCCP IP
     category: config
     dps:
       - id: 104    # occp_ip
@@ -521,7 +513,7 @@ entities:
         optional: true
         name: value
   - entity: text
-    name: occp_port
+    name: OCCP port
     category: config
     dps:
       - id: 105    # occp_port
@@ -529,16 +521,15 @@ entities:
         optional: true
         name: value
   - entity: text
-    name: password
+    name: Password
     category: config
     dps:
       - id: 109    # password
         type: string
-        hidden: true
         optional: true
         name: value
   - entity: text
-    name: car_binding
+    name: Car binding
     category: config
     dps:
       - id: 21    # car_binding
@@ -546,14 +537,16 @@ entities:
         optional: true
         name: value
   - entity: sensor
-    name: alarm_set_1
+    name: Alarm 1
+    hidden: true
     dps:
       - id: 11    # alarm_set_1
         type: base64
         name: sensor
         optional: true
   - entity: sensor
-    name: alarm_set_2
+    name: Alarm 2
+    hidden: true
     dps:
       - id: 12    # alarm_set_2
         type: base64

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -1,0 +1,565 @@
+name: EV charger
+products:
+  - id: bf2dedfe80f14bc81czzwo
+    manufacturer: Dowell Technology Co., Ltd.
+    model: DCHS-K7 #(Dowell iOneAIO ESS - 32A - 7kW)
+entities:
+  - entity: sensor
+    translation_key: status
+    icon: "mdi:ev-station"
+    class: enum
+    dps:
+      - id: 3  # work_state
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: charger_charging
+            value: charging
+          - dps_val: charger_free
+            value: available
+          - dps_val: charger_insert
+            value: plugged_in
+          - dps_val: charger_free_fault
+            value: fault_unplugged
+          - dps_val: charger_wait
+            value: waiting
+          - dps_val: charger_pause
+            value: paused
+          - dps_val: charger_end
+            value: charged
+          - dps_val: charger_fault
+            value: fault
+  - entity: sensor
+    name: meter_id
+    category: diagnostic
+    dps:            
+      - id: 22  # meter_id
+        type: string
+        name: sensor
+  - entity: sensor
+    category: diagnostic
+    name: system_version
+    dps:               
+      - id: 23  # system_version
+        type: string
+        name: sensor
+  - entity: sensor
+    name: Total electricity consumption
+    class: energy
+    dps:
+      - id: 1  # forward_energy_total
+        type: integer
+        name: sensor
+        class: total_increasing
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic  
+    class: battery
+    dps:
+      - id: 2  # battery_percentage
+        type: integer
+        optional: true
+        name: sensor
+        unit: "%"
+  - entity: number
+    name: Maximum charging current
+    category: config
+    class: current
+    mode: box
+    icon: "mdi:current-ac"
+    dps:
+      - id: 4  # charge_cur_set
+        type: integer
+        name: value
+        unit: A
+        optional: true
+        range:
+          min: 6
+          max: 80
+        mapping:
+          - scale: 1
+  - entity: number
+    name: Household load balancing
+    category: config
+    class: current
+    mode: box    
+    icon: "mdi:current-ac"
+    dps:
+      - id: 107  # dlb_cur_set
+        type: integer
+        name: value
+        unit: A
+        optional: true
+        range:
+          min: 10
+          max: 140
+        mapping:
+          - scale: 1
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 9  # power_total
+        type: integer
+        optional: true
+        name: sensor
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10  # fault
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10  # fault
+        type: bitfield
+        name: fault_code
+      - id: 10  # fault
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ov_cr
+          - dps_val: 1
+            value: ov2_cr_fault
+          - dps_val: 2
+            value: ov_vol
+          - dps_val: 4
+            value: undervoltage_alarm
+          - dps_val: 8
+            value: contactor_adhesion
+          - dps_val: 16
+            value: contactor_fault
+          - dps_val: 32
+            value: earth_fault
+          - dps_val: 64
+            value: meter_hardware_alarm
+          - dps_val: 128
+            value: scram_fault
+          - dps_val: 256
+            value: cp_fault
+          - dps_val: 512
+            value: meter_commu_fault
+          - dps_val: 1024
+            value: card_reader_fault
+          - dps_val: 2048
+            value: cir_short_fault
+          - dps_val: 4096
+            value: adhesion_fault
+          - dps_val: 8192
+            value: self_test_alarm
+          - dps_val: 16384
+            value: leakagecurr_alarm
+  - entity: sensor
+    name: Connection
+    icon: "mdi:ev-plug-type2"
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 13  # connection_state
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: controlpi_12v
+            value: Standby
+          - dps_val: controlpi_12v_pwm
+            value: Communication initialising
+          - dps_val: controlpi_9v
+            value: Vehicle detected
+          - dps_val: controlpi_9v_pwm
+            value: Vehicle connected
+          - dps_val: controlpi_6v
+            value: Ready to charge
+          - dps_val: controlpi_6v_pwm
+            value: Charging
+          - dps_val: controlpi_error
+            value: Error
+  - entity: select
+    name: Charging mode
+    icon: "mdi:ev-station"
+    category: config
+    dps:
+      - id: 14  # work_mode
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: Plug and Play
+          - dps_val: charge_energy
+            value: Normal mode
+          - dps_val: charge_schedule
+            value: Scheduled
+  - entity: sensor
+    translation_key: voltage_x
+    translation_placeholders:
+      x: A
+    class: voltage
+    dps:
+      - id: 6  # phase_a
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    translation_key: current_x
+    translation_placeholders:
+      x: A
+    class: current
+    dps:
+      - id: 6  # phase_a
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    translation_key: power_x
+    translation_placeholders:
+      x: A
+    class: power
+    dps:
+      - id: 6  # phase_a
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    translation_key: voltage_x
+    translation_placeholders:
+      x: B
+    class: voltage
+    dps:
+      - id: 7  # phase_b
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    translation_key: current_x
+    translation_placeholders:
+      x: B
+    class: current
+    dps:
+      - id: 7  # phase_b
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    translation_key: power_x
+    translation_placeholders:
+      x: B
+    class: power
+    dps:
+      - id: 7  # phase_b
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    translation_key: voltage_x
+    translation_placeholders:
+      x: C
+    class: voltage
+    dps:
+      - id: 8  # phase_c
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    translation_key: current_x
+    translation_placeholders:
+      x: C
+    class: current
+    dps:
+      - id: 8  # phase_c
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    translation_key: power_x
+    translation_placeholders:
+      x: C
+    class: power
+    dps:
+      - id: 8  # phase_c
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24  # temp_current
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: number
+    name: Remaining available power
+    category: diagnostic
+    class: energy_storage
+    dps:
+      - id: 15  # balance_energy
+        type: integer
+        optional: true
+        name: value
+        unit: kWh
+        range:
+          min: 0
+          max: 99999999
+        mapping:
+          - scale: 100
+  - entity: number
+    name: energy_charge
+    category: diagnostic
+    class: energy_storage
+    dps:
+      - id: 17  # energy_charge
+        type: integer
+        optional: true
+        name: value
+        unit: kWh
+        range:
+          min: 1
+          max: 20000000
+        mapping:
+          - scale: 100          
+  - entity: number
+    name: Charge time
+    category: config
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 19  # charge_time
+        type: integer
+        optional: true
+        name: value
+        unit: min
+        range:
+          min: 1
+          max: 1440
+  - entity: sensor
+    name: Charge energy
+    class: energy_storage
+    dps:
+      - id: 25  # charge_energy_once
+        type: integer
+        optional: true
+        name: value
+        unit: kWh
+        range:
+          min: 1
+          max: 20000000
+        mapping:
+          - scale: 1000
+  - entity: switch
+    icon: "mdi:ev-station"
+    dps:
+      - id: 18  # switch
+        type: boolean
+        name: switch
+  - entity: sensor
+    name: Charging time
+    class: duration
+    dps:
+      - id: 101 # charging_time1
+        type: base64
+        name: sensor
+        optional: true
+        unit: s
+        mask: "0000FFFF"
+  - entity: select
+    name: Mode
+    icon: "mdi:cogs"
+    category: config
+    dps:
+      - id: 102 # mode
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: home
+            value: Home
+          - dps_val: mode
+            value: Mode
+          - dps_val: recode
+            value: Recode
+          - dps_val: setting
+            value: Setting
+  - entity: sensor
+    name: Minimum current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 103 # current_limit
+        type: base64
+        optional: true
+        name: sensor
+        unit: A
+        mask: "FFFF0000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Maximum current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 103 # current_limit
+        type: base64
+        optional: true
+        name: sensor
+        unit: A
+        mask: "0000FFFF"
+        mapping:
+          - scale: 10
+  - entity: button
+    name: Reset energy counter
+    class: restart
+    category: config
+    dps:
+      - id: 16  # clear_energy
+        type: boolean
+        optional: true
+        name: button
+  - entity: select
+    name: online_state
+    category: diagnostic
+    dps:
+      - id: 27 # online_state
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: offline
+            value: offline
+          - dps_val: online
+            value: online
+  - entity: switch
+    name: rf_enable
+    category: config
+    dps:
+      - id: 110 # rf_enable
+        type: boolean
+        optional: true
+        name: switch
+  - entity: switch
+    name: pen_enable
+    category: config    
+    dps:
+      - id: 108 # pen_enable
+        type: boolean
+        optional: true        
+        name: switch
+  - entity: binary_sensor
+    class: safety
+    category: diagnostic
+    dps:
+      - id: 106 # safety_notice
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 106 # safety_notice
+        type: bitfield
+        name: fault_code
+      - id: 106 # safety_notice
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: software_safety
+          - dps_val: 1
+            value: case_open
+          - dps_val: 2
+            value: lock_fault
+          - dps_val: 4
+            value: software_change
+  - entity: text
+    name: occp_ip
+    category: config
+    dps:
+      - id: 104 # occp_ip
+        type: string
+        optional: true
+        name: value
+  - entity: text
+    name: occp_port
+    category: config
+    dps:
+      - id: 105 # occp_port
+        type: string
+        optional: true
+        name: value
+  - entity: text
+    name: password
+    category: config
+    dps:
+      - id: 109 # password
+        type: string
+        hidden: true
+        optional: true
+        name: value
+  - entity: text
+    name: car_binding
+    category: config
+    dps:
+      - id: 21  # car_binding
+        type: string
+        optional: true
+        name: value
+  - entity: sensor
+    name: alarm_set_1
+    dps:
+      - id: 11 # alarm_set_1
+        type: base64
+        name: sensor
+        optional: true
+  - entity: sensor
+    name: alarm_set_2
+    dps:
+      - id: 12 # alarm_set_2
+        type: base64
+        name: sensor
+        optional: true

--- a/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/dowell_dchs-k7_32_7kw_ev_charger.yaml
@@ -457,19 +457,19 @@ entities:
         type: boolean
         optional: true
         name: button
-  - entity: select
-    name: online_state
+  - entity: binary_sensor
+    class: connectivity
     category: diagnostic
     dps:
       - id: 27    # online_state
         type: string
         optional: true
-        name: option
+        name: sensor
         mapping:
           - dps_val: offline
-            value: offline
+            value: off
           - dps_val: online
-            value: online
+            value: on
   - entity: switch
     name: rf_enable
     category: config


### PR DESCRIPTION
The configuration is 98% working allows to control this EV Charger from within Home Assistant.
2% remaining corresponds to four DPs that I didn't manage to make them work.

Known issues:

_Log from custom_components.tuya_local.helpers.config:_

```
1. Error adding sensor_charge_energy: sensor_charge_energy is missing a sensor dps
2. Error adding text_occp_ip: tuple indices must be integers or slices, not str
3. Error adding text_occp_port: tuple indices must be integers or slices, not str
4. Error adding text_password: tuple indices must be integers or slices, not str
5. Error adding text_car_binding: tuple indices must be integers or slices, not str
```