### PR TITLE
Add device: Steinbach Silent Mini Heatpump

### DIFF
--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -1,0 +1,187 @@
+name: Steinbach Silent Mini Heatpump
+products:
+  - manufacturer: Steinbach
+    model: Silent Mini
+
+entities:
+  # Main-Entity: Climate
+  - entity: climate
+    translation_key: pool_heatpump
+    icon: mdi:heat-pump
+    dps:  
+      # DP1 = Power (On/Off)
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "Heating"
+                value: heat
+              - dps_val: "Cooling"
+                value: cool
+      
+      # DP4 supporting DP for dp1 constraint
+      - id: 4
+        type: string
+        name: mode
+  
+      # DP2 = target temperature (°C, integer)
+      - id: 2
+        type: integer
+        name: temperature
+        unit: "°C"
+        range:
+          min: 10
+          max: 45
+        step: 1
+  
+      # DP3 = Current Temperature (°C)
+      - id: 3
+        type: integer
+        name: current_temperature
+        unit: "°C"
+
+      - id: 13
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: "c"
+            value: C
+          - dps_val: "f"
+            value: F
+
+  - entity: switch
+    name: Power
+    icon: mdi:power
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+
+  - entity: select
+    name: Operation mode
+    icon: mdi:cached
+    dps:
+      - id: 4
+        type: string
+        option: operation_mode
+        mapping:
+          - dps_val: "Heating"
+            value: heat
+          - dps_val: "Cooling"
+            value: cool
+
+  - entity: sensor
+    name: Target temperature
+    class: temperature
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: "°C"
+
+  - entity: sensor
+    name: Current temperature
+    class: temperature
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        unit: "°C"
+
+  - entity: sensor
+    name: DP21 Fault code (raw)
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+
+  # - entity: sensor
+  #   name: Water temperature
+  #   class: temperature
+  #   hidden: yes
+  #   dps:
+  #     - id: 101
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+
+  # - entity: sensor
+  #   name: DP102 Ambient? temperature
+  #   class: temperature
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 102
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+
+  # - entity: sensor
+  #   name: DP103 Coil? temperature
+  #   class: temperature
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 103
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+
+  # - entity: sensor
+  #   name: DP104 Compressor? temperature
+  #   class: temperature
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 104
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+
+  # - entity: sensor
+  #   name: DP105 Unknown raw
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 105
+  #       type: integer
+  #       name: sensor
+
+  # - entity: sensor
+  #   name: DP106 Coil(aux)? temperature
+  #   class: temperature
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 106
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+
+  # - entity: sensor
+  #   name: DP107 Temperatur Kompressor Austritt?
+  #   class: temperature
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 107
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+
+  # - entity: sensor
+  #   name: DP108 TargetSetpoint? (0.1°C)
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 108
+  #       type: integer
+  #       name: sensor
+  #       unit: "°C"
+  #       scale: 10

--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -40,7 +40,6 @@ entities:
         range:
           min: 10
           max: 45
-        step: 1
 
       # DP3 = Current Temperature (°C)
       - id: 3

--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -10,7 +10,7 @@ entities:
   - entity: climate
     translation_key: pool_heatpump
     icon: mdi:heat-pump
-    dps:  
+    dps:
       # DP1 = Power (On/Off)
       - id: 1
         type: boolean
@@ -25,12 +25,12 @@ entities:
                 value: heat
               - dps_val: "Cooling"
                 value: cool
-      
+
       # DP4 supporting DP for dp1 constraint
       - id: 4
         type: string
         name: mode
-  
+
       # DP2 = target temperature (°C, integer)
       - id: 2
         type: integer
@@ -40,7 +40,7 @@ entities:
           min: 10
           max: 45
         step: 1
-  
+
       # DP3 = Current Temperature (°C)
       - id: 3
         type: integer
@@ -102,88 +102,87 @@ entities:
       - id: 21
         type: bitfield
         name: sensor
+# - entity: sensor
+#   name: Water temperature
+#   class: temperature
+#   hidden: yes
+#   dps:
+#     - id: 101
+#       type: integer
+#       name: sensor
+#       unit: "°C"
 
