### PR TITLE
Add support for Dream of You dual dimmable lamp (t1o91dvgdb9xclnm)

### DIFF
--- a/custom_components/tuya_local/devices/dual_dimmable_lamp.yaml
+++ b/custom_components/tuya_local/devices/dual_dimmable_lamp.yaml
@@ -1,0 +1,33 @@
+name: Dual Dimmable Lamp
+products:
+  - id: t1o91dvgdb9xclnm
+    name: Dream of You Dual Lamp
+entities:
+  - entity: light
+    name: Filament
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+        mapping:
+          - scale: 0.255
+  - entity: light
+    name: Base
+    dps:
+      - id: 7
+        type: boolean
+        name: switch
+      - id: 8
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+        mapping:
+          - scale: 0.255


### PR DESCRIPTION
### Summary
Adds support for the "Dream of You" dual-channel dimmable lamp.

- Two light entities: Filament (DPIDs 1,2) and Base (DPIDs 7,8)
- Brightness (10–1000) mapped to Home Assistant’s 1–255
- Product ID: t1o91dvgdb9xclnm
- Countdown DPIDs exist (6,12) but not exposed

### Testing
Verified working locally with my device.
