### PR TITLE
Added support for Aziot 8 & 7 Node smart switches

### DIFF
--- a/custom_components/tuya_local/devices/aziot_7_node_io_smart_switch.yaml
+++ b/custom_components/tuya_local/devices/aziot_7_node_io_smart_switch.yaml
@@ -1,0 +1,177 @@
+name: Aziot 7 Node IO Smart Switch
+products:
+  - id: kqkj2vssnbwqq34j
+    manufacturer: Aziot
+    model: 7 Node-IO Smart Switch
+
+entities:
+  # Switches 1 to 7
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "1" }
+    dps:
+      - id: 1
+        code: switch_1
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "2" }
+    dps:
+      - id: 2
+        code: switch_2
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "3" }
+    dps:
+      - id: 3
+        code: switch_3
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "4" }
+    dps:
+      - id: 4
+        code: switch_4
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "5" }
+    dps:
+      - id: 5
+        code: switch_5
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "6" }
+    dps:
+      - id: 6
+        code: switch_6
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "7" }
+    dps:
+      - id: 141
+        code: switch_7
+        name: switch
+        type: boolean
+
+  # Master Switch
+  - entity: switch
+    name: Master Switch
+    icon: "mdi:toggle-switch"
+    dps:
+      - id: 13
+        code: switch_all
+        name: switch
+        type: boolean
+
+  # Timers 1 to 6
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "1" }
+    dps:
+      - id: 7
+        code: countdown_1
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "2" }
+    dps:
+      - id: 8
+        code: countdown_2
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "3" }
+    dps:
+      - id: 9
+        code: countdown_3
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "4" }
+    dps:
+      - id: 10
+        code: countdown_4
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "5" }
+    dps:
+      - id: 11
+        code: countdown_5
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "6" }
+    dps:
+      - id: 12
+        code: countdown_6
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60

--- a/custom_components/tuya_local/devices/aziot_8_node_smart_switch.yaml
+++ b/custom_components/tuya_local/devices/aziot_8_node_smart_switch.yaml
@@ -1,0 +1,218 @@
+name: Aziot 8 Node Smart Switch
+products:
+  - id: xs4fwrqy9rxg5tak
+    manufacturer: Aziot
+    model: 8 Node Smart Switch
+
+entities:
+  # Switches 1 to 8
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "1" }
+    dps:
+      - id: 1
+        code: switch_1
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "2" }
+    dps:
+      - id: 2
+        code: switch_2
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "3" }
+    dps:
+      - id: 3
+        code: switch_3
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "4" }
+    dps:
+      - id: 4
+        code: switch_4
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "5" }
+    dps:
+      - id: 5
+        code: switch_5
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "6" }
+    dps:
+      - id: 6
+        code: switch_6
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "7" }
+    dps:
+      - id: 141
+        code: switch_7
+        name: switch
+        type: boolean
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: { x: "8" }
+    dps:
+      - id: 171
+        code: switch_8
+        name: switch
+        type: boolean
+
+  # Master Switch
+  - entity: switch
+    name: Master Switch
+    icon: "mdi:toggle-switch"
+    dps:
+      - id: 13
+        code: switch_all
+        name: switch
+        type: boolean
+
+  # Timers 1 to 8
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "1" }
+    dps:
+      - id: 7
+        code: countdown_1
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "2" }
+    dps:
+      - id: 8
+        code: countdown_2
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "3" }
+    dps:
+      - id: 9
+        code: countdown_3
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "4" }
+    dps:
+      - id: 10
+        code: countdown_4
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "5" }
+    dps:
+      - id: 11
+        code: countdown_5
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "6" }
+    dps:
+      - id: 12
+        code: countdown_6
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "7" }
+    dps:
+      - id: 143
+        code: countdown_7
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60
+
+  - entity: number
+    category: config
+    class: duration
+    translation_key: timer_x
+    translation_placeholders: { x: "8" }
+    dps:
+      - id: 172
+        code: countdown_8
+        type: integer
+        name: value
+        unit: min
+        range: { min: 0, max: 86400 }
+        mapping:
+          - scale: 60
+            step: 60


### PR DESCRIPTION
Hi @make-all, adding two devices mentioned below.

- [AZIOT 8 Node Smart Switch](https://www.amazon.in/AZIOT-Bluetooth-Scheduling-SmartLife-Retrofit/dp/B0F6YT4KYN/ref=sr_1_2?crid=345V6TUE3JWIJ&dib=eyJ2IjoiMSJ9.7BVedjHrTyiEWHHdRERp6wTYtsIRUrAq5M-OPKR77VE2vygqTzn9YC7u6XL3EZzcrx5gv4IEffbS4ALfr9NSTNmwxY2pJ2Rg8VEsIZKjzV_wF6ZW6U0FHU3OF_Szzllx_n-xLJEdd9uhwPij4yp0pfA4VKKhTPIuIblSk7V1By3VsPQs7KN_18Bnbop8zhJAHgaM19QS6RWo9jLlQr-hZ828M633LNm1YXRd53EGETb4bgAjViMj9yTBXgJy3LB7Ir9OmEW8ijiqJke9qUfKE9p1afFhkjSmT3B20Oliq-Q.r6_m--HGBxcJTeJqZPF1hiMIBpk_jK9sMvx3o7w_NkI&dib_tag=se&keywords=aziot+8+node+smart+switch&nsdOptOutParam=true&qid=1754627834&sprefix=aziot+8%2Caps%2C218&sr=8-2) mentioned in #3601 
- [AZIOT 7 Node IO Smart Switch](https://www.aziot.life/products/aziot-7-node-io-smart-switch-6-normal-loads-1-x-16a-heavy-load-wifi-bluetooth-dual-power-input-inverter-raw-timer-function-voice-control-with-alexa-google-made-in-india?srsltid=AfmBOooAl6_OVtNqY1n5hqXFcqxLQIj9CMP1DwUs4gXHsGBlOsDPMjPC&variant=51276971180332) mentioned in #3602

I've tested both of them on my devices and working flawlessly. Sharing few screenshots here.

<img width="702" height="848" alt="image" src="https://github.com/user-attachments/assets/6537c871-d8a2-4b78-b971-ff116e80a838" />
<img width="683" height="869" alt="image" src="https://github.com/user-attachments/assets/d48e1dd6-aaa5-43d3-a58b-f46dd461de21" />

Looking forward to contribute more devices from the same brand in the future. These devices have a few competitor brands in India and it is likely that they share the exact same DPS thus may extend a huge support towards them.