-  # - entity: sensor
-  #   name: Water temperature
-  #   class: temperature
-  #   hidden: yes
-  #   dps:
-  #     - id: 101
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
+# - entity: sensor
+#   name: DP102 Ambient? temperature
+#   class: temperature
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 102
+#       type: integer
+#       name: sensor
+#       unit: "°C"
 
-  # - entity: sensor
-  #   name: DP102 Ambient? temperature
-  #   class: temperature
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 102
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
+# - entity: sensor
+#   name: DP103 Coil? temperature
+#   class: temperature
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 103
+#       type: integer
+#       name: sensor
+#       unit: "°C"
 
-  # - entity: sensor
-  #   name: DP103 Coil? temperature
-  #   class: temperature
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 103
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
+# - entity: sensor
+#   name: DP104 Compressor? temperature
+#   class: temperature
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 104
+#       type: integer
+#       name: sensor
+#       unit: "°C"
 
-  # - entity: sensor
-  #   name: DP104 Compressor? temperature
-  #   class: temperature
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 104
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
+# - entity: sensor
+#   name: DP105 Unknown raw
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 105
+#       type: integer
+#       name: sensor
 
-  # - entity: sensor
-  #   name: DP105 Unknown raw
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 105
-  #       type: integer
-  #       name: sensor
+# - entity: sensor
+#   name: DP106 Coil(aux)? temperature
+#   class: temperature
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 106
+#       type: integer
+#       name: sensor
+#       unit: "°C"
 
-  # - entity: sensor
-  #   name: DP106 Coil(aux)? temperature
-  #   class: temperature
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 106
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
+# - entity: sensor
+#   name: DP107 Temperatur Kompressor Austritt?
+#   class: temperature
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 107
+#       type: integer
+#       name: sensor
+#       unit: "°C"
 
-  # - entity: sensor
-  #   name: DP107 Temperatur Kompressor Austritt?
-  #   class: temperature
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 107
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
-
-  # - entity: sensor
-  #   name: DP108 TargetSetpoint? (0.1°C)
-  #   category: diagnostic
-  #   hidden: yes
-  #   dps:
-  #     - id: 108
-  #       type: integer
-  #       name: sensor
-  #       unit: "°C"
-  #       scale: 10
+# - entity: sensor
+#   name: DP108 TargetSetpoint? (0.1°C)
+#   category: diagnostic
+#   hidden: yes
+#   dps:
+#     - id: 108
+#       type: integer
+#       name: sensor
+#       unit: "°C"
+#       scale: 10

--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -64,7 +64,7 @@ entities:
   - entity: sensor
     name: Water temperature
     class: temperature
-    hidden: yes
+    hidden: true
     dps:
       - id: 101
         type: integer
@@ -81,7 +81,7 @@ entities:
     name: Ambient temperature
     class: temperature
     category: diagnostic
-    hidden: yes
+    hidden: true
     dps:
       - id: 102
         type: integer
@@ -98,7 +98,7 @@ entities:
     name: Coil temperature
     class: temperature
     category: diagnostic
-    hidden: yes
+    hidden: true
     dps:
       - id: 103
         type: integer
@@ -115,7 +115,7 @@ entities:
     name: Compressor temperature
     class: temperature
     category: diagnostic
-    hidden: yes
+    hidden: true
     dps:
       - id: 104
         type: integer
@@ -131,7 +131,7 @@ entities:
   # - entity: sensor
   #   name: DP105 Unknown raw
   #   category: diagnostic
-  #   hidden: yes
+  #   hidden: true
   #   dps:
   #     - id: 105
   #       type: base64
@@ -141,7 +141,7 @@ entities:
     name: Aux coil temperature
     class: temperature
     category: diagnostic
-    hidden: yes
+    hidden: true
     dps:
       - id: 106
         type: integer
@@ -158,7 +158,7 @@ entities:
     name: Outlet temperature
     class: temperature
     category: diagnostic
-    hidden: yes
+    hidden: true
     dps:
       - id: 107
         type: integer
