### PR TITLE
Add device id for Beok SH-TGM50 WP thermostat

### DIFF
--- a/custom_components/tuya_local/devices/beok_tgm50wp_thermostat.yaml
+++ b/custom_components/tuya_local/devices/beok_tgm50wp_thermostat.yaml
@@ -1,0 +1,216 @@
+name: Thermostat
+products:
+  - id: daltzmaeoxybutqs
+    manufacturer: Beok / Avatto
+    model: SH-TGM50 WP
+entities:
+  - entity: climate
+    translation_only_key: thermostat
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            constraint: preset_mode
+            conditions:
+              - dps_val: auto
+                value: auto
+              - dps_val: temporary
+                value: auto
+                hidden: true
+              - dps_val: home
+                value: heat
+              - dps_val: leave
+                value: heat
+                hidden: true
+          - dps_val: false
+            value: "off"
+      - id: 2
+        name: temperature
+        type: integer
+        unit: C
+        range:
+          min: 50
+          max: 950
+        mapping:
+          - scale: 10
+            step: 5
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - scale: 10
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: leave
+            value: away
+          - dps_val: home
+            value: manual
+          - dps_val: auto
+            value: program
+          - dps_val: temporary
+            value: temp_override
+      - id: 5
+        type: string
+        name: hvac_action
+        mapping:
+          - dps_val: "0"
+            value: idle
+          - dps_val: "1"
+            value: heating
+      - id: 15
+        name: max_temperature
+        type: integer
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 9
+        type: boolean
+        name: lock
+  - entity: binary_sensor
+    category: diagnostic
+    class: problem
+    dps:
+      - id: 11
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 11
+        name: fault_code
+        type: bitfield
+  - entity: number
+    name: Temperature hysteresis
+    category: config
+    icon: "mdi:thermometer-plus"
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        unit: °
+        range:
+          min: 5
+          max: 95
+        mapping:
+          - scale: 10
+  - entity: number
+    name: Maximum temperature
+    category: config
+    class: temperature
+    icon: "mdi:thermometer-chevron-up"
+    dps:
+      - id: 15
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 15
+          max: 95
+  - entity: number
+    name: Calibration offset
+    category: config
+    icon: "mdi:arrow-collapse-up"
+    dps:
+      - id: 19
+        type: integer
+        name: value
+        unit: °
+        range:
+          min: -90
+          max: 90
+        mapping:
+          - scale: 10
+  - entity: number
+    name: External temperature limit
+    category: config
+    class: temperature
+    icon: "mdi:arrow-collapse-up"
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 35
+          max: 60
+  - entity: switch
+    translation_key: anti_frost
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: button
+    translation_key: factory_reset
+    category: config
+    dps:
+      - id: 104
+        name: button
+        type: boolean
+  - entity: light
+    translation_key: backlight
+    category: config
+    dps:
+      - id: 106
+        type: string
+        name: brightness
+        mapping:
+          - dps_val: "0"
+            value: 0
+          - dps_val: "1"
+            value: 100
+          - dps_val: "2"
+            value: 180
+          - dps_val: "3"
+            value: 255
+  - entity: number
+    name: Away mode temperature
+    category: config
+    class: temperature
+    icon: "mdi:island"
+    dps:
+      - id: 107
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 0
+          max: 30
+  - entity: switch
+    name: Invert output
+    category: config
+    icon: "mdi:swap-horizontal"
+    dps:
+      - id: 108
+        type: boolean
+        name: switch
+  - entity: select
+    name: Sensor selection
+    category: config
+    icon: "mdi:home-thermometer"
+    dps:
+      - id: 110
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "1"
+            value: Internal
+          - dps_val: "2"
+            value: External
+          - dps_val: "3"
+            value: Both
+  - entity: switch
+    name: Sound
+    category: config
+    icon: "mdi:music-note"
+    dps:
+      - id: 109
+        type: boolean
+        name: switch


### PR DESCRIPTION
Implements: #3799 

Added new device that calls itself a M5-G but is sold and labelled as a [Beok TGM50 WP](https://www.beoks.com/products/Room-Thermostat1/Water-Floor-Heating-Thermostat_1382089.html). It is the same as the existing Beok TGM50 device, except for id:107 which provides the preset away temp instead of the program information. The model I have is specifically the WP (underfloor wet heating) variant, so I assume that's the difference. 

Here are the datapoints reported in the logs:
```{

  "1": true,
  "2": 215,
  "3": 213,
  "4": "auto",
  "5": "0",
  "9": false,
  "11": 0,
  "15": 60,
  "19": -10,
  "101": 5,
  "102": 60,
  "103": false,
  "104": false,
  "106": "0",
  "107": 12,
  "108": false,
  "109": true,
  "110": "1",
  "111": false,
  "28": "BgAAyAgAANcLHgDXDB4A1xIAAL4WAACgBgAAyAgAANcLHgDXDB4A1xIAAL4WAACgBgAAyAgAANcLHgDXDB4A1xIAAL4WAACgBgAAyAgAANcLHgDXDB4A1xIAAL4WAACgBgAAyAgAANcLHgDXDB4A1xIAAL4WAACgBgAAyAgAANcLHgDXDB4A1xIAAL4WAACgBgAAyAgAANcLHgDXDB4A1xIAAL4WAACg",
  "112": "AAAAAA=="
}
```