### PR TITLE
Added definitions for SmartKnight ML Accessories Ltd Smart Socket

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -590,7 +590,7 @@ the best option.
 - DIGOO DG-SP202 dual smartplug with energy monitoring and timers
 - DIGOO DG-SP01 USB smartplug with night light
 - Dual power monitoring smartplug (Geex)
-- Dual power monitoring smartplug v2 (Smatrul, Deltaco)
+- Dual power monitoring smartplug v2 (Smatrul, Deltaco, Knightsbridge)
 - Eightree ET43 3-outlet powerstrip with energy monitoring
 - ES01 3 outlet + USB powerstrip with individual timers
 - ESP Fort EC-SPSP USB and mains smartplug

--- a/custom_components/tuya_local/devices/dual_power_monitor_smartplugv2.yaml
+++ b/custom_components/tuya_local/devices/dual_power_monitor_smartplugv2.yaml
@@ -16,6 +16,10 @@ products:
   - id: r03i57pimbyua3ev
     manufacturer: ARLEC
     model: PC287HA
+  - id: bfjt9eoebwzdypvu
+    manufacturer: SmartKnight ML Accessories Ltd
+    model: Knightsbridge 13A Smart Swtched Socket (2-gang)
+    model_id: SN9KW/CU9KW/OP9KW
 entities:
   - entity: switch
     translation_key: outlet_x


### PR DESCRIPTION
These devices are marketed as "Knightsbridge 13A 2-gang Smart Socket" in the UK.

Just adding the product_id to the correct YAML device file.  I've been testing this for about 72 hours and the energy monitoring appears much more robust using 'Dual power monitoring smartplug v2' than either of the 'Generic smartplug with power monitoring' options, which was the default choice before adding the product_id.

Also updated DEVICES.md to reflect the change.