### PR TITLE
vevor_3_7kw_evcharger: Fix typo in DP value string mapping

### DIFF
--- a/custom_components/tuya_local/devices/vevor_3_7kw_evcharger.yaml
+++ b/custom_components/tuya_local/devices/vevor_3_7kw_evcharger.yaml
@@ -148,7 +148,7 @@ entities:
         mapping:
           - dps_val: controlpi_12v
             value: Standby
-          - dps_val: controlpi_12v_pwn
+          - dps_val: controlpi_12v_pwm
             value: Communication initialising
           - dps_val: controlpi_9v
             value: Vehicle detected


### PR DESCRIPTION
vevor_3_7kw_evcharger.yaml has "controlpi_12v_pwn" instead of "controlpi_12v_pwm" as a possible enumeration value for DP 13.

The specification and the output from my actual device is "pwm", so fix that.