### PR TITLE
feat (devices): add ELEGRP DTR10 Single Pole 2.4 GHz WiFi Dimmable Switch

### DIFF
--- a/custom_components/tuya_local/devices/elegrp_dtr10_dimmer_switch.yaml
+++ b/custom_components/tuya_local/devices/elegrp_dtr10_dimmer_switch.yaml
@@ -98,14 +98,12 @@ entities:
             value: Slow (15s)
   # Indicator LED converted to light (brightness only)
   - entity: light
-    name: Night indicator light
+    translation_key: indicator
     category: config
-    icon: "mdi:led-on"
     dps:
       - id: 101
         type: integer
         name: brightness
-        unit: "%"
         range:
           min: 0
           max: 100
@@ -157,9 +155,8 @@ entities:
 
   # Timer
   - entity: time
-    name: Timer duration
+    translation_key: timer
     category: config
-    icon: "mdi:timer"
     dps:
       - id: 111
         type: integer
@@ -169,7 +166,7 @@ entities:
           max: 86399
         optional: true
   - entity: select
-    name: Timer auto on mode
+    name: Timer mode
     category: config
     icon: "mdi:timer-cog"
     dps:
@@ -183,8 +180,9 @@ entities:
           - dps_val: true
             value: "On"
   - entity: sensor
-    name: Time remaining
-    icon: "mdi:timer-sand"
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
     dps:
       - id: 6
         type: integer


### PR DESCRIPTION
- Complete device configuration
- Timer system
- Physical interface settings (long press, indicator brightness)
- Tests

Supported features:
- Dimmable light control (DPS 1,2)
- Configurable minimum brightness with app auto-management (DPS 3,114)
- Bulb type selection for optimal dimming (DPS 4)
- Customizable fade on/off speeds (DPS 103,104)
- Long press brightness presets (DPS 108)
- LED indicator brightness control (DPS 101)
- Timer functionality with action selection (DPS 110,111,6)
- Firmware version reporting (DPS 113)