### PR TITLE
New Device: Cat Litter Box (multiple brands)

### DIFF
--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -8,7 +8,6 @@ products:
 # LubadiPaw
 # Previous brands:
 # MEEGEEM
-#primary_entity:
 entities:
   - entity: sensor
     name: Action
@@ -36,6 +35,8 @@ entities:
           - dps_val: 7
             value: Resetting Paused
 
+# Probably shouldn't be shown.  Option in Smart Life app but just spins the
+# litter chamber around all the way, dumping all litter (clean litter too!)
   - entity: button
     name: Empty
     icon: "mdi:shimmer"
@@ -44,8 +45,6 @@ entities:
     - id: "1"
       type: boolean
       name: button
-# Probably shouldn't be shown.  Option in Smart Life app but just spins the
-# litter chamber around all the way, dumping all litter (clean litter too!)
 
   - entity: button
     name: Clean
@@ -200,7 +199,7 @@ entities:
 # Threshold unknown.  Based on litter weight?
 
   - entity: sensor
-    name: Operating mode
+    name: Operating Mode
     icon: "mdi:shimmer"
     hidden: true
     dps:

--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -36,7 +36,7 @@ entities:
     icon: "mdi:delete-empty-outline"
     hidden: true
     dps:
-      - id: "1"
+      - id: 1
         type: boolean
         name: button
 
@@ -44,7 +44,7 @@ entities:
     name: Clean
     icon: "mdi:delete-empty"
     dps:
-      - id: "3"
+      - id: 3
         type: boolean
         name: button
 
@@ -52,7 +52,7 @@ entities:
     name: Reset
     icon: "mdi:refresh"
     dps:
-      - id: "4"
+      - id: 4
         type: boolean
         name: button
 
@@ -60,7 +60,7 @@ entities:
     name: Deodorize
     icon: "mdi:scent"
     dps:
-      - id: "9"
+      - id: 9
         type: boolean
         name: button
 

--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -1,0 +1,225 @@
+name: Cat Litter Box
+products:
+  - id: e2uhpgprwtq40un2
+    manufacturer: MEEGEEM
+# Other brands available at the time of purchase - all appear to be clones.  Can this be a list?  Generic?
+# August 2025 list of brands:
+# BCHARYA
+# LubadiPaw
+# Previous brands:
+# MEEGEEM
+#primary_entity:
+entities:
+  - entity: sensor
+    name: Action
+    icon: "mdi:shimmer"
+    class: enum
+    dps:
+      - id: 107
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: Standby
+          - dps_val: 1
+            value: Cleaning
+          - dps_val: 2
+            value: Emptying
+          - dps_val: 3
+            value: Resetting
+          - dps_val: 4
+            value: Deodorizing
+          - dps_val: 5
+            value: Cleaning Paused
+          - dps_val: 6
+            value: Emptying Paused
+          - dps_val: 7
+            value: Resetting Paused
+
+  - entity: button
+    name: Empty
+    icon: "mdi:shimmer"
+    hidden: true
+    dps:
+    - id: "1"
+      type: boolean
+      name: button
+# Probably shouldn't be shown.  Option in Smart Life app but just spins the
+# litter chamber around all the way, dumping all litter (clean litter too!)
+
+  - entity: button
+    name: Clean
+    icon: "mdi:delete-empty"
+    dps:
+    - id: "3"
+      type: boolean
+      name: button
+
+  - entity: button
+    name: Reset
+    icon: "mdi:shimmer"
+    dps:
+    - id: "4"
+      type: boolean
+      name: button
+
+  - entity: button
+    name: Deodorize
+    icon: "mdi:scent"
+    dps:
+    - id: "9"
+      type: boolean
+      name: button
+
+  - entity: sensor
+    name: Weight
+    class: enum
+    dps:
+      - id: 21
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 0
+            value: Unused
+          - dps_val: 1
+            value: Unknown
+          - dps_val: 2
+            value: 1
+          - dps_val: 4
+            value: 2
+          - dps_val: 8
+            value: 3
+          - dps_val: 16
+            value: 4
+          - dps_val: 32
+            value: 5
+          - dps_val: 64
+            value: 6
+          - dps_val: 128
+            value: 7
+          - dps_val: 256
+            value: 8
+          - dps_val: 512
+            value: 9
+          - dps_val: 1024
+            value: 10
+          - dps_val: 2048
+            value: 11
+          - dps_val: 4096
+            value: 12
+          - dps_val: 8192
+            value: 13
+          - dps_val: 16384
+            value: 14
+          - dps_val: 32768
+            value: 15
+          - dps_val: 65536
+            value: 16
+          - dps_val: 131072
+            value: 17
+          - dps_val: 262144
+            value: 18
+          - dps_val: 524288
+            value: 19
+          - dps_val: 1048576
+            value: 20
+
+  - entity: sensor
+    name: State
+    icon: "mdi:emoticon-poop"
+    class: enum
+    dps:
+      - id: 22
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 0
+            value: Unused
+          - dps_val: 1
+            value: Other
+          - dps_val: 2
+            value: Litter Low
+          - dps_val: 4
+            value: Waste Bin Full
+          - dps_val: 8
+            value: Cleaning Interrupted
+          - dps_val: 16
+            value: Litter Reset Failed
+          - dps_val: 32
+            value: Other
+          - dps_val: 64
+            value: Cleaning Complete
+          - dps_val: 128
+            value: Emptying Complete
+          - dps_val: 256
+            value: Reset Complete
+          - dps_val: 512
+            value: Deodorizing Complete
+
+  - entity: number
+    name: Auto-Clean Delay # How long after cat leaves to start cleaning
+    icon: "mdi:clock"
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 20
+
+  - entity: switch
+    name: Auto-Clean # Whether to clean after cat leaves
+    icon: "mdi:shimmer"
+    dps:
+      - id: 102
+        name: switch
+        type: boolean
+
+  - entity: switch
+    name: Auto-Deodorize # Whether to run "ozone generator" in waste bin after cleaning is complete
+    icon: "mdi:shimmer"
+    dps:
+      - id: 103
+        name: switch
+        type: boolean
+
+  - entity: sensor
+    name: Litter Status
+    icon: "mdi:shimmer"
+    class: enum
+    dps:
+      - id: 104
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: Needs Attention
+          - dps_val: 1
+            value: Acceptable
+# Threshold unknown.  Based on litter weight?
+
+  - entity: sensor
+    name: Operating mode
+    icon: "mdi:shimmer"
+    hidden: true
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+# 0-3 in steps of 1, not shown in Smart Life app, unknown function
+
+  - entity: sensor
+    name: Waste Bin Status
+    icon: "mdi:shimmer"
+    class: enum
+    dps:
+      - id: 106
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: Needs Attention
+          - dps_val: 1
+            value: Acceptable
+# Threshold unknown.  Can be triggered by waste bag improperly installed.  Suspect a light gate across top of bin.  Not weight based.

