### PR TITLE
properly closes #3559 - support for air quality monitor

### DIFF
--- a/custom_components/tuya_local/devices/prodotec_airquality_monitor.yaml
+++ b/custom_components/tuya_local/devices/prodotec_airquality_monitor.yaml
@@ -422,7 +422,7 @@ entities:
           - dps_val: alarm
             value: High
   - entity: sensor
-    name: Temperature state
+    name: Humidity state
     class: enum
     icon: "mdi:water-percent"
     category: diagnostic


### PR DESCRIPTION
This is a partial support. I could not get my head around enums and some triggers but at least it displays all the reading correctly.