### PR TITLE
Add support for Quoya QL500 Curtain

### DIFF
--- a/custom_components/tuya_local/devices/quoya_ql500_curtain.yaml
+++ b/custom_components/tuya_local/devices/quoya_ql500_curtain.yaml
@@ -1,0 +1,34 @@
+name: Curtain rail motor
+products:
+  - id: p1fiefpamvaqek4u
+    manufacturer: Quoya
+    model: QL500
+entities:
+  - entity: cover
+    class: curtain
+    dps:
+      - id: 101
+        name: position
+        type: integer
+        range:
+          min: 0
+          max: 100
+      - id: 102
+        name: control
+        type: string
+        mapping:
+          - dps_val: ZZ
+            value: open
+          - dps_val: FZ
+            value: close
+          - dps_val: STOP
+            value: stop
+  - entity: switch
+    name: Reverse
+    category: config
+    icon: "mdi:arrow-u-down-left"
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+        optional: true


### PR DESCRIPTION
Adding support for these smart curtains from Amazon. (https://www.quoyaliving.com/products/smart-electric-curtains-curtain-track-3m).

The config seems to be exactly the same as the Abalon bcm700d but I wasn't sure if you wanted a new device config or to just add it under the Abalon config file. Been running this with no issues for many months.

Also more information here: https://github.com/home-assistant/core/issues/128911