### PR TITLE
Update geyserwise_water_heater.yaml - added Current Temperature to Diagnostic category 

### DIFF
--- a/custom_components/tuya_local/devices/geyserwise_water_heater.yaml
+++ b/custom_components/tuya_local/devices/geyserwise_water_heater.yaml
@@ -194,3 +194,15 @@ entities:
         optional: true
         unit: C
         class: measurement
+
+  - entity: sensor
+    name: Current temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement

--- a/tests/devices/test_moebot.py
+++ b/tests/devices/test_moebot.py
@@ -44,7 +44,7 @@ class TestMoebot(TuyaDeviceTestCase):
                 "binary_sensor_problem",
                 "select_mowing_mode",
                 "sensor_problem",
-                "switch.backward_blade_stop",
+                "switch_backward_blade_stop",
                 "switch_rain_mode",
                 "number_running_time",
                 "button_clear_schedule",


### PR DESCRIPTION
Update geyserwise_water_heater.yaml to add Current Temperature to the Diagnostic category

This makes the Current temperature available outside the  water heater entity  