### PR TITLE
Add Petempo PAF-02 pet feeder

### DIFF
--- a/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
@@ -11,9 +11,6 @@ entities:
       - id: 2
         type: boolean
         name: button
-        mapping:
-          - dps_val: true
-            value: true
   - entity: number
     name: Manual feed
     icon: "mdi:food-drumstick"

--- a/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
@@ -1,4 +1,4 @@
-name: pet feeder
+name: Pet feeder
 products:
   - id: go142kwowvlxvmmn
     manufacturer: Petempo
@@ -87,6 +87,3 @@ entities:
        - id: 24
          type: boolean
          name: button
-         mapping:
-           - dps_val: true
-             value: true

--- a/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
@@ -40,8 +40,8 @@ entities:
             value: feeding
           - dps_val: done
             value: feeding_complete
-   - entity: sensor
-     class: battery
+  - entity: sensor
+    class: battery
     category: diagnostic
     dps:
       - id: 10
@@ -49,8 +49,8 @@ entities:
         name: sensor
         unit: "%"
         class: measurement
-   - entity: binary_sensor
-     class: battery_charging
+  - entity: binary_sensor
+    class: battery_charging
     category: diagnostic
     dps:
       - id: 11
@@ -65,13 +65,13 @@ entities:
         type: integer
         name: sensor
         unit: portions
-   - entity: light
-     translation_key: display
-     category: config
-     dps:
-       - id: 17
-         type: boolean
-         name: switch
+  - entity: light
+    translation_key: display
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: switch
   - entity: switch
     name: Slow feed
     icon: "mdi:speedometer-slow"

--- a/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
@@ -1,4 +1,4 @@
-name: Petempo PAF-02 pet feeder
+name: pet feeder
 products:
   - id: go142kwowvlxvmmn
     manufacturer: Petempo
@@ -40,9 +40,8 @@ entities:
             value: feeding
           - dps_val: done
             value: feeding_complete
-  - entity: sensor
-    name: Battery
-    class: battery
+   - entity: sensor
+     class: battery
     category: diagnostic
     dps:
       - id: 10
@@ -50,9 +49,8 @@ entities:
         name: sensor
         unit: "%"
         class: measurement
-  - entity: binary_sensor
-    name: Charging
-    class: battery_charging
+   - entity: binary_sensor
+     class: battery_charging
     category: diagnostic
     dps:
       - id: 11
@@ -67,14 +65,13 @@ entities:
         type: integer
         name: sensor
         unit: portions
-  - entity: switch
-    name: display
-    icon: "mdi:light-switch"
-    category: config
-    dps:
-      - id: 17
-        type: boolean
-        name: switch
+   - entity: light
+     translation_key: display
+     category: config
+     dps:
+       - id: 17
+         type: boolean
+         name: switch
   - entity: switch
     name: Slow feed
     icon: "mdi:speedometer-slow"
@@ -83,14 +80,13 @@ entities:
       - id: 23
         type: boolean
         name: switch
-  - entity: button
-    name: Factory reset
-    icon: "mdi:restore"
-    category: config
-    dps:
-      - id: 24
-        type: boolean
-        name: button
-        mapping:
-          - dps_val: true
-            value: true
+   - entity: button
+     translation_key: factory_reset
+     category: config
+     dps:
+       - id: 24
+         type: boolean
+         name: button
+         mapping:
+           - dps_val: true
+             value: true

--- a/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
@@ -80,10 +80,10 @@ entities:
       - id: 23
         type: boolean
         name: switch
-   - entity: button
-     translation_key: factory_reset
-     category: config
-     dps:
-       - id: 24
-         type: boolean
-         name: button
+  - entity: button
+    translation_key: factory_reset
+    category: config
+    dps:
+      - id: 24
+        type: boolean
+        name: button

--- a/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/petempo_paf02_pet_feeder.yaml
@@ -1,0 +1,96 @@
+name: Petempo PAF-02 pet feeder
+products:
+  - id: go142kwowvlxvmmn
+    manufacturer: Petempo
+    model: PAF-02
+entities:
+  - entity: button
+    name: Quick feed
+    icon: "mdi:food-drumstick"
+    dps:
+      - id: 2
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: true
+            value: true
+  - entity: number
+    name: Manual feed
+    icon: "mdi:food-drumstick"
+    dps:
+      - id: 3
+        type: integer
+        name: value
+        unit: portions
+        range:
+          min: 1
+          max: 6
+  - entity: sensor
+    class: enum
+    translation_key: status
+    category: diagnostic
+    dps:
+      - id: 4
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: standby
+            value: standby
+          - dps_val: feeding
+            value: feeding
+          - dps_val: done
+            value: feeding_complete
+  - entity: sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    name: Charging
+    class: battery_charging
+    category: diagnostic
+    dps:
+      - id: 11
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Feed report
+    icon: "mdi:food-drumstick"
+    category: diagnostic
+    dps:
+      - id: 14
+        type: integer
+        name: sensor
+        unit: portions
+  - entity: switch
+    name: display
+    icon: "mdi:light-switch"
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Slow feed
+    icon: "mdi:speedometer-slow"
+    category: config
+    dps:
+      - id: 23
+        type: boolean
+        name: switch
+  - entity: button
+    name: Factory reset
+    icon: "mdi:restore"
+    category: config
+    dps:
+      - id: 24
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: true
+            value: true


### PR DESCRIPTION
Tuya exposes this as having the ability to dispense up to 60 portions (maybe a typo from the manufacture?), I've limited to 6 as a more sane value otherwise it's very easy to dispense too much food (even if my cats are happy about the possibility of 60 portions at once)