### PR TITLE
Update its_45hd_heatpump to correct heating / cooling

### DIFF
--- a/custom_components/tuya_local/devices/its_45hd_heatpump.yaml
+++ b/custom_components/tuya_local/devices/its_45hd_heatpump.yaml
@@ -33,6 +33,9 @@ entities:
       - id: 14
         type: integer
         name: EEV
+      - id: 17
+        type: string
+        name: work_mode
       - id: 27
         type: boolean
         name: hvac_action

--- a/custom_components/tuya_local/devices/its_45hd_heatpump.yaml
+++ b/custom_components/tuya_local/devices/its_45hd_heatpump.yaml
@@ -33,20 +33,18 @@ entities:
       - id: 14
         type: integer
         name: EEV
-      - id: 17
-        type: string
+      - id: 27
+        type: boolean
         name: hvac_action
         mapping:
-          - dps_val: normal
+          - dps_val: true
             constraint: four_valve_state
             conditions:
               - dps_val: false
                 value: heating
               - dps_val: true
                 value: cooling
-          - dps_val: ERR
-            value: "off"
-          - dps_val: "NO"
+          - dps_val: false
             value: idle
       - id: 18
         type: integer


### PR DESCRIPTION
Current definition always shows "Idle" even when unit is actually heating the water.
This update changes this