### PR TITLE
feat: restore text on restart and add property to ignore None values

### DIFF
--- a/custom_components/tuya_local/devices/cleverio_pf100_petfeeder.yaml
+++ b/custom_components/tuya_local/devices/cleverio_pf100_petfeeder.yaml
@@ -34,6 +34,7 @@ entities:
       - id: 1
         type: base64
         name: value
+        ignore_none: true
   - entity: button
     translation_key: factory_reset
     category: config
@@ -80,7 +81,7 @@ entities:
         name: description
         mapping:
           - dps_val: 0
-            value: 'OK'
+            value: "OK"
           - dps_val: 1
             value: food_shortages
           - dps_val: 2

--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -437,6 +437,10 @@ class TuyaDpsConfig:
         return self._config.get("sensitive", False)
 
     @property
+    def ignore_none(self):
+        return self._config.get("ignore_none", False)
+
+    @property
     def format(self):
         fmt = self._config.get("format")
         if fmt:

--- a/custom_components/tuya_local/text.py
+++ b/custom_components/tuya_local/text.py
@@ -4,7 +4,7 @@ Setup for different kinds of Tuya text entities
 
 import logging
 
-from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.components.text import TextMode
 from homeassistant.components.text.const import (
     ATTR_MAX,
     ATTR_MIN,

--- a/custom_components/tuya_local/text.py
+++ b/custom_components/tuya_local/text.py
@@ -4,7 +4,7 @@ Setup for different kinds of Tuya text entities
 
 import logging
 
-from homeassistant.components.text import TextMode
+from homeassistant.components.text import RestoreText, TextMode
 from homeassistant.components.text.const import (
     ATTR_MAX,
     ATTR_MIN,
@@ -16,7 +16,6 @@ from .device import TuyaLocalDevice
 from .entity import TuyaLocalEntity
 from .helpers.config import async_tuya_setup_platform
 from .helpers.device_config import TuyaEntityConfig
-from homeassistant.components.text import RestoreText
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -120,6 +120,7 @@ DP_SCHEMA = vol.Schema(
         vol.Optional("mask"): str,
         vol.Optional("endianness"): vol.In(["little"]),
         vol.Optional("mask_signed"): True,
+        vol.Optional("ignore_none"): True,
     }
 )
 ENTITY_SCHEMA = vol.Schema(


### PR DESCRIPTION
This change introduces a mechanism to retain the meal_plan value after a restart. Since meal_plan only updates when explicitly modified, it's reasonable to exclude it from automatic resets. This avoids the need to redefine the value after every reload, restart, or temporary loss of access to the device.