### PR TITLE
Add Insoma Water Timer Valve

### DIFF
--- a/custom_components/tuya_local/devices/insoma_water_timer_valve.yaml
+++ b/custom_components/tuya_local/devices/insoma_water_timer_valve.yaml
@@ -1,0 +1,85 @@
+name: Insoma Water Timer Valve
+products:
+  - id: nxquc5lb
+    model: SOP10
+    manufacturer: Insoma
+entities:
+  - entity: valve
+    class: water
+    dps:
+      - id: 1
+        type: boolean
+        name: valve
+      - id: 13
+        type: string
+        name: weather
+        optional: true
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Operation
+    category: diagnostic
+    dps:
+      - id: 12
+        type: string
+        name: sensor
+  - entity: sensor
+    name: Accumulated use time
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: s
+  - entity: sensor
+    name: Last use time
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 15
+        type: integer
+        name: sensor
+        unit: s
+        optional: true
+  - entity: select
+    name: Weather delay
+    translation_key: timer
+    icon: "mdi:weather-cloudy-clock"
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: "24h"
+            value: "24h"
+          - dps_val: "48h"
+            value: "48h"
+          - dps_val: "72h"
+            value: "72h"
+  - entity: number
+    name: Irrigation time
+    category: config
+    class: duration
+    translation_key: timer
+    dps:
+      - id: 11
+        type: integer
+        name: value
+        unit: min
+        optional: true
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60


### PR DESCRIPTION
### Summary

Added support for **Insoma Smart Water Timer Valve**.  
Product link: [Amazon](https://a.co/d/8ybD4vM)

Although this device is similar to other water timers, it did not work correctly with the existing `ble_water_valve.yaml` configuration.

### Why a new configuration was needed

The existing `ble_water_valve.yaml` did not fully support this model:

- Switch state was unreliable (did not always turn on or reflect the actual device state)  
- Irrigation time always reset to 0 minutes  
- Time values using AM/PM were not valid for this device  

### Insoma Smart Water Timer DP Mapping

| DP ID | Code                 | Type     | Unit | Min     | Max     | Step | Options                       |
|-------|----------------------|----------|------|---------|---------|------|-------------------------------|
| 1     | `switch`             | Boolean  | –    | –       | –       | –    | –                             |
| 7     | `battery_percentage` | Integer  | %    | 0       | 100     | 1    | –                             |
| 9     | `time_use`           | Integer  | s    | 0       | 2,592,000 | 1  | –                             |
| 10    | `weather_delay`      | Enum     | –    | –       | –       | –    | `cancel`, `24h`, `48h`, `72h` |
| 11    | `countdown`          | Integer  | s    | 0       | 86,400  | 1    | –                             |
| 12    | `work_state`         | Enum     | –    | –       | –       | –    | `auto`, `manual`, `idle`      |
| 13    | `smart_weather`      | Enum     | –    | –       | –       | –    | `sunny`, `cloudy`, `rainy`    |
| 15    | `use_time_one`       | Integer  | s    | 0       | 86,400  | 1    | –                             |
