### PR TITLE
Update dewin_kws306wf_energymeter.yaml

### DIFF
--- a/custom_components/tuya_local/devices/dewin_kws306wf_energymeter.yaml
+++ b/custom_components/tuya_local/devices/dewin_kws306wf_energymeter.yaml
@@ -13,7 +13,7 @@ entities:
         optional: true
         name: sensor
         unit: kWh
-        class: measurement
+        class: total_increasing
         mapping:
           - scale: 100
           - dps_val: null
@@ -107,7 +107,7 @@ entities:
         optional: true
         name: sensor
         unit: kWh
-        class: measurement
+        class: total_increasing
         mapping:
           - scale: 100
           - dps_val: null
@@ -141,7 +141,7 @@ entities:
         optional: true
         name: sensor
         unit: kWh
-        class: measurement
+        class: total_increasing
         mapping:
           - scale: 100
           - dps_val: null
@@ -164,7 +164,7 @@ entities:
         optional: true
         name: sensor
         unit: kWh
-        class: measurement
+        class: total_increasing
         mapping:
           - scale: 100
           - dps_val: null
@@ -175,19 +175,16 @@ entities:
         name: alt
         mapping:
           - scale: 100
-  - entity: number
+  - entity: sensor
     name: Run time
     class: duration
-    category: config
+    category: diagnostic
     dps:
       - id: 106
         type: integer
         optional: true
-        name: value
+        name: sensor
         unit: min
-        range:
-          min: 0
-          max: 10000000
   - entity: sensor
     class: frequency
     category: diagnostic


### PR DESCRIPTION
Two issues fixed:

1. Energy consumption sensor is not compatible with Energy dashboard in HA. When Energy dashboard is configured with Energy sensor, no energy consumption is being shown. Warning message in HA UI:

```
Last reset missing
The following entities have state class 'measurement' but 'last_reset' is missing:
sensor.kws_306wf_energy
```

Additionally all four energy sensors generate warnings in log:

```
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.kws_306wf_energy (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using state class 'measurement' which is impossible considering device class ('energy') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.kws_306wf_energy_consumed_a (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using state class 'measurement' which is impossible considering device class ('energy') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.kws_306wf_energy_consumed_b (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using state class 'measurement' which is impossible considering device class ('energy') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.kws_306wf_energy_consumed_c (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using state class 'measurement' which is impossible considering device class ('energy') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues
```

FIX: changed class to 'total_increasing' in all four energy sensors

2. Run time - configured as number in config section. Since this DP is providing a total number of minutes since last startup, I suggest to configure it as a read only sensor in diagnostic category.

FIX: changed entity from 'number' to 'sensor' and category from 'config' to 'diagnostic'.