### PR TITLE
Clarify fault code and separate mode and meal_plan from Manual feed f…

### DIFF
--- a/custom_components/tuya_local/devices/cleverio_pf100_petfeeder.yaml
+++ b/custom_components/tuya_local/devices/cleverio_pf100_petfeeder.yaml
@@ -14,13 +14,29 @@ entities:
         range:
           min: 1
           max: 20
-      - id: 1
-        type: string
-        optional: true
-        name: meal_plan
+  - entity: sensor
+    name: Mode
+    class: enum
+    category: diagnostic
+    dps:
       - id: 103
         type: string
-        name: mode
+        name: sensor
+        mapping:
+          - dps_val: 1
+            value: real_time_mode
+          - dps_val: 2
+            value: eco_mode
+
+  - entity: text
+    name: Meal plan
+    category: config
+    hidden: true
+    dps:
+      - id: 1
+        type: base64
+        name: value
+
   - entity: button
     translation_key: factory_reset
     category: config
@@ -48,20 +64,30 @@ entities:
       - id: 12
         type: boolean
         name: sensor
-  - entity: binary_sensor
-    class: problem
+  - entity: sensor
+    name: Problem
     category: diagnostic
     dps:
       - id: 14
         type: bitfield
         name: sensor
-        mapping:
-          - dps_val: 0
-            value: false
-          - value: true
       - id: 14
         type: bitfield
-        name: fault_code
+        optional: true
+        name: fault_name
+        mapping:
+          - dps_val: 0
+            value: 'OK'
+          - dps_val: 1
+            value: food_shortages
+          - dps_val: 2
+            value: food_jam
+          - dps_val: 4
+            value: battery_low
+          - dps_val: 4
+            value: ac_power_off
+
+
   - entity: sensor
     name: Last feed
     icon: "mdi:food-drumstick"


### PR DESCRIPTION
The following is changed:
* Meal plan as separate configuration and be able to modify it.
* Mode to tell if the device use eco or real time changes.
* Problem specify what problem it is and extra attribute for the name of error

![image](https://github.com/user-attachments/assets/61678cd9-8321-4c4a-bf7e-855887cde009)

![image](https://github.com/user-attachments/assets/2e392d30-a27e-407d-8dd5-bb4156e28f09)

