### PR TITLE
Add support for Howeall Register Booster Fan

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -264,6 +264,7 @@
 - Hiper T3 bladeless fan
 - Hoenofly Smart Amari ceiling fan with light
 - Homebase 12" oscillating fan
+- Howeall Register Booster Fan
 - Hunter Pacific 9 speed ceiling fan with light
 - HYD WeAir Plus bladeless fan with heating function
 - Immax Neo Lite Vento ceiling fan with light
@@ -470,7 +471,7 @@
 - Unknown brand dual channel smart meter
 - V-WIFI-DL01-ES energy consumption single clamp meter
 - V-WIFI-DL02-ES energy consumption dual clamp meter
-- WDYK 2P63A, 3P 400V, 4P100A  energy meter circuit breakers
+- WDYK 2P63A, 3P 400V, 4P100A energy meter circuit breakers
 - Xoca DAC2121C BI energy meter
 - Yagusmart 3PN 63A 3-phase multi-tariff energy meter
 - Zemismart SDM01-TW0-12-ZM 3-phase bidirectional energy meter

--- a/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
+++ b/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
@@ -4,41 +4,36 @@ products:
     manufacturer: Howeall
     name: Register Booster Fan
 entities:
-  # Primary Fan Entity
-  - entity: switch
-    name: "Power"
+  - entity: fan
+    translation_only_key: fan_with_presets
     dps:
-      - id: 1  # DP for Power ON/OFF
+      - id: 1
         type: boolean
         name: switch
-  - entity: select  # separate entity for speed control
-    name: "Speed"
-    icon: mdi:fan
-    dps:
       - id: 12
         type: string
-        name: option
+        name: speed
         mapping:
           - dps_val: "1"
-            value: "1"
+            value: 10
           - dps_val: "2"
-            value: "2"
+            value: 20
           - dps_val: "3"
-            value: "3"
+            value: 30
           - dps_val: "4"
-            value: "4"
+            value: 40
           - dps_val: "5"
-            value: "5"
+            value: 50
           - dps_val: "6"
-            value: "6"
+            value: 60
           - dps_val: "7"
-            value: "7"
+            value: 70
           - dps_val: "8"
-            value: "8"
+            value: 80
           - dps_val: "9"
-            value: "9"
+            value: 90
           - dps_val: "10"
-            value: "10"
+            value: 100
   # Cooling temp trigger (temp below this will trigger the fan)
   - entity: number
     name: "Cooling Trigger"

--- a/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
+++ b/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
@@ -1,11 +1,70 @@
-name: register_booster_fan
+name: Register booster fan
 products:
   - id: zbhikxau56accfsp
-    manufacturer: Howeall
-    name: Register Booster Fan
+    manufacturer: Howeall / Sanycasa
 entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: operating_mode
+            conditions:
+              - dps_val: FAN
+                value: fan_only
+              - dps_val: COOL
+                value: cool
+              - dps_val: HEAT
+                value: heat
+              - dps_val: SLEEP
+                value: fan_only
+                hidden: true
+      - id: 2
+        type: string
+        name: operating_mode
+        hidden: true
+      - id: 9
+        type: integer
+        name: current_temperature
+      - id: 45
+        type: integer
+        name: temperature
+        unit: F
+        range:
+          min: 60
+          max: 90
+        mapping:
+          - constraint: operating_mode
+            conditions:
+              - dps_val: HEAT
+                value_redirect: heating_temp
+              - dps_val: FAN
+                invalid: true
+              - dps_val: SLEEP
+                invalid: true
+      - id: 106
+        type: integer
+        name: heating_temp
+        range:
+          min: 60
+          max: 90
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: FAN
+            value: Manual
+          - dps_val: HEAT
+            value: Heating
+          - dps_val: COOL
+            value: Cooling
+          - dps_val: SLEEP
+            value: sleep
   - entity: fan
-    translation_only_key: fan_with_presets
     dps:
       - id: 1
         type: boolean
