### PR TITLE
fix: return None for invalid temperature unit

### DIFF
--- a/custom_components/tuya_local/water_heater.py
+++ b/custom_components/tuya_local/water_heater.py
@@ -38,6 +38,7 @@ def validate_temp_unit(unit):
         return UnitOfTemperature(translated_unit)
     except ValueError:
         _LOGGER.warning("%s is not a valid temperature unit", unit)
+        return None 
 
 
 class TuyaLocalWaterHeater(TuyaLocalEntity, WaterHeaterEntity):


### PR DESCRIPTION
Explicitly return None for invalid temperature units, ensuring callers can detect invalid values