--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -1,11 +1,10 @@
-name: Cat Litter Box
+name: Litter box
 products:
   - id: e2uhpgprwtq40un2
-    manufacturer: MEEGEEM
+    manufacturer: Meegeem
 entities:
   - entity: sensor
-    name: Action
-    icon: "mdi:bell"
+    translation_key: status
     class: enum
     dps:
       - id: 107
@@ -13,28 +12,26 @@ entities:
         name: sensor
         mapping:
           - dps_val: 0
-            value: Standby
+            value: standby
           - dps_val: 1
-            value: Cleaning
+            value: cleaning
           - dps_val: 2
-            value: Emptying
+            value: emptying
           - dps_val: 3
-            value: Resetting
+            value: resetting
           - dps_val: 4
-            value: Deodorizing
+            value: deodorizing
           - dps_val: 5
-            value: Cleaning Paused
+            value: Cleaning paused
           - dps_val: 6
-            value: Emptying Paused
+            value: Emptying paused
           - dps_val: 7
-            value: Resetting Paused
+            value: Resetting paused
 
   - entity: button
-    # Probably shouldn't be shown.  Option in Smart Life app but just spins the
-    # litter chamber around all the way, dumping all litter (clean litter too!)
     name: Empty
     icon: "mdi:delete-empty-outline"
-    hidden: true
+    category: config
     dps:
       - id: 1
         type: boolean
@@ -65,18 +62,17 @@ entities:
         name: button
 
   - entity: sensor
-    name: Weight
-    icon: "mdi:weight-kilogram"
-    class: enum
+    class: weight
     dps:
       - id: 21
         name: sensor
         type: bitfield
+        unit: kg
         mapping:
           - dps_val: 0
-            value: Unused
+            value: null
           - dps_val: 1
-            value: Unknown
+            value: null
           - dps_val: 2
             value: 1
           - dps_val: 4
@@ -118,42 +114,59 @@ entities:
           - dps_val: 1048576
             value: 20
 
-  - entity: sensor
-    name: State
-    icon: "mdi:cat"
-    class: enum
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
     dps:
       - id: 22
+        type: bitfield
         name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 64
+            value: false
+          - dps_val: 128
+            value: false
+          - dps_val: 256
+            value: false
+          - dps_val: 512
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+      - id: 22
+        name: description
         type: bitfield
         mapping:
           - dps_val: 0
-            value: Unused
+            value: OK
           - dps_val: 1
             value: Other
           - dps_val: 2
-            value: Litter Low
+            value: Litter low
           - dps_val: 4
-            value: Waste Bin Full
+            value: Waste bin full
           - dps_val: 8