@@ -170,11 +170,11 @@ entities:
         mapping:
           - dps_val: f
             value: F
-          ^ value: C
+          - value: C
   - entity: sensor
     name: Target setpoint
     category: diagnostic
-    hidden: yes
+    hidden: true
     dps:
       - id: 108
         type: integer

--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -4,6 +4,7 @@ name: Steinbach Silent Mini Heatpump
 products:
   - manufacturer: Steinbach
     model: Silent Mini
+    id: QR46359
 
 entities:
   # Main-Entity: Climate

--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -1,3 +1,5 @@
+# Connection: local tuya, protocol versio: 3.4
+
 name: Steinbach Silent Mini Heatpump
 products:
   - manufacturer: Steinbach
@@ -68,12 +70,12 @@ entities:
     dps:
       - id: 4
         type: string
-        option: operation_mode
+        name: option
         mapping:
           - dps_val: "Heating"
-            value: heat
+            value: Heating
           - dps_val: "Cooling"
-            value: cool
+            value: Cooling
 
   - entity: sensor
     name: Target temperature

--- a/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml
@@ -1,18 +1,13 @@
-# Connection: local tuya, protocol versio: 3.4
-
-name: Steinbach Silent Mini Heatpump
-products:
-  - manufacturer: Steinbach
-    model: Silent Mini
-    id: QR46359
-
+name: Heatpump
+# products:
+#   - manufacturer: Steinbach
+#     model: Silent Mini
+#     id: QR46359
 entities:
-  # Main-Entity: Climate
   - entity: climate
     translation_key: pool_heatpump
     icon: mdi:heat-pump
     dps:
-      # DP1 = Power (On/Off)
       - id: 1
         type: boolean
         name: hvac_mode
@@ -26,163 +21,165 @@ entities:
                 value: heat
               - dps_val: "Cooling"
                 value: cool
-
-      # DP4 supporting DP for dp1 constraint
       - id: 4
         type: string
         name: mode
-
-      # DP2 = target temperature (°C, integer)
       - id: 2
         type: integer
         name: temperature
-        unit: "°C"
         range:
           min: 10
           max: 45
-
-      # DP3 = Current Temperature (°C)
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                range:
+                  min: 50
+                  max: 113
       - id: 3
         type: integer
         name: current_temperature
-        unit: "°C"
-
       - id: 13
         type: string
         name: temperature_unit
         mapping:
-          - dps_val: "c"
-            value: C
-          - dps_val: "f"
+          - dps_val: f
             value: F
-
-  - entity: switch
-    name: Power
-    icon: mdi:power
-    dps:
-      - id: 1
-        type: boolean
-        name: switch
-
-  - entity: select
-    name: Operation mode
-    icon: mdi:cached
-    dps:
-      - id: 4
-        type: string
-        name: option
-        mapping:
-          - dps_val: "Heating"
-            value: Heating
-          - dps_val: "Cooling"
-            value: Cooling
-
-  - entity: sensor
-    name: Target temperature
-    class: temperature
-    dps:
-      - id: 2
-        type: integer
-        name: sensor
-        unit: "°C"
-
-  - entity: sensor
-    name: Current temperature
-    class: temperature
-    dps:
-      - id: 3
-        type: integer
-        name: sensor
-        unit: "°C"
-
-  - entity: sensor
-    name: DP21 Fault code (raw)
+          - value: C
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
     dps:
       - id: 21
         type: bitfield
         name: sensor