@@ -34,105 +93,33 @@ entities:
             value: 90
           - dps_val: "10"
             value: 100
-  # Cooling temp trigger (temp below this will trigger the fan)
-  - entity: number
-    name: "Cooling Trigger"
-    category: config
-    icon: mdi:thermometer-low
-    dps:
-      - id: 45
-        type: integer
-        name: value
-        range:
-          min: 60
-          max: 90
-
-  # Heating Temp Trigger (temp above this will trigger the fan)
-  - entity: number
-    name: "Heating Temp Trigger"
-    category: config
-    icon: mdi:thermometer
-    dps:
-      - id: 106
-        type: integer
-        name: value
-        range:
-          min: 60
-          max: 90
-
-  - entity: select
-    name: "Operating Mode"
-    icon: mdi:hvac
-    dps:
-      - id: 2
+      - id: 101
         type: string
-        name: option
-        mapping:
-          - dps_val: "FAN"
-            value: "Fan Only"
-          - dps_val: "COOL"
-            value: "Cooling"
-          - dps_val: "HEAT"
-            value: "Heating"
-
-
-  # Secondary Entities (Sensors and Switches for other DPs)
-  - entity: sensor
-    name: "Current Temperature"
-    category: diagnostic
-    dps:
-      - id: 9
-        type: integer
-        name: sensor  # The value of this DP will be the sensor's state
-
-  - entity: switch
-    name: "Child Lock"
+        name: cool_max
+      - id: 103
+        type: string
+        name: cool_min
+      - id: 104
+        type: string
+        name: heat_max
+      - id: 105
+        type: string
+        name: heat_min
+  - entity: lock
+    translation_key: child_lock
     category: config
     dps:
       - id: 14
         type: boolean
-        name: switch  # This DP's boolean state IS the switch state
-
-  - entity: sensor
-    name: "Status DP101"
-    category: diagnostic
-    dps:
-      - id: 101
-        type: string
-        name: sensor  # Generic name, the DP value will be the state
-
-  - entity: select
-    name: "Light Control"
-    icon: mdi:lightbulb
+        name: lock
+  - entity: light
+    translation_key: display
     dps:
       - id: 102
         type: string
-        name: option
+        name: switch
         mapping:
           - dps_val: "on"
-            value: "On"
+            value: true
           - dps_val: "off"
-            value: "Off"
-  - entity: sensor
-    name: "Status DP103"
-    category: diagnostic
-    dps:
-      - id: 103
-        type: string
-        name: sensor
-
-  - entity: sensor
-    name: "Status DP104"
-    category: diagnostic
-    dps:
-      - id: 104
-        type: string
-        name: sensor
-
-  - entity: sensor
-    name: "Status DP105"
-    category: diagnostic
-    dps:
-      - id: 105
-        type: string
-        name: sensor
+            value: false

--- a/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
+++ b/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
@@ -5,7 +5,7 @@ products:
     name: Register Booster Fan
 entities:
   # Primary Fan Entity
-  - entity: fan
+  - entity: switch
     name: "Power"
     dps:
       - id: 1  # DP for Power ON/OFF
@@ -51,8 +51,6 @@ entities:
         range:
           min: 60
           max: 90
-          step: 1
-        unit_of_measurement: "°F"
 
   # Heating Temp Trigger (temp above this will trigger the fan)
   - entity: number
@@ -66,8 +64,6 @@ entities:
         range:
           min: 60
           max: 90
-          step: 1
-        unit_of_measurement: "°F"
 
   - entity: select
     name: "Operating Mode"
@@ -93,8 +89,6 @@ entities:
       - id: 9
         type: integer
         name: sensor  # The value of this DP will be the sensor's state
-        unit_of_measurement: "°F"
-        device_class: temperature
 
   - entity: switch
     name: "Child Lock"

--- a/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
+++ b/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
@@ -4,153 +4,146 @@ products:
     manufacturer: Howeall
     name: Register Booster Fan
 entities:
