### PR TITLE
Add support for FUKUMARU (AF01-W) PET feeder

### DIFF
--- a/custom_components/tuya_local/devices/fukumaru_af01w_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/fukumaru_af01w_pet_feeder.yaml
@@ -1,9 +1,8 @@
-name: pet feeder
+name: Pet feeder
 products:
   - id: jttvwskiffndnb1q
-    manufacturer: FUKUMARU
-    model: FUKUMARU-W
-    model_id: AF01-W
+    manufacturer: Fukumaru
+    model: AF01-W
 entities:
   - entity: button
     name: Quick feed
@@ -12,9 +11,6 @@ entities:
       - id: 2
         type: boolean
         name: button
-        mapping:
-          - dps_val: true
-            value: true
   - entity: number
     name: Manual feed
     icon: "mdi:food-drumstick"


### PR DESCRIPTION
From what I can gather the fukumaru feeders all advertise themselves as "FUKUMARU-W" through the Tuya API (I only have the AF01-W so can't test this theory) so I've added the model id to the filename and model_id

Model IDs can be seen on this page
https://fukumarupet.com/pages/support