### PR TITLE
Device Support - Herschel XLS T-PL Plugin Wifi Thermostat

### DIFF
--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -132,20 +132,20 @@ entities:
         range:
           min: 0
           max: 99
-  - entity: select
+  - entity: switch
     name: Open window detection
     icon: "mdi:window-open"
     category: config
     dps:
       - id: 103
-        name: option
         type: string
+        name: switch
         optional: true
         mapping:
           - dps_val: continue
-            value: "On"
+            value: true
           - dps_val: close
-            value: "Off"
+            value: false
   - entity: sensor
     name: Up time
     class: duration

--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -1,6 +1,6 @@
 name: IR Heater
 products:
-  - id: cl2wgyhohpjjjuzb
+  - id: eb7636b53a97009d63e1ur
     manufacturer: Herschel
     model: Herschel XLS T-PL Plugin Wifi Thermostat 
 entities:

--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -1,0 +1,159 @@
+name: IR Heater
+products:
+  - id: cl2wgyhohpjjjuzb
+    manufacturer: Herschel
+    model: Herschel XLS T-PL Plugin Wifi Thermostat 
+entities:
+  - entity: climate
+    translation_only_key: thermostat
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            value: "heat"
+            icon: "mdi:radiator"
+          - dps_val: false
+            value: "off"
+            icon: "mdi:radiator-disabled"
+      - id: 2
+        name: temperature
+        type: integer
+        mapping:
+          - scale: 10
+            step: 10
+        range:
+          min: 0
+          max: 370
+        unit: "C"
+      - id: 3
+        name: current_temperature
+        type: integer
+        mapping:
+          - scale: 10
+            step: 10
+      - id: 4
+        type: string
+        mapping:
+          - dps_val: manual
+            value: manual
+          - dps_val: holiday
+            value: away
+          - dps_val: auto
+            value: program
+        name: preset_mode
+      - id: 109
+        name: hvac_action
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: idle
+          - dps_val: true
+            value: heating
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: cancel
+          - dps_val: "1"
+            value: "1h"
+          - dps_val: "2"
+            value: "2h"
+          - dps_val: "3"
+            value: "3h"
+          - dps_val: "4"
+            value: "4h"
+          - dps_val: "5"
+            value: "5h"
+          - dps_val: "6"
+            value: "6h"
+          - dps_val: "7"
+            value: "7h"
+          - dps_val: "8"
+            value: "8h"
+          - dps_val: "9"
+            value: "9h"
+          - dps_val: "10"
+            value: "10h"
+          - dps_val: "11"
+            value: "11h"
+          - dps_val: "12"
+            value: "12h"
+          - dps_val: "13"
+            value: "13h"
+          - dps_val: "14"
+            value: "14h"
+          - dps_val: "15"
+            value: "15h"
+          - dps_val: "16"
+            value: "16h"
+          - dps_val: "17"
+            value: "17h"
+          - dps_val: "18"
+            value: "18h"
+          - dps_val: "19"
+            value: "19h"
+          - dps_val: "20"
+            value: "20h"
+          - dps_val: "21"
+            value: "21h"
+          - dps_val: "22"
+            value: "22h"
+          - dps_val: "23"
+            value: "23h"
+          - dps_val: "24"
+            value: "24h"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 11
+        type: integer
+        name: sensor
+        unit: min
+        optional: true
+  - entity: number
+    name: Holiday
+    icon: "mdi:island"
+    category: config
+    dps:
+      - id: 101
+        name: value
+        type: integer
+        unit: d
+        optional: true
+        range:
+          min: 0
+          max: 99
+  - entity: select
+    name: Open window detection
+    icon: "mdi:window-open"
+    category: config
+    dps:
+      - id: 103
+        name: option
+        type: string
+        optional: true
+        mapping:
+          - dps_val: continue
+            value: "On"
+          - dps_val: close
+            value: "Off"
+  - entity: sensor
+    name: Up time
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: min
+        optional: true

--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -2,7 +2,7 @@ name: IR Heater
 products:
   - id: 7o1bzm3omsqau6w6
     manufacturer: Herschel
-    model: Herschel XLS T-PL Plugin Wifi Thermostat 
+    model: "Herschel XLS T-PL Plugin Wifi Thermostat" 
 entities:
   - entity: climate
     translation_only_key: thermostat

--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -1,6 +1,6 @@
 name: IR Heater
 products:
-  - id: eb7636b53a97009d63e1ur
+  - id: 7o1bzm3omsqau6w6
     manufacturer: Herschel
     model: Herschel XLS T-PL Plugin Wifi Thermostat 
 entities:

--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -1,9 +1,8 @@
-name: IR Heater
+name: Thermostat
 products:
   - id: 7o1bzm3omsqau6w6
     manufacturer: Herschel
     model: XLS-T-PL
-    name: Herschel plugin Wifi thermostat
 entities:
   - entity: climate
     translation_only_key: thermostat
@@ -33,7 +32,6 @@ entities:
         type: integer
         mapping:
           - scale: 10
-            step: 10
       - id: 4
         type: string
         mapping:

--- a/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
+++ b/custom_components/tuya_local/devices/herschel_xls_tpl_thermostat.yaml
@@ -2,7 +2,8 @@ name: IR Heater
 products:
   - id: 7o1bzm3omsqau6w6
     manufacturer: Herschel
-    model: "Herschel XLS T-PL Plugin Wifi Thermostat" 
+    model: XLS-T-PL
+    name: Herschel plugin Wifi thermostat
 entities:
   - entity: climate
     translation_only_key: thermostat


### PR DESCRIPTION
Added support for a new device.

Manufacturer: Herschel
Device: XLS T-PL Plugin Wifi Thermostat

Device Webpage: https://www.herschel-infrared.com.au/product/t-pl-plugin-thermostat/
Device Manual: https://drive.google.com/file/d/1x3qmKyOxJx0ugtU__A7yZegjx-SRQLGt/view

Includes HVAC_STATE monitoring on ID109.