### PR TITLE
Fine tune Lawn Mower devices and moebot/parkside mower

### DIFF
--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -22,7 +22,7 @@ entities:
           - dps_val: EMERGENCY
             value: error
           - dps_val: LOCKED
-            value: docked
+            value: error
           - dps_val: PAUSED
             value: paused
           - dps_val: PARK

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -324,7 +324,7 @@ entities:
           - dps_val: AutoMode
             value: Auto
           - dps_val: GardenMode
-            value: Garde
+            value: Garden
   - entity: binary_sensor
     name: Cover
     category: diagnostic

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -30,7 +30,7 @@ entities:
           - dps_val: CHARGING_WITH_TASK_SUSPEND
             value: docked
           - dps_val: FIXED_MOWING
-            value: mowing
+            value: spot mowing
           - dps_val: ERROR
             value: error
           - dps_val: UPDATA
@@ -45,7 +45,7 @@ entities:
           - dps_val: StartMowing
             value: start_mowing
           - dps_val: StartFixedMowing
-            value: start_mowing
+            value: fixed_mowing
             hidden: true
           - dps_val: PauseWork
             value: pause
@@ -77,6 +77,17 @@ entities:
         name: zones
         optional: true
   - entity: button
+    name: Start mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: StartMowing
+            value: true
+  - entity: button
     name: Start fixed mowing
     icon: "mdi:mower-on"
     dps:
@@ -88,6 +99,17 @@ entities:
           - dps_val: StartFixedMowing
             value: true
   - entity: button
+    name: Pause mowing
+    icon: "mdi:mower"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: PauseWork
+            value: true
+  - entity: button
     name: Cancel mowing
     icon: "mdi:mower"
     dps:
@@ -97,6 +119,17 @@ entities:
         optional: true
         mapping:
           - dps_val: CancelWork
+            value: true
+  - entity: button
+    name: Start docking
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: StartReturnStation
             value: true
   - entity: button
     name: Continue mowing
@@ -228,6 +261,9 @@ entities:
           - dps_val: MOWER_UI_LOCKED
             value: UI locked
             icon: "mdi:hand-back-right-off"
+      - id: 103
+        name: raw_problem
+        type: string
   - entity: switch
     name: Rain mode
     icon: "mdi:weather-pouring"
@@ -288,7 +324,7 @@ entities:
           - dps_val: AutoMode
             value: Auto
           - dps_val: GardenMode
-            value: Garden
+            value: Garde
   - entity: binary_sensor
     name: Cover
     category: diagnostic

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -50,7 +50,7 @@ entities:
           - dps_val: PauseWork
             value: pause
           - dps_val: CancelWork
-            value: pause
+            value: cancel
             hidden: true
           - dps_val: ContinueWork
             value: start_mowing

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -30,7 +30,7 @@ entities:
           - dps_val: CHARGING_WITH_TASK_SUSPEND
             value: docked
           - dps_val: FIXED_MOWING
-            value: spot mowing
+            value: fixed mowing
           - dps_val: ERROR
             value: error
           - dps_val: UPDATA

--- a/custom_components/tuya_local/lawn_mower.py
+++ b/custom_components/tuya_local/lawn_mower.py
@@ -1,6 +1,8 @@
 """
 Setup for different kinds of Tuya lawn mowers
 """
