### PR TITLE
Add Hoenofly Smart Wood Low Profile Ceiling Fan with Lights

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -33,6 +33,7 @@
 - Heatstorm DH-100-TWI, HS-1500 and HS-6000-GC heaters
 - Herschel infrared heater
 - HJZ oil column radiator
+- Hoenofly Smart Wood Low Profile Ceiling Fan with Lights
 - Hombli radiator controller
 - INOW Wi-Fi heating element (single and dual air/water temperature control variants)
 - Juskys OH125BW2 oil radiator

--- a/custom_components/tuya_local/devices/hoenofly_ceiling_fan_with_light.yaml
+++ b/custom_components/tuya_local/devices/hoenofly_ceiling_fan_with_light.yaml
@@ -1,0 +1,73 @@
+name: Ceiling Fan with Light
+products:
+  - id: iue9ugpzag3bbnsu
+    manufacturer: Hoenofly
+    model: Smart Wood Low Profile Ceiling Fan
+entities:
+  - entity: fan
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+      - id: 104
+        type: integer
+        name: speed
+        range:
+          min: 1
+          max: 6
+        mapping:
+          - scale: 0.16667
+      - id: 102
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: level_1
+            value: "1"
+          - dps_val: level_2
+            value: "2"
+          - dps_val: level_3
+            value: "3"
+          - dps_val: level_4
+            value: "4"
+          - dps_val: level_5
+            value: "5"
+          - dps_val: level_6
+            value: "6"
+      - id: 101
+        type: string
+        name: direction
+        mapping:
+          - dps_val: forward
+            value: forward
+          - dps_val: reverse
+            value: reverse
+      - id: 106
+        type: string
+        name: fan_mode
+        optional: true
+      - id: 103
+        type: string
+        name: countdown_set
+        optional: true
+  - entity: light
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 22
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+      - id: 23
+        type: integer
+        name: color_temp
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - target_range:
+              min: 3000
+              max: 5000
+            step: 500

--- a/tests/const.py
+++ b/tests/const.py
@@ -1701,3 +1701,15 @@ MUSTOOL_MT15MT29_AIRBOX_PAYLOAD = {
     "118": True,
     # last 3 must be true for the time entities to be enabled
 }
+CEILING_FAN_WITH_LIGHT_NEW_PAYLOAD = {
+    "20": False,
+    "21": "white",
+    "22": 500,
+    "23": 0,
+    "101": "forward",
+    "102": "level_2",
+    "103": "cancel",
+    "104": 1,
+    "105": False,
+    "106": "fresh",
+}

--- a/tests/devices/test_hoenofly_ceiling_fan_with_light.py
+++ b/tests/devices/test_hoenofly_ceiling_fan_with_light.py
@@ -1,0 +1,70 @@
+from homeassistant.components.fan import FanEntityFeature
+from homeassistant.components.light import ColorMode
+
+from ..const import CEILING_FAN_WITH_LIGHT_NEW_PAYLOAD
+from ..mixins import BasicFanTests, BasicLightTests
+from .base_device_tests import TuyaDeviceTestCase
+
+SWITCH_DPS = "105"
+SPEED_DPS = "104"
+PRESET_DPS = "102"
+DIRECTION_DPS = "101"
+LIGHT_DPS = "20"
+BRIGHTNESS_DPS = "22"
+COLORTEMP_DPS = "23"
+COLORMODE_DPS = "21"
+
+
+class TestHoenoflyFanWithLight(
+    BasicFanTests, BasicLightTests, TuyaDeviceTestCase
+):
+    __test__ = True
+
+    def setUp(self):
+        self.setUpForConfig("hoenofly_ceiling_fan_with_light.yaml", CEILING_FAN_WITH_LIGHT_NEW_PAYLOAD)
+        self.subject = self.entities.get("fan")
+        self.light = self.entities.get("light")
+        self.mark_secondary(["light"])
+
+    def test_supported_features(self):
+        self.assertEqual(
+            self.subject.supported_features,
+            (
+                FanEntityFeature.SET_SPEED
+                | FanEntityFeature.DIRECTION
+                | FanEntityFeature.PRESET_MODE
+            ),
+        )
+
+    def test_speed(self):
+        self.dps[SPEED_DPS] = 3
+        self.assertEqual(self.subject.percentage, 50)
+
+    def test_speed_step(self):
+        self.assertEqual(self.subject.speed_count, 6)
+
+    def test_preset_modes(self):
+        self.assertCountEqual(
+            self.subject.preset_modes,
+            ["1", "2", "3", "4", "5", "6"],
+        )
+
+    def test_preset_mode(self):
+        self.dps[PRESET_DPS] = "level_3"
+        self.assertEqual(self.subject.preset_mode, "3")
+
+    def test_direction(self):
+        self.dps[DIRECTION_DPS] = "forward"
+        self.assertEqual(self.subject.current_direction, "forward")
+
+    def test_light_brightness(self):
+        self.dps[BRIGHTNESS_DPS] = 500
+        self.assertEqual(self.light.brightness, 128)
+
+    def test_light_color_temp(self):
+        self.dps[COLORTEMP_DPS] = 500
+        self.assertEqual(self.light.color_temp_kelvin, 4600)
+
+    def test_light_color_mode(self):
+        self.dps[COLORMODE_DPS] = "white"
+        self.assertEqual(self.light.color_mode, ColorMode.COLOR_TEMP)


### PR DESCRIPTION
**Amazon Product Link:** https://a.co/d/3PUya5i

There a few other Hoenofly smart fans that already have support but this particular one hasn't seemed to be added and has a different set of DPS settings.

This gives support for both the fan and light entities. For the fan, there are 6 speeds and will be exposed both in the fan speed slider (as percentages) as well as scenes (where you a select the speed number directly). The light is pretty straight forward, allowing on/off, brightness, and color temperature.