-            value: Cleaning Interrupted
+            value: Cleaning interrupted
           - dps_val: 16
-            value: Litter Reset Failed
+            value: Litter reset failed
           - dps_val: 32
             value: Other
           - dps_val: 64
-            value: Cleaning Complete
+            value: Cleaning complete
           - dps_val: 128
-            value: Emptying Complete
+            value: Emptying complete
           - dps_val: 256
-            value: Reset Complete
+            value: Reset complete
           - dps_val: 512
-            value: Deodorizing Complete
+            value: Deodorizing complete
 
   - entity: number
-    # How long after cat leaves to start cleaning
-    name: Auto-Clean Delay
+    name: Auto-clean delay
     icon: "mdi:clock"
+    category: config
     dps:
       - id: 101
         type: integer
@@ -164,41 +177,40 @@ entities:
           max: 20
 
   - entity: switch
-    # Whether to clean after cat leaves
-    name: Auto-Clean
+    name: Auto-clean
     icon: "mdi:delete-empty"
+    category: config
     dps:
       - id: 102
         name: switch
         type: boolean
 
   - entity: switch
-    # Whether to run "ozone generator" in waste bin after cleaning is complete
-    name: Auto-Deodorize
+    name: Auto-deodorize
     icon: "mdi:scent"
+    category: config
     dps:
       - id: 103
         name: switch
         type: boolean
 
-  - entity: sensor
-    # Threshold unknown.  Based on litter weight?
-    name: Litter Status
+  - entity: binary_sensor
+    name: Litter
     icon: "mdi:toilet"
-    class: enum
+    class: problem
     dps:
       - id: 104
         type: string
         name: sensor
         mapping:
-          - dps_val: 0
-            value: Needs Attention
-          - dps_val: 1
-            value: Acceptable
+          - dps_val: "0"
+            value: true
+          - dps_val: "1"
+            value: false
 
   - entity: sensor
     # 0-3 in steps of 1, not shown in Smart Life app, unknown function
-    name: Operating Mode
+    name: Operating mode
     icon: "mdi:shimmer"
     hidden: true
     dps:
@@ -206,18 +218,16 @@ entities:
         type: integer
         name: sensor
 
-  - entity: sensor
-    # Threshold unknown.  Can be triggered by waste bag improperly installed.
-    # Suspect a light gate across top of bin.  Not weight based.
-    name: Waste Bin Status
+  - entity: binary_sensor
+    name: Waste bin
     icon: "mdi:delete"
-    class: enum
+    class: problem
     dps:
       - id: 106
         type: string
         name: sensor
         mapping:
-          - dps_val: 0
-            value: Needs Attention
-          - dps_val: 1
-            value: Acceptable
+          - dps_val: "0"
+            value: true
+          - dps_val: "1"
+            value: false

--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -2,12 +2,6 @@ name: Cat Litter Box
 products:
   - id: e2uhpgprwtq40un2
     manufacturer: MEEGEEM
-# Other brands available at the time of purchase - all appear to be clones.  Can this be a list?  Generic?
-# August 2025 list of brands:
-# BCHARYA
-# LubadiPaw
-# Previous brands:
-# MEEGEEM
 entities:
   - entity: sensor
     name: Action
@@ -35,40 +29,40 @@ entities:
           - dps_val: 7
             value: Resetting Paused
 
-# Probably shouldn't be shown.  Option in Smart Life app but just spins the
-# litter chamber around all the way, dumping all litter (clean litter too!)
   - entity: button
+    # Probably shouldn't be shown.  Option in Smart Life app but just spins the
+    # litter chamber around all the way, dumping all litter (clean litter too!)
     name: Empty
     icon: "mdi:delete-empty-outline"
     hidden: true
     dps:
-    - id: "1"
-      type: boolean
-      name: button
+      - id: "1"
+        type: boolean
+        name: button
 
   - entity: button
     name: Clean
     icon: "mdi:delete-empty"
     dps:
-    - id: "3"
-      type: boolean
-      name: button
+      - id: "3"
+        type: boolean
+        name: button
 
   - entity: button
     name: Reset
     icon: "mdi:refresh"
     dps:
-    - id: "4"
-      type: boolean
-      name: button
+      - id: "4"
+        type: boolean
+        name: button
 
   - entity: button
     name: Deodorize
     icon: "mdi:scent"
     dps:
-    - id: "9"
-      type: boolean
-      name: button
+      - id: "9"
+        type: boolean
+        name: button
 
   - entity: sensor
     name: Weight
@@ -157,7 +151,8 @@ entities:
             value: Deodorizing Complete
 
   - entity: number
-    name: Auto-Clean Delay # How long after cat leaves to start cleaning
+    # How long after cat leaves to start cleaning
+    name: Auto-Clean Delay
     icon: "mdi:clock"
     dps:
       - id: 101
