### PR TITLE
Add device: Kaisai Pro Heat+ Air Conditioner

### DIFF
--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -1,0 +1,52 @@
+name: "Air conditioner"
+products:
+  - id: nn2ooaacswz6uyi0
+    manufacturer: Kaisai
+    model: Pro Heat+ AC
+
+entities:
+  - entity: climate
+    name: "HVAC"
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "0"
+                value: auto
+              - dps_val: "1"
+                value: cool
+              - dps_val: "2"
+                value: dry
+              - dps_val: "3"
+                value: fan_only
+              - dps_val: "4"
+                value: heat
+
+      - id: 4
+        name: mode
+        type: string
+        hidden: true
+
+      - id: 2
+        name: temperature
+        type: integer
+        unit: "°C"
+        range:
+          min: 1600
+          max: 3100
+        mapping:
+          - scale: 100
+            step: 50
+
+      - id: 3
+        name: current_temperature
+        type: integer
+        unit: "°C"
+        mapping:
+          - scale: 100

--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -1,12 +1,10 @@
-name: "Air conditioner"
+name: Air conditioner
 products:
   - id: nn2ooaacswz6uyi0
     manufacturer: Kaisai
     model: Pro Heat+ AC
-
 entities:
   - entity: climate
-    name: "HVAC"
     dps:
       - id: 1
         name: hvac_mode
@@ -27,12 +25,10 @@ entities:
                 value: fan_only
               - dps_val: "4"
                 value: heat
-
       - id: 4
         name: mode
         type: string
         hidden: true
-
       - id: 2
         name: temperature
         type: integer
@@ -43,15 +39,12 @@ entities:
         mapping:
           - scale: 100
             step: 50
-
       - id: 3
         name: current_temperature
         type: integer
         unit: C
-        readonly: true
         mapping:
           - scale: 100
-
       - id: 5
         name: fan_mode
         type: string
@@ -59,48 +52,46 @@ entities:
           - constraint: auto_fan
             conditions:
               - dps_val: true
-                value: "auto"
+                value: auto
           - dps_val: "1"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "quiet"
+                value: quiet
           - dps_val: "2"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "low"
+                value: low
           - dps_val: "3"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "medium_low"
+                value: medium_low
           - dps_val: "4"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "medium"
+                value: medium
           - dps_val: "5"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "medium_high"
+                value: medium_high
           - dps_val: "6"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "high"
+                value: high
           - dps_val: "7"
             constraint: auto_fan
             conditions:
               - dps_val: false
-                value: "turbo"
-
+                value: turbo
       - id: 7
         name: auto_fan
         type: boolean
         hidden: true
-
       - id: 31
         name: swing_mode
         type: string
@@ -108,22 +99,21 @@ entities:
           - dps_val: "0"
             value: "off"
           - dps_val: "1"
-            value: "vertical"
+            value: vertical
           - dps_val: "2"
-            value: "up"
+            value: up
           - dps_val: "3"
-            value: "down"
+            value: down
           - dps_val: "9"
-            value: "up_fixed"
+            value: up_fixed
           - dps_val: "10"
-            value: "up_offset_fixed"
+            value: up_offset_fixed
           - dps_val: "11"
-            value: "middle_fixed"
+            value: middle_fixed
           - dps_val: "12"
-            value: "down_offset_fixed"
+            value: down_offset_fixed
           - dps_val: "13"
-            value: "down_fixed"
-
+            value: down_fixed
       - id: 34
         name: swing_horizontal_mode
         type: string
@@ -131,48 +121,48 @@ entities:
           - dps_val: "0"
             value: "off"
           - dps_val: "1"
-            value: "horizontal"
+            value: horizontal
           - dps_val: "2"
-            value: "left"
+            value: left
           - dps_val: "3"
-            value: "center"
+            value: center
           - dps_val: "4"
-            value: "right"
+            value: right
           - dps_val: "9"
-            value: "left_fixed"
+            value: left_fixed
           - dps_val: "10"
-            value: "left_offset_fixed"
+            value: left_offset_fixed
           - dps_val: "11"
-            value: "center_fixed"
+            value: center_fixed
           - dps_val: "12"
-            value: "right_offset_fixed"
+            value: right_offset_fixed
           - dps_val: "13"
-            value: "right_fixed"
-
+            value: right_fixed
       - id: 8
         name: preset_mode
         type: boolean
+        optional: true
         mapping:
           - dps_val: false
-            value: "none"
+            value: none
           - dps_val: true
-            value: "eco"
-
+            value: eco
+          - dps_value: null
+            value: none
+            hidden: true
   - entity: sensor
-    name: "Outdoor Temperature"
+    name: Outdoor temperature
     class: temperature
     dps:
       - id: 116
         name: sensor
         type: integer
         unit: C
-        readonly: true
         optional: true
         mapping:
           - scale: 100
 
   - entity: sensor
-    name: "Electricity Usage"
     class: energy
     dps:
       - id: 127
@@ -180,37 +170,34 @@ entities:
         type: integer
         unit: kWh
         class: total_increasing
-        readonly: true
         optional: true
         mapping:
           - scale: 100
 
   - entity: sensor
-    name: "External Fan Speed"
+    name: External fan speed
     dps:
       - id: 117
         name: sensor
         type: integer
         unit: rpm
-        readonly: true
         optional: true
 
   - entity: sensor