-      # Primary Fan Entity
-      - entity: fan
-        # The 'name' for the fan entity itself. If omitted, HA will generate one.
-        # You can also use 'translation_key' if the integration supports it for standard fan types.
-        name: "Power"
-        dps:
-          - id: 1  # DP for Power ON/OFF
-            type: boolean
-            name: switch # This 'name' is how the fan platform identifies this DP's function
-      # Fan Speed as a separate select entity
-      - entity: select
-        name: "Fan Speed"
-          # category: control
-        icon: mdi:fan
-        dps:
-          - id: 12
-            type: string
-            name: option
-            mapping:
-              - dps_val: "1"
-                value: "1"
-              - dps_val: "2"
-                value: "2"
-              - dps_val: "3"
-                value: "3"
-              - dps_val: "4"
-                value: "4"
-              - dps_val: "5"
-                value: "5"
-              - dps_val: "6"
-                value: "6"
-              - dps_val: "7"
-                value: "7"
-              - dps_val: "8"
-                value: "8"
-              - dps_val: "9"
-                value: "9"
-              - dps_val: "10"
-                value: "10"
-      # Cooling temp trigger (temp below this will trigger the fan)
-      - entity: number
-        name: "Cooling Trigger"
-        category: config
-        icon: mdi:thermometer-low
-        dps:
-          - id: 45
-            type: integer
-            name: value
-            range:
-              min: 60
-              max: 90
-              step: 1
-            unit_of_measurement: "°F"
+  # Primary Fan Entity
+  - entity: fan
+    name: "Power"
+    dps:
+      - id: 1  # DP for Power ON/OFF
+        type: boolean
+        name: switch
+  - entity: select  # separate entity for speed control
+    name: "Speed"
+    icon: mdi:fan
+    dps:
+      - id: 12
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+          - dps_val: "6"
+            value: "6"
+          - dps_val: "7"
+            value: "7"
+          - dps_val: "8"
+            value: "8"
+          - dps_val: "9"
+            value: "9"
+          - dps_val: "10"
+            value: "10"
+  # Cooling temp trigger (temp below this will trigger the fan)
+  - entity: number
+    name: "Cooling Trigger"
+    category: config
+    icon: mdi:thermometer-low
+    dps:
+      - id: 45
+        type: integer
+        name: value
+        range:
+          min: 60
+          max: 90
+          step: 1
+        unit_of_measurement: "°F"
 
-      # Heating Temp Trigger (temp above this will trigger the fan)
-      - entity: number
-        name: "Heating Temp Trigger"
-        category: config
-        icon: mdi:thermometer
-        dps:
-          - id: 106
-            type: integer
-            name: value
-            range:
-              min: 60
-              max: 90
-              step: 1
-            unit_of_measurement: "°F"
+  # Heating Temp Trigger (temp above this will trigger the fan)
+  - entity: number
+    name: "Heating Temp Trigger"
+    category: config
+    icon: mdi:thermometer
+    dps:
+      - id: 106
+        type: integer
+        name: value
+        range:
+          min: 60
+          max: 90
+          step: 1
+        unit_of_measurement: "°F"
 
-      - entity: select
-        name: "Operating Mode"
-        icon: mdi:hvac
-        dps:
-          - id: 2
-            type: string
-            name: option
-            mapping:
-              - dps_val: "FAN"
-                value: "Fan Only"
-              - dps_val: "COOL"
-                value: "Cooling"
-              - dps_val: "HEAT"
-                value: "Heating"
+  - entity: select
+    name: "Operating Mode"
+    icon: mdi:hvac
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: "FAN"
+            value: "Fan Only"
+          - dps_val: "COOL"
+            value: "Cooling"
+          - dps_val: "HEAT"
+            value: "Heating"
 
 
-      # Secondary Entities (Sensors and Switches for other DPs)
-      - entity: sensor
-        name: "Current Temperature"
-        # category: diagnostic # Optional: helps HA classify the entity
-        dps:
-          - id: 9
-            type: integer
-            name: sensor # The value of this DP will be the sensor's state
-            unit_of_measurement: "°F"
-            device_class: "temperature"
+  # Secondary Entities (Sensors and Switches for other DPs)
+  - entity: sensor
+    name: "Current Temperature"
+    category: diagnostic
+    dps:
+      - id: 9
+        type: integer
+        name: sensor  # The value of this DP will be the sensor's state
+        unit_of_measurement: "°F"
+        device_class: temperature
 
