### PR TITLE
Fix Detection Because Optional Flag is missing inkbird_ibs_m2

### DIFF
--- a/custom_components/tuya_local/devices/inkbird_ibs_m2.yaml
+++ b/custom_components/tuya_local/devices/inkbird_ibs_m2.yaml
@@ -15,6 +15,7 @@ entities:
             value: celsius
           - dps_val: "f"
             value: fahrenheit
+
   - entity: sensor
     name: Temperature probe 1
     class: temperature
@@ -30,6 +31,7 @@ entities:
         mapping:
           - scale: 10
       - id: 103
+        optional: true
         type: string
         name: available
         mapping:
@@ -48,6 +50,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 103
+        optional: true
         type: string
         name: available
         mapping:
@@ -99,6 +102,7 @@ entities:
         mapping:
           - scale: 10
       - id: 104
+        optional: true
         type: string
         name: available
         mapping:
@@ -118,6 +122,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 104
+        optional: true
         type: string
         name: available
         mapping:
@@ -169,6 +174,7 @@ entities:
         mapping:
           - scale: 10
       - id: 105
+        optional: true
         type: string
         name: available
         mapping:
@@ -188,6 +194,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 105
+        optional: true
         type: string
         name: available
         mapping:
@@ -239,6 +246,7 @@ entities:
         mapping:
           - scale: 10
       - id: 106
+        optional: true
         type: string
         name: available
         mapping:
@@ -258,6 +266,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 106
+        optional: true
         type: string
         name: available
         mapping:
@@ -309,6 +318,7 @@ entities:
         mapping:
           - scale: 10
       - id: 107
+        optional: true
         type: string
         name: available
         mapping:
@@ -328,6 +338,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 107
+        optional: true
         type: string
         name: available
         mapping:
@@ -379,6 +390,7 @@ entities:
         mapping:
           - scale: 10
       - id: 108
+        optional: true
         type: string
         name: available
         mapping:
@@ -398,6 +410,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 108
+        optional: true
         type: string
         name: available
         mapping:
@@ -449,6 +462,7 @@ entities:
         mapping:
           - scale: 10
       - id: 109
+        optional: true
         type: string
         name: available
         mapping:
@@ -468,6 +482,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 109
+        optional: true
         type: string
         name: available
         mapping:
@@ -519,6 +534,7 @@ entities:
         mapping:
           - scale: 10
       - id: 110
+        optional: true
         type: string
         name: available
         mapping:
@@ -538,6 +554,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 110
+        optional: true
         type: string
         name: available
         mapping:
@@ -589,6 +606,7 @@ entities:
         mapping:
           - scale: 10
       - id: 111
+        optional: true
         type: string
         name: available
         mapping:
@@ -608,6 +626,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 111
+        optional: true
         type: string
         name: available
         mapping:
@@ -659,6 +678,7 @@ entities:
         mapping:
           - scale: 10
       - id: 112
+        optional: true
         type: string
         name: available
         mapping:
@@ -678,6 +698,7 @@ entities:
         unit: "%"
         mask: "000000000000000000FF"
       - id: 112
+        optional: true
         type: string
         name: available
         mapping:


### PR DESCRIPTION
Hey there just a Heads Up, the latest change broke the matching because some of the values only get transmitted after a time, the initial  connection only includes those:  
{"updated_at": 1754338572.520221, "9": "c", "113": 0, "114": 0, "115": 0, "116": 0, "117": 0, "118": 0, "119": 0, "120": 0, "121": 0, "122": 0, "124": 1, "125": 1, "126": 0} of which only the 9 is relevant.  I added the needed optional flags to the DPS.

Thx. Florian