### PR TITLE
Support for MW201W Level Sensor

### DIFF
--- a/custom_components/tuya_local/devices/ME201W_level_sensor.yaml
+++ b/custom_components/tuya_local/devices/ME201W_level_sensor.yaml
@@ -1,0 +1,120 @@
+name: ME201W Level sensor
+products:
+  - id: 4u9z7qg3je42rsw8
+    model: ME201W
+entities:
+  - entity: sensor
+    translation_key: status
+    class: enum
+    dps:
+      - id: 1
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: normal
+            value: normal
+          - dps_val: lower_alarm
+            value: low
+          - dps_val: upper_alarm
+            value: high
+  - entity: sensor
+    name: Depth
+    class: distance
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: m
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Battery voltage
+    class: voltage
+    category: diagnostic
+    hidden: unavailable
+    dps:
+      - id: 5
+        type: integer
+        optional: true
+        name: sensor
+        unit: V
+        class: measurement
+        mapping:
+          - scale: 10
+      - id: 5
+        type: integer
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
+  - entity: number
+    name: High level
+    category: config
+    icon: "mdi:arrow-collapse-up"
+    dps:
+      - id: 7
+        type: integer
+        optional: true
+        name: value
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: number
+    name: Low level
+    category: config
+    icon: "mdi:arrow-collapse-down"
+    dps:
+      - id: 8
+        type: integer
+        optional: true
+        name: value
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: number
+    name: Installation height
+    category: config
+    class: distance
+    icon: "mdi:human-male-height"
+    dps:
+      - id: 19
+        type: integer
+        optional: true
+        name: value
+        unit: m
+        range:
+          min: 10
+          max: 500
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Maximum depth
+    category: config
+    class: distance
+    icon: "mdi:wave-arrow-up"
+    dps:
+      - id: 21
+        type: integer
+        optional: true
+        name: value
+        unit: m
+        range:
+          min: 10
+          max: 500
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Level
+    category: diagnostic
+    icon: "mdi:water-percent"
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement


### PR DESCRIPTION
I have copied this config from the other level sensor (ept tech) - it matched almost exactly, only value scaling and limits differed in some of dpids.
Seems to work fine:
<img width="674" height="747" alt="image" src="https://github.com/user-attachments/assets/bdbc0f38-9b85-4439-96c5-8b3a9ce4eae6" />
