### PR TITLE
New device: Korex AX-WF306N kettle

### DIFF
--- a/custom_components/tuya_local/devices/korex_axwf306n_smart_kettle.yaml
+++ b/custom_components/tuya_local/devices/korex_axwf306n_smart_kettle.yaml
@@ -101,7 +101,7 @@ entities:
     dps:
       - id: 105
         type: string
-        name: sensor
+        name: option
         mapping:
           - dps_val: c
             value: celcius


### PR DESCRIPTION
This adds support for Korex AX-WF306N kettle.

https://github.com/make-all/tuya-local/issues/3262