-    name: "Compressor Frequency"
+    name: Compressor frequency
+    class: frequency
     dps:
       - id: 119
         name: sensor
         type: integer
         unit: Hz
-        readonly: true
         optional: true
 
   - entity: binary_sensor
-    name: "Filter Block Status"
+    name: Filter blockage
     class: problem
     dps:
       - id: 110
         name: sensor
         type: boolean
-        readonly: true
         optional: true

--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -36,7 +36,7 @@ entities:
       - id: 2
         name: temperature
         type: integer
-        unit: "°C"
+        unit: C
         range:
           min: 1600
           max: 3100
@@ -47,6 +47,172 @@ entities:
       - id: 3
         name: current_temperature
         type: integer
-        unit: "°C"
+        unit: C
+        readonly: true
         mapping:
           - scale: 100
+
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          # When auto_fan (DP 7) is true, show as auto regardless of manual speed setting
+          - constraint: auto_fan
+            conditions:
+              - dps_val: true
+                value: "auto"
+          # When auto_fan is false, use manual speed settings
+          - dps_val: "1"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "quiet"
+          - dps_val: "2"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "low"
+          - dps_val: "3"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "medium_low"
+          - dps_val: "4"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "medium"
+          - dps_val: "5"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "medium_high"
+          - dps_val: "6"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "high"
+          - dps_val: "7"
+            constraint: auto_fan
+            conditions:
+              - dps_val: false
+                value: "turbo"
+
+      - id: 7
+        name: auto_fan
+        type: boolean
+        hidden: true
+
+      - id: 31
+        name: swing_mode
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "vertical"
+          - dps_val: "2"
+            value: "up"
+          - dps_val: "3"
+            value: "down"
+          - dps_val: "9"
+            value: "up_fixed"
+          - dps_val: "10"
+            value: "up_offset_fixed"
+          - dps_val: "11"
+            value: "middle_fixed"
+          - dps_val: "12"
+            value: "down_offset_fixed"
+          - dps_val: "13"
+            value: "down_fixed"
+
+      - id: 34
+        name: swing_horizontal_mode
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "horizontal"
+          - dps_val: "2"
+            value: "left"
+          - dps_val: "3"
+            value: "center"
+          - dps_val: "4"
+            value: "right"
+          - dps_val: "9"
+            value: "left_fixed"
+          - dps_val: "10"
+            value: "left_offset_fixed"
+          - dps_val: "11"
+            value: "center_fixed"
+          - dps_val: "12"
+            value: "right_offset_fixed"
+          - dps_val: "13"
+            value: "right_fixed"
+
+      - id: 8
+        name: preset_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "none"
+          - dps_val: true
+            value: "eco"
+
+  - entity: sensor
+    name: "Outdoor Temperature"
+    class: temperature
+    dps:
+      - id: 116
+        name: sensor
+        type: integer
+        unit: C
+        readonly: true
+        optional: true
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: "Electricity Usage"
+    class: energy
+    dps:
+      - id: 127
+        name: sensor
+        type: integer
+        unit: kWh
+        class: total_increasing
+        readonly: true
+        optional: true
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: "External Fan Speed"
+    dps:
+      - id: 117
+        name: sensor
+        type: integer
+        unit: rpm
+        readonly: true
+        optional: true
+
+  - entity: sensor
+    name: "Compressor Frequency"
+    dps:
+      - id: 119
+        name: sensor
+        type: integer
+        unit: Hz
+        readonly: true
+        optional: true
+
+  - entity: binary_sensor
+    name: "Filter Block Status"
+    class: problem
+    dps:
+      - id: 110
+        name: sensor
+        type: boolean
+        readonly: true
+        optional: true

--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -147,7 +147,7 @@ entities:
             value: none
           - dps_val: true
             value: eco
-          - dps_value: null
+          - dps_val: null
             value: none
             hidden: true
   - entity: sensor

--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -56,12 +56,10 @@ entities:
         name: fan_mode
         type: string
         mapping:
-          # When auto_fan (DP 7) is true, show as auto regardless of manual speed setting
           - constraint: auto_fan
             conditions:
               - dps_val: true
                 value: "auto"
-          # When auto_fan is false, use manual speed settings
           - dps_val: "1"
             constraint: auto_fan
             conditions:


### PR DESCRIPTION
Add support for Kaisai Pro Heat+ split air conditioner.

**Device and Climate Entity Support**
- `climate` entity with support for:
  - HVAC mode
  -  set temperature 
  - current temperature
  - fan mode (including auto/manual speeds) 
  - swing modes (vertical and horizontal)
  - eco mode
- `sensor` entities for:
  - outdoor temperature
  - electricity usage (energy)
  - external fan speed
  - compressor frequency
- `binary` sensor for: 
  - filter block status allowing detection of maintenance issues

Note: not all entities are mapped, some were left out of scope like advanced heat settings, smart wind and power source detection. I aimed to map most important AC features.

Support request: https://github.com/make-all/tuya-local/issues/3695.

Tested using local device.

<img width="1568" height="1056" alt="Screenshot 2025-09-08 at 15 22 45" src="https://github.com/user-attachments/assets/3fd85a20-d49c-4488-9123-b52cd9b05b24" />

<img width="1568" height="1056" alt="Screenshot 2025-09-08 at 15 22 54" src="https://github.com/user-attachments/assets/a6008493-f48d-4e43-a035-6d9401302414" />