+from enum import IntFlag
+from homeassistant.components.lawn_mower.const import LawnMowerEntityFeature as BaseFeature
 
 from homeassistant.components.lawn_mower import LawnMowerEntity
 from homeassistant.components.lawn_mower.const import (
@@ -8,7 +10,6 @@ from homeassistant.components.lawn_mower.const import (
     SERVICE_PAUSE,
     SERVICE_START_MOWING,
     LawnMowerActivity,
-    LawnMowerEntityFeature,
 )
 
 from .device import TuyaLocalDevice
@@ -19,17 +20,12 @@ from .helpers.device_config import TuyaEntityConfig
 SERVICE_FIXED_MOWING = "fixed_mowing"
 SERVICE_CANCEL = "cancel"
 
-
-from homeassistant.components.lawn_mower.const import LawnMowerEntityFeature as BaseFeature
-from enum import IntFlag
-
 class ExtendedLawnMowerEntityFeature(IntFlag):
     START_MOWING = BaseFeature.START_MOWING
     PAUSE = BaseFeature.PAUSE
     DOCK = BaseFeature.DOCK
     FIXED_MOWING = 8
     CANCEL = 16
-
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     config = {**config_entry.data, **config_entry.options}

--- a/custom_components/tuya_local/lawn_mower.py
+++ b/custom_components/tuya_local/lawn_mower.py
@@ -67,7 +67,7 @@ class TuyaLocalLawnMower(TuyaLocalEntity, LawnMowerEntity):
                 self._attr_supported_features |= ExtendedLawnMowerEntityFeature.PAUSE
             if SERVICE_DOCK in available_commands:
                 self._attr_supported_features |= ExtendedLawnMowerEntityFeature.DOCK
-            if SERVICE_FIXED_MOVING in available_commands:
+            if SERVICE_FIXED_MOWING in available_commands:
                 self._attr_supported_features |= ExtendedLawnMowerEntityFeature.FIXED_MOWING
             if SERVICE_CANCEL in available_commands:
                 self._attr_supported_features |= ExtendedLawnMowerEntityFeature.CANCEL

--- a/custom_components/tuya_local/lawn_mower.py
+++ b/custom_components/tuya_local/lawn_mower.py
@@ -16,6 +16,20 @@ from .entity import TuyaLocalEntity
 from .helpers.config import async_tuya_setup_platform
 from .helpers.device_config import TuyaEntityConfig
 
+SERVICE_FIXED_MOWING = "fixed_mowing"
+SERVICE_CANCEL = "cancel"
+
+
+from homeassistant.components.lawn_mower.const import LawnMowerEntityFeature as BaseFeature
+from enum import IntFlag
+
+class ExtendedLawnMowerEntityFeature(IntFlag):
+    START_MOWING = BaseFeature.START_MOWING
+    PAUSE = BaseFeature.PAUSE
+    DOCK = BaseFeature.DOCK
+    FIXED_MOWING = 8
+    CANCEL = 16
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     config = {**config_entry.data, **config_entry.options}
@@ -26,6 +40,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         "lawn_mower",
         TuyaLocalLawnMower,
     )
+
 
 
 class TuyaLocalLawnMower(TuyaLocalEntity, LawnMowerEntity):
@@ -47,11 +62,17 @@ class TuyaLocalLawnMower(TuyaLocalEntity, LawnMowerEntity):
         if self._command_dp:
             available_commands = self._command_dp.values(self._device)
             if SERVICE_START_MOWING in available_commands:
-                self._attr_supported_features |= LawnMowerEntityFeature.START_MOWING
+                self._attr_supported_features |= ExtendedLawnMowerEntityFeature.START_MOWING
             if SERVICE_PAUSE in available_commands:
-                self._attr_supported_features |= LawnMowerEntityFeature.PAUSE
+                self._attr_supported_features |= ExtendedLawnMowerEntityFeature.PAUSE
             if SERVICE_DOCK in available_commands:
-                self._attr_supported_features |= LawnMowerEntityFeature.DOCK
+                self._attr_supported_features |= ExtendedLawnMowerEntityFeature.DOCK
+            if SERVICE_FIXED_MOVING in available_commands:
+                self._attr_supported_features |= ExtendedLawnMowerEntityFeature.FIXED_MOWING
+            if SERVICE_CANCEL in available_commands:
+                self._attr_supported_features |= ExtendedLawnMowerEntityFeature.CANCEL
+
+
 
     @property
     def activity(self) -> LawnMowerActivity | None:
@@ -72,3 +93,15 @@ class TuyaLocalLawnMower(TuyaLocalEntity, LawnMowerEntity):
         """Stop mowing and return to dock."""
         if self._command_dp:
             await self._command_dp.async_set_value(self._device, SERVICE_DOCK)
+
+    async def async_fixed_mowing(self):
+        """Start spot mowing."""
+        if self._command_dp:
+            await self._command_dp.async_set_value(self._device, SERVICE_FIXED_MOWING)
+
+    async def async_cancel(self):
+        """Cancel lawn mower ongoing task."""
+        if self._command_dp:
+            await self._command_dp.async_set_value(self._device, SERVICE_CANCEL)
+            
+


### PR DESCRIPTION
- Parkside mowers have a cancel feature to interrupt the ongoing task before a new command is issued. (Pause only has transiton to start_mowing/resume.)
- fixed multiple typos/logics
- Added missing Return to dock button
- Implemented spot/fixed mowing functionality by extending the LawnMoverEntityFeature core class
- Add raw text attribute to problem sensor