### PR TITLE
New device: Smart Kettle Götze & Jensen KT975K

### DIFF
--- a/custom_components/tuya_local/devices/smart_kettle_gotze_jensen_kt975k.yaml
+++ b/custom_components/tuya_local/devices/smart_kettle_gotze_jensen_kt975k.yaml
@@ -1,0 +1,169 @@
+name: Smart Kettle Götze & Jensen KT975K
+products:
+  - id: m3piuietzgcgyrfk
+    manufacturer: Götze & Jensen
+    model: KT975K
+    name: Kettle KT975K
+entities:
+  - entity: water_heater
+    translation_key: kettle
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: electric
+      - id: 2
+        type: integer
+        name: current_temperature
+        unit: °C
+        range:
+          min: 0
+          max: 100
+      - id: 4
+        type: integer
+        name: temperature
+        range:
+          min: 0
+          max: 100
+        unit: °C
+  - entity: select
+    translation_key: kettle_mode
+    dps:
+      - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: diy
+            value: custom
+          - dps_val: boiled_water
+            value: boil
+          - dps_val: dechlorination
+            value: dechlorinate
+          - dps_val: black_tea
+            value: black_tea
+          - dps_val: coffee
+            value: coffee
+          - dps_val: green_tea
+            value: green_tea
+          - dps_val: honey_water
+            value: honey_water
+          - dps_val: milk_powder
+            value: infant_formula
+  - entity: number
+    name: Boil temperature
+    category: config
+    class: temperature
+    icon: "mdi:coolant-temperature"
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: °C
+        range:
+          min: 0
+          max: 100
+  - entity: number
+    name: Keep warm temperature
+    category: config
+    class: temperature
+    icon: "mdi:coolant-temperature"
+    dps:
+      - id: 15
+        type: integer
+        name: value
+        unit: °C
+        range:
+          min: 0
+          max: 100
+  - entity: number
+    name: Keep warm time
+    category: config
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 7
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 120
+  - entity: switch
+    name: Keep warm
+    icon: "mdi:kettle-outline"
+    dps:
+      - id: 14
+        type: boolean
+        name: switch
+  - entity: sensor
+    translation_key: status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 8
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: standby
+            value: standby
+          - dps_val: heating
+            value: heating
+          - dps_val: cooling
+            value: cooling
+          - dps_val: warm
+            value: keeping_warm
+  - entity: sensor
+    name: Current temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: °C
+        class: measurement
+        range:
+          min: 0
+          max: 100
+  - entity: sensor
+    name: Keep warm remaining time
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 17
+        type: integer
+        name: sensor
+        unit: min
+        range:
+          min: 0
+          max: 720
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10
+        type: bitfield
+        name: fault_code
+      - id: 10
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: dry_heating
+          - dps_val: 2
+            value: lack_water
+          - dps_val: 3
+            value: sensor_fault


### PR DESCRIPTION
Add new device Smart Kettle Götze & Jensen KT975K
https://www.mediaexpert.pl/agd-male/do-kuchni/czajniki/czajniki-gotze-jensen-kt975k-smart-1-5l-3000w-czern