### PR TITLE
PlantsIO Ivy smart planter - add touch buttons

### DIFF
--- a/custom_components/tuya_local/devices/plantsio_ivy_smart_planter.yaml
+++ b/custom_components/tuya_local/devices/plantsio_ivy_smart_planter.yaml
@@ -141,6 +141,55 @@ entities:
           - dps_val: 2
             value: "Too Dry"
           - value: "Unknown state"
+  # Button entities
+  - entity: event
+    name: Left touch
+    class: button
+    dps:
+      - id: 127
+        type: boolean
+        name: event
+        optional: true
+        mapping:
+          - dps_val: true
+            value: pressed
+          - value: null
+  - entity: event
+    name: Right touch
+    class: button
+    dps:
+      - id: 128
+        type: boolean
+        name: event
+        optional: true
+        mapping:
+          - dps_val: true
+            value: pressed
+          - value: null
+  - entity: event
+    name: Plant touch
+    class: button
+    dps:
+      - id: 129
+        type: boolean
+        name: event
+        optional: true
+        mapping:
+          - dps_val: true
+            value: pressed
+          - value: null
+  - entity: event
+    name: Hug
+    class: button
+    dps:
+      - id: 111
+        type: string
+        name: event
+        optional: true
+        mapping:
+          - dps_val: "hug"
+            value: pressed
+          - value: null
   # Diagnostic entities
   - entity: sensor
     class: battery


### PR DESCRIPTION
This PR adds the various touch pads on the [PlantsIO Ivy Smart Planter](https://store.plantsio.com/products/ivy-smart-planter) to use as buttons to trigger automations.

This was requested as per https://github.com/make-all/tuya-local/discussions/2791#discussioncomment-13262702.

Because event entity is stateless, I only implemented the touch event. I noticed other implementations also had a release state, but I think that event would fire every time the device is loaded not just on release, which does not make sense to me. If you disagree let me know.

Touching both the left and right pad at the same creates a unique hug state so I have mapped that as well.

Example automation using the hug event:

```yaml
alias: Love
description: ""
triggers:
  - entity_id:
      - event.smart_planter_hug
    trigger: state
conditions:
  - condition: state
    entity_id: event.smart_planter_hug
    attribute: event_type
    state: pressed
actions:
  - target:
      entity_id: tts.home_assistant_cloud
    data:
      media_player_entity_id: media_player.bedroom_display
      message: I love you!
    action: tts.speak
mode: single
```


