### PR TITLE
Add new device: Zemismart Wifi 2 Phase Energy meter

### DIFF
--- a/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
@@ -130,6 +130,7 @@ entities:
     dps:
       - id: 117
         name: sensor
+        type: integer
         unit: "%"
         class: measurement
   - entity: number

--- a/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
@@ -58,7 +58,7 @@ entities:
         class: measurement
         type: integer
         mapping:
-          - scale: 1         
+          - scale: 1
   - entity: sensor
     name: Phase A Voltage
     class: voltage
@@ -106,7 +106,7 @@ entities:
         class: measurement
         type: integer
         mapping:
-          - scale: 1000         
+          - scale: 1000
   - entity: sensor
     name: Frequency
     class: frequency

--- a/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
@@ -1,11 +1,12 @@
-name: Wifi 2 Phase Energy Meter Max
+name: Energy meter
 products:
   - id: cdw24010001
     manufacturer: Zemismart
-    model: SDM02T-TW
+    model_id: SDM02T-TW
+    model: 2-Phase Energy Meter Max
 entities:
   - entity: sensor
-    name: Total Forward Energy
+    translation_key: energy_consumed
     class: energy
     dps:
       - id: 1
@@ -16,7 +17,7 @@ entities:
         mapping:
           - scale: 100
   - entity: sensor
-    name: Total Reverse Energy
+    translation_key: energy_produced
     class: energy
     dps:
       - id: 9
@@ -27,7 +28,6 @@ entities:
         mapping:
           - scale: 100
   - entity: sensor
-    name: Total Power
     class: power
     dps:
       - id: 29
@@ -35,10 +35,10 @@ entities:
         unit: W
         class: measurement
         type: integer
-        mapping:
-          - scale: 1
   - entity: sensor
-    name: Phase A Power
+    translation_key: power_x
+    translation_placeholders:
+      x: A
     class: power
     dps:
       - id: 105
@@ -46,10 +46,10 @@ entities:
         unit: W
         class: measurement
         type: integer
-        mapping:
-          - scale: 1
   - entity: sensor
-    name: Phase B Power
+    translation_key: power_x
+    translation_placeholders:
+      x: B
     class: power
     dps:
       - id: 114
@@ -57,10 +57,10 @@ entities:
         unit: W
         class: measurement
         type: integer
-        mapping:
-          - scale: 1
   - entity: sensor
-    name: Phase A Voltage
+    translation_key: voltage_x
+    translation_placeholders:
+      x: A
     class: voltage
     category: diagnostic
     dps:
@@ -72,7 +72,9 @@ entities:
         mapping:
           - scale: 10
   - entity: sensor
-    name: Phase B Voltage
+    translation_key: voltage_x
+    translation_placeholders:
+      x: B
     class: voltage
     category: diagnostic
     dps:
@@ -84,7 +86,9 @@ entities:
         mapping:
           - scale: 10
   - entity: sensor
-    name: Phase A Current
+    translation_key: current_x
+    translation_placeholders:
+      x: A
     class: current
     category: diagnostic
     dps:
@@ -96,7 +100,9 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Phase B Current
+    translation_key: current_x
+    translation_placeholders:
+      x: B
     class: current
     category: diagnostic
     dps:
@@ -108,7 +114,6 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Frequency
     class: frequency
     category: diagnostic
     dps:
@@ -120,17 +125,13 @@ entities:
         mapping:
           - scale: 100
   - entity: sensor
-    name: Overall Power Factor
     class: power_factor
     category: diagnostic
     dps:
       - id: 117
         name: sensor
-        unit: '%'
+        unit: "%"
         class: measurement
-        type: integer
-        mapping:
-          - scale: 1
   - entity: number
     name: Reporting interval
     category: config

--- a/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/zemismart_sdm02ttw_energymeter.yaml
@@ -1,0 +1,146 @@
+name: Wifi 2 Phase Energy Meter Max
+products:
+  - id: cdw24010001
+    manufacturer: Zemismart
+    model: SDM02T-TW
+entities:
+  - entity: sensor
+    name: Total Forward Energy
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Total Reverse Energy
+    class: energy
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Total Power
+    class: power
+    dps:
+      - id: 29
+        name: sensor
+        unit: W
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 1
+  - entity: sensor
+    name: Phase A Power
+    class: power
+    dps:
+      - id: 105
+        name: sensor
+        unit: W
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 1
+  - entity: sensor
+    name: Phase B Power
+    class: power
+    dps:
+      - id: 114
+        name: sensor
+        unit: W
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 1         
+  - entity: sensor
+    name: Phase A Voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 103
+        name: sensor
+        unit: V
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Phase B Voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 112
+        name: sensor
+        unit: V
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Phase A Current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 104
+        name: sensor
+        unit: A
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Phase B Current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 113
+        name: sensor
+        unit: A
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 1000         
+  - entity: sensor
+    name: Frequency
+    class: frequency
+    category: diagnostic
+    dps:
+      - id: 32
+        name: sensor
+        unit: Hz
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Overall Power Factor
+    class: power_factor
+    category: diagnostic
+    dps:
+      - id: 117
+        name: sensor
+        unit: '%'
+        class: measurement
+        type: integer
+        mapping:
+          - scale: 1
+  - entity: number
+    name: Reporting interval
+    category: config
+    class: duration
+    icon: "mdi:timer-cog"
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 5
+          max: 3600


### PR DESCRIPTION
- Adds Zemismart Wifi 2 Phase Energy meter Max 120A with 2 clamps works with Tuya
- Product model: SMD02T-TZ