### PR TITLE
feat: add support for Dura Comfort DH50PWM Dehumidifier

### DIFF
--- a/custom_components/tuya_local/devices/duracomfort_dh50pwm_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/duracomfort_dh50pwm_dehumidifier.yaml
@@ -2,6 +2,7 @@ name: Dehumidifier
 products:
   - id: keyfa7qemdvvux5c
     manufacturer: Dura Comfort
+    model: DH50PWM
 entities:
   - entity: humidifier
     class: dehumidifier
@@ -33,7 +34,6 @@ entities:
         name: current_humidity
         type: integer
   - entity: fan
-    translation_only_key: fan_with_presets
     dps:
       - id: 1
         type: boolean
@@ -55,6 +55,8 @@ entities:
         name: sensor
         mapping:
           - dps_val: 0
+            value: false
+          - dps_val: 32
             value: false
           - value: true
   - entity: binary_sensor

--- a/custom_components/tuya_local/devices/duracomfort_dh50pwm_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/duracomfort_dh50pwm_dehumidifier.yaml
@@ -1,0 +1,77 @@
+name: Dehumidifier
+products:
+  - id: keyfa7qemdvvux5c
+    manufacturer: Dura Comfort
+entities:
+  - entity: humidifier
+    class: dehumidifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 5
+        name: mode
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: normal
+          - dps_val: 1
+            value: boost
+          - dps_val: 2
+            value: comfort
+          - dps_val: 3
+            value: continuous
+      - id: 6
+        name: humidity
+        type: integer
+        range:
+          min: 35
+          max: 80
+        mapping:
+          - step: 5
+      - id: 18
+        name: current_humidity
+        type: integer
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 8
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "0"
+            value: 50
+          - dps_val: "2"
+            value: 100
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 15
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: 32
+            value: true
+          - value: false
+  - entity: switch
+    name: Pump
+    icon: "mdi:water-pump"
+    dps:
+      - id: 20
+        type: boolean
+        name: switch


### PR DESCRIPTION
Adds support for the Dura Comfort DH50PWM Dehumidifier.
https://www.amazon.com/dp/B09NBBM1PS

Is a switch required to implement a fan entity? I've used DP-1 in this case for both the dehumidifier and the fan since it seemed like it was required to get it working.

Sample DPs from tinytuya:
```
{'1': True, '5': '0', '6': 40, '8': '0', '15': 32, '18': 53, '20': False, '101': 1}
```

I'm not sure what `101` maps to.

The fault code accounts for P1 which is tank full/removed. E1, E2, E3 exist based on looking at some of the Amazon reviews and look to be related to things such as critical failure, and ambient temperature too hot or shut down due to coils being frosted.

<img width="315" height="640" alt="image" src="https://github.com/user-attachments/assets/aba5b324-ca7a-4b04-8039-876ecdf51f28" />
<img width="315" height="640" alt="image" src="https://github.com/user-attachments/assets/ae70ac8a-e7fd-4fc4-8170-c8a592a917b2" />


