### PR TITLE
Create neopower_heat_pump_water_heater.yaml

### DIFF
--- a/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
@@ -1,4 +1,8 @@
-name: Neopower All in One Heat Pump
+name: Water heat pump
+products:
+  - id: opugd8qgpbqbcizu
+    manufacturer: Neopower
+    model: Black Diamond all-in-one
 entities:
   - entity: water_heater
     dps:
@@ -30,12 +34,16 @@ entities:
         range:
           min: 15
           max: 75
-      - id: 7
-        type: boolean
-        name: defrosting
       - id: 16
         type: integer
         name: current_temperature
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 7
+        type: boolean
+        name: sensor
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -50,47 +58,63 @@ entities:
       - id: 15
         type: bitfield
         name: fault_code
+  - entity: binary_sensor
+    name: Element
+    class: running
+    category: diagnostic
+    icon: "mdi:heating-coil"
+    dps:
       - id: 32
         type: boolean
-        name: ele_heating_state
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            value: "on"
+        name: sensor
+  - entity: binary_sensor
+    name: Compressor
+    class: running
+    category: diagnostic
+    dps:
       - id: 27
         type: boolean
-        name: compressor_state
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            value: "on"
-      - id: 7
-        type: boolean
-        name: defrost_state
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            value: "on"
+        name: sensor
+  - entity: sensor
+    name: Vent temperature
+    class: temperature
+    category: diagnostic
+    dps:
       - id: 24
         type: integer
-        name: venting_temp
+        name: sensor
+        unit: C
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
       - id: 18
         type: integer
-        name: power_consumption
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Top temperature
+    class: temperature
+    category: diagnostic
+    dps:
       - id: 21
         type: integer
-        name: temp_top
+        name: sensor
+        unit: C
+  - entity: sensor
+    name: Bottom temperature
+    class: temperature
+    category: diagnostic
+    dps:
       - id: 22
         type: integer
-        name: temp_bottom
+        name: sensor
+        unit: C
+  - entity: binary_sensor
+    class: opening
+    name: Four-way valve
+    category: diagnostic
+    dps:
       - id: 28
         type: boolean
-        name: four_valve_state
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            value: "on"
+        name: sensor


### PR DESCRIPTION
Modified from the Aquatech RAPID/X6 device which partially worked, however had some invalid modes like HYB1/Boost. DP ID's changed to suit the neopower heat pump. Successfully working in Home Assistant.
[https://neopower.com.au/all-in-one-heat-pump/](https://neopower.com.au/all-in-one-heat-pump/)


Additional info like ele_heating_state & compressor_state are listed as attributes in the Problem area, but are still exposed to home assistant so can be used for automations. I'm not sure how to make these appear as sensors
<img width="591" height="873" alt="Screenshot 2025-09-30 144652" src="https://github.com/user-attachments/assets/56fa9adf-48c0-40d8-8524-2bafa13d48a3" />

<img width="591" height="849" alt="brave_i5ModPvMZR" src="https://github.com/user-attachments/assets/dbe214fa-13cc-4a2e-84e9-721be4dd34e2" />



Full list of DP ID's are here
[https://github.com/banemonster/neopower_heatpump_tuya/blob/main/neopower_DP_IDs](https://github.com/banemonster/neopower_heatpump_tuya/blob/main/neopower_DP_IDs)
