### PR TITLE
Add Princess Smart Air Cooler

### DIFF
--- a/custom_components/tuya_local/devices/princess-smart-air-cooler.yaml
+++ b/custom_components/tuya_local/devices/princess-smart-air-cooler.yaml
@@ -1,0 +1,64 @@
+name: Princess Smart Air Cooler
+products:
+  - id: "y7qqmrwarh8e6jji"
+    manufacturer: Princess
+    model: Smart Air Cooler
+    model_id: "358640"
+
+entities:
+  - entity: fan
+    translation_key: fan_with_presets
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 3
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: ordinary
+            value: normal
+          - dps_val: nature
+            value: nature
+          - dps_val: sleep
+            value: sleep
+      - id: 2
+        type: integer
+        name: speed
+        range:
+          min: 1
+          max: 3
+          step: 1
+      - id: 5
+        type: boolean
+        name: oscillate
+
+  - entity: switch
+    name: Cooling
+    icon: mdi:snowflake
+    dps:
+      - id: 11
+        type: boolean
+        name: switch
+        
+  # This is labelled as "panel light" in Tuya but actually silences 
+  - entity: switch
+    name: Silence
+    icon: mdi:volume-off
+    dps:
+      - id: 12
+        type: boolean
+        name: switch
+
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 13
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 24


### PR DESCRIPTION
This is a straightforward implementation for the Princess Smart Air Cooler.

Tuya lists DP 12 and calls it "light", but this actually puts the machine into a silence mode whereby pressing the controls doesn't cause a beep to be emitted.