-# - entity: sensor
-#   name: Water temperature
-#   class: temperature
-#   hidden: yes
-#   dps:
-#     - id: 101
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-
-# - entity: sensor
-#   name: DP102 Ambient? temperature
-#   class: temperature
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 102
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-
-# - entity: sensor
-#   name: DP103 Coil? temperature
-#   class: temperature
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 103
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-
-# - entity: sensor
-#   name: DP104 Compressor? temperature
-#   class: temperature
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 104
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-
-# - entity: sensor
-#   name: DP105 Unknown raw
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 105
-#       type: integer
-#       name: sensor
-
-# - entity: sensor
-#   name: DP106 Coil(aux)? temperature
-#   class: temperature
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 106
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-
-# - entity: sensor
-#   name: DP107 Temperatur Kompressor Austritt?
-#   class: temperature
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 107
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-
-# - entity: sensor
-#   name: DP108 TargetSetpoint? (0.1°C)
-#   category: diagnostic
-#   hidden: yes
-#   dps:
-#     - id: 108
-#       type: integer
-#       name: sensor
-#       unit: "°C"
-#       scale: 10
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Water temperature
+    class: temperature
+    hidden: yes
+    dps:
+      - id: 101
+        type: integer
+        optional: true
+        name: sensor
+      - id: 13
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Ambient temperature
+    class: temperature
+    category: diagnostic
+    hidden: yes
+    dps:
+      - id: 102
+        type: integer
+        optional: true
+        name: sensor
+      - id: 13
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Coil temperature
+    class: temperature
+    category: diagnostic
+    hidden: yes
+    dps:
+      - id: 103
+        type: integer
+        optional: true
+        name: sensor
+      - id: 13
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Compressor temperature
+    class: temperature
+    category: diagnostic
+    hidden: yes
+    dps:
+      - id: 104
+        type: integer
+        optional: true
+        name: sensor
+      - id: 13
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  # - entity: sensor
+  #   name: DP105 Unknown raw
+  #   category: diagnostic
+  #   hidden: yes
+  #   dps:
+  #     - id: 105
+  #       type: base64
+  #       optional: true
+  #       name: sensor
+  - entity: sensor
+    name: Aux coil temperature
+    class: temperature
+    category: diagnostic
+    hidden: yes
+    dps:
+      - id: 106
+        type: integer
+        optional: true
+        name: sensor
+      - id: 13
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
+  - entity: sensor
+    name: Outlet temperature
+    class: temperature
+    category: diagnostic
+    hidden: yes
+    dps:
+      - id: 107
+        type: integer
+        optional: true
+        name: sensor
+      - id: 13
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          ^ value: C
+  - entity: sensor
+    name: Target setpoint
+    category: diagnostic
+    hidden: yes
+    dps:
+      - id: 108
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°"
+        mapping:
+          - scale: 10

--- a/custom_components/tuya_local/devices/tongou_sa1_wifi_energy_meter.yaml
+++ b/custom_components/tuya_local/devices/tongou_sa1_wifi_energy_meter.yaml
@@ -136,3 +136,10 @@ entities:
         range:
           min: 0
           max: 999999
+      - id: 11
+        type: boolean
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false


### PR DESCRIPTION
**Brand/Model**: Steinbach Silent Mini Heatpump
**Category**: Climate (pool heat pump)
**File**: custom_components/tuya_local/devices/steinbach_silent_mini_heatpump.yaml

**Tested on**: Home Assistant 2025.7.1, tuya-local 2025.8.0
**Connection**: LocalTuya (LAN), Version 3.4

**DP Map**
- DP1 boolean: Power / hvac_mode (off/heat/cool via constraint on DP4)
- DP2 int: Target temperature (°C)
- DP3 int: Current water temperature (°C)
- DP4 string: Mode ("Heating"/"Cooling")
- DP13 string: Temperature unit ("c"/"f")
- DP21 bitfield: Fault code (raw) — Bit 256 = "no flow"
- DP101–108 integers: Diagnostics (see comments in YAML)

**Notes**
- Device stores separate setpoints per mode internally; DP2 exposes only the active one.
- Added fault bitfield (DP21) as diagnostic sensor; users can template a binary_sensor for "no flow".
- Icons and entity names follow HA style.

**Screenshots**
<img width="353" height="752" alt="grafik" src="https://github.com/user-attachments/assets/6f149809-472f-4482-8c61-749132f4ae14" />

<img width="561" height="728" alt="grafik" src="https://github.com/user-attachments/assets/8c348b27-1297-4c4f-8cb2-159454931add" />


**Checklist**
- [x] YAML validates & loads
- [x] Entities appear and work: mode, setpoint, temps
- [x] No HA log errors/warnings from tuya_local