-      - entity: switch
-        name: "Child Lock"
-        category: config # Optional
-        dps:
-          - id: 14
-            type: boolean
-            name: switch # This DP's boolean state IS the switch state
+  - entity: switch
+    name: "Child Lock"
+    category: config
+    dps:
+      - id: 14
+        type: boolean
+        name: switch  # This DP's boolean state IS the switch state
 
+  - entity: sensor
+    name: "Status DP101"
+    category: diagnostic
+    dps:
+      - id: 101
+        type: string
+        name: sensor  # Generic name, the DP value will be the state
 
-      - entity: sensor
-        name: "Status DP101"
-        # category: diagnostic
-        dps:
-          - id: 101
-            type: string
-            name: sensor # Generic name, the DP value will be the state
+  - entity: select
+    name: "Light Control"
+    icon: mdi:lightbulb
+    dps:
+      - id: 102
+        type: string
+        name: option
+        mapping:
+          - dps_val: "on"
+            value: "On"
+          - dps_val: "off"
+            value: "Off"
+  - entity: sensor
+    name: "Status DP103"
+    category: diagnostic
+    dps:
+      - id: 103
+        type: string
+        name: sensor
 
-      - entity: select
-        name: "Light Control"
-          # category: control
-        icon: mdi:lightbulb
-        dps:
-          - id: 102
-            type: string
-            name: option
-            mapping:
-              - dps_val: "on"
-                value: "On"
-              - dps_val: "off"
-                value: "Off"
-      - entity: sensor
-        name: "Status DP103"
-        # category: diagnostic
-        dps:
-          - id: 103
-            type: string
-            name: sensor
+  - entity: sensor
+    name: "Status DP104"
+    category: diagnostic
+    dps:
+      - id: 104
+        type: string
+        name: sensor
 
-      - entity: sensor
-        name: "Status DP104"
-        # category: diagnostic
-        dps:
-          - id: 104
-            type: string
-            name: sensor
-
-      - entity: sensor
-        name: "Status DP105"
-        # category: diagnostic
-        dps:
-          - id: 105
-            type: string
-            name: sensor
-
+  - entity: sensor
+    name: "Status DP105"
+    category: diagnostic
+    dps:
+      - id: 105
+        type: string
+        name: sensor

