### PR TITLE
Correct timer enum values for Holmes Tower Fan

### DIFF
--- a/custom_components/tuya_local/devices/holmes_tower_fan.yaml
+++ b/custom_components/tuya_local/devices/holmes_tower_fan.yaml
@@ -41,9 +41,9 @@ entities:
             value: cancel
           - dps_val: "1h"
             value: "1h"
-          - dps_val: "1h"
-            value: "2h"
           - dps_val: "2h"
+            value: "2h"
+          - dps_val: "3h"
             value: "3h"
           - dps_val: "4h"
             value: "4h"


### PR DESCRIPTION
Correct timer enum values for Holmes Tower Fan. Two and three hour dps_val entries were incorrect.