@@ -169,7 +164,8 @@ entities:
           max: 20
 
   - entity: switch
-    name: Auto-Clean # Whether to clean after cat leaves
+    # Whether to clean after cat leaves
+    name: Auto-Clean
     icon: "mdi:delete-empty"
     dps:
       - id: 102
@@ -177,7 +173,8 @@ entities:
         type: boolean
 
   - entity: switch
-    name: Auto-Deodorize # Whether to run "ozone generator" in waste bin after cleaning is complete
+    # Whether to run "ozone generator" in waste bin after cleaning is complete
+    name: Auto-Deodorize
     icon: "mdi:scent"
     dps:
       - id: 103
@@ -185,6 +182,7 @@ entities:
         type: boolean
 
   - entity: sensor
+    # Threshold unknown.  Based on litter weight?
     name: Litter Status
     icon: "mdi:toilet"
     class: enum
@@ -197,9 +195,9 @@ entities:
             value: Needs Attention
           - dps_val: 1
             value: Acceptable
-# Threshold unknown.  Based on litter weight?
 
   - entity: sensor
+    # 0-3 in steps of 1, not shown in Smart Life app, unknown function
     name: Operating Mode
     icon: "mdi:shimmer"
     hidden: true
@@ -207,9 +205,10 @@ entities:
       - id: 105
         type: integer
         name: sensor
-# 0-3 in steps of 1, not shown in Smart Life app, unknown function
 
   - entity: sensor
+    # Threshold unknown.  Can be triggered by waste bag improperly installed.
+    # Suspect a light gate across top of bin.  Not weight based.
     name: Waste Bin Status
     icon: "mdi:delete"
     class: enum
@@ -222,4 +221,3 @@ entities:
             value: Needs Attention
           - dps_val: 1
             value: Acceptable
-# Threshold unknown.  Can be triggered by waste bag improperly installed.  Suspect a light gate across top of bin.  Not weight based.

--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -11,7 +11,7 @@ products:
 entities:
   - entity: sensor
     name: Action
-    icon: "mdi:shimmer"
+    icon: "mdi:bell"
     class: enum
     dps:
       - id: 107
@@ -39,7 +39,7 @@ entities:
 # litter chamber around all the way, dumping all litter (clean litter too!)
   - entity: button
     name: Empty
-    icon: "mdi:shimmer"
+    icon: "mdi:delete-empty-outline"
     hidden: true
     dps:
     - id: "1"
@@ -56,7 +56,7 @@ entities:
 
   - entity: button
     name: Reset
-    icon: "mdi:shimmer"
+    icon: "mdi:refresh"
     dps:
     - id: "4"
       type: boolean
@@ -72,6 +72,7 @@ entities:
 
   - entity: sensor
     name: Weight
+    icon: "mdi:weight-kilogram"
     class: enum
     dps:
       - id: 21
@@ -125,7 +126,7 @@ entities:
 
   - entity: sensor
     name: State
-    icon: "mdi:emoticon-poop"
+    icon: "mdi:cat"
     class: enum
     dps:
       - id: 22
@@ -169,7 +170,7 @@ entities:
 
   - entity: switch
     name: Auto-Clean # Whether to clean after cat leaves
-    icon: "mdi:shimmer"
+    icon: "mdi:delete-empty"
     dps:
       - id: 102
         name: switch
@@ -177,7 +178,7 @@ entities:
 
   - entity: switch
     name: Auto-Deodorize # Whether to run "ozone generator" in waste bin after cleaning is complete
-    icon: "mdi:shimmer"
+    icon: "mdi:scent"
     dps:
       - id: 103
         name: switch
@@ -185,7 +186,7 @@ entities:
 
   - entity: sensor
     name: Litter Status
-    icon: "mdi:shimmer"
+    icon: "mdi:toilet"
     class: enum
     dps:
       - id: 104
@@ -210,7 +211,7 @@ entities:
 
   - entity: sensor
     name: Waste Bin Status
-    icon: "mdi:shimmer"
+    icon: "mdi:delete"
     class: enum
     dps:
       - id: 106


### PR DESCRIPTION
At time of purchase (late 2023), brand was MEEGEEM with a few others available.

Current brands are BCHARYA and LubadiPaw, though I haven't purchased either to verify product IDs.

All are physically identical as far as I can tell.

Worth renaming to something generic like `smart_cat_litter_box.yaml` or `generic_cat_litter_box.yaml`, what ever the typical convention is.  Couldn't really figure that out. 

This configuration has been running in my instance for over a year.  Finally got some time to polish it up for contribution.

Weight is in kg but I couldn't figure out how to make `unit: kg` play nicely with `class: enum`.

<img width="346" height="926" alt="image" src="https://github.com/user-attachments/assets/a6340dd9-941f-4c26-8105-654c5c8c971f" />