--- a/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
+++ b/custom_components/tuya_local/devices/howeall_register_booster_fan.yaml
@@ -1,0 +1,156 @@
+name: register_booster_fan
+products:
+  - id: zbhikxau56accfsp
+    manufacturer: Howeall
+    name: Register Booster Fan
+entities:
+      # Primary Fan Entity
+      - entity: fan
+        # The 'name' for the fan entity itself. If omitted, HA will generate one.
+        # You can also use 'translation_key' if the integration supports it for standard fan types.
+        name: "Power"
+        dps:
+          - id: 1  # DP for Power ON/OFF
+            type: boolean
+            name: switch # This 'name' is how the fan platform identifies this DP's function
+      # Fan Speed as a separate select entity
+      - entity: select
+        name: "Fan Speed"
+          # category: control
+        icon: mdi:fan
+        dps:
+          - id: 12
+            type: string
+            name: option
+            mapping:
+              - dps_val: "1"
+                value: "1"
+              - dps_val: "2"
+                value: "2"
+              - dps_val: "3"
+                value: "3"
+              - dps_val: "4"
+                value: "4"
+              - dps_val: "5"
+                value: "5"
+              - dps_val: "6"
+                value: "6"
+              - dps_val: "7"
+                value: "7"
+              - dps_val: "8"
+                value: "8"
+              - dps_val: "9"
+                value: "9"
+              - dps_val: "10"
+                value: "10"
+      # Cooling temp trigger (temp below this will trigger the fan)
+      - entity: number
+        name: "Cooling Trigger"
+        category: config
+        icon: mdi:thermometer-low
+        dps:
+          - id: 45
+            type: integer
+            name: value
+            range:
+              min: 60
+              max: 90
+              step: 1
+            unit_of_measurement: "°F"
+
+      # Heating Temp Trigger (temp above this will trigger the fan)
+      - entity: number
+        name: "Heating Temp Trigger"
+        category: config
+        icon: mdi:thermometer
+        dps:
+          - id: 106
+            type: integer
+            name: value
+            range:
+              min: 60
+              max: 90
+              step: 1
+            unit_of_measurement: "°F"
+
+      - entity: select
+        name: "Operating Mode"
+        icon: mdi:hvac
+        dps:
+          - id: 2
+            type: string
+            name: option
+            mapping:
+              - dps_val: "FAN"
+                value: "Fan Only"
+              - dps_val: "COOL"
+                value: "Cooling"
+              - dps_val: "HEAT"
+                value: "Heating"
+
+
+      # Secondary Entities (Sensors and Switches for other DPs)
+      - entity: sensor
+        name: "Current Temperature"
+        # category: diagnostic # Optional: helps HA classify the entity
+        dps:
+          - id: 9
+            type: integer
+            name: sensor # The value of this DP will be the sensor's state
+            unit_of_measurement: "°F"
+            device_class: "temperature"
+
+      - entity: switch
+        name: "Child Lock"
+        category: config # Optional
+        dps:
+          - id: 14
+            type: boolean
+            name: switch # This DP's boolean state IS the switch state
+
+
+      - entity: sensor
+        name: "Status DP101"
+        # category: diagnostic
+        dps:
+          - id: 101
+            type: string
+            name: sensor # Generic name, the DP value will be the state
+
+      - entity: select
+        name: "Light Control"
+          # category: control
+        icon: mdi:lightbulb
+        dps:
+          - id: 102
+            type: string
+            name: option
+            mapping:
+              - dps_val: "on"
+                value: "On"
+              - dps_val: "off"
+                value: "Off"
+      - entity: sensor
+        name: "Status DP103"
+        # category: diagnostic
+        dps:
+          - id: 103
+            type: string
+            name: sensor
+
+      - entity: sensor
+        name: "Status DP104"
+        # category: diagnostic
+        dps:
+          - id: 104
+            type: string
+            name: sensor
+
+      - entity: sensor
+        name: "Status DP105"
+        # category: diagnostic
+        dps:
+          - id: 105
+            type: string
+            name: sensor
+


### PR DESCRIPTION

**Device:** Howeall Register Booster Fan  
**Product ID:** zbhikxau56accfsp

**Features supported:**
- Fan power control (DP 1)
- Fan speed 1-10 (DP 12)  
- Operating modes: Fan/Cool/Heat (DP 2)
- Temperature triggers for cooling/heating (DP 45, 106)
- Current temperature sensor (DP 9)
- Child lock (DP 14)
- Light control (DP 102)
- Various status sensors (DP 101, 103-105)

**Changes:**
- Added device configuration file: `howeall_register_booster_fan.yaml`
- Updated `DEVICES.md` to include the new device in the Fans section

**Testing:** 
tested on the 4x10" and 4x12'" versions of the register booster fans bought from Amazon. 
https://a.co/d/50yyX08. 
Runs on my home assistant instance at home with automation that syncs the fan operation with the thermostat kicking in for both heating and cooling