### PR TITLE
Add Smart Motorized Pop-up Socket

### DIFF
--- a/custom_components/tuya_local/devices/smart_motorized_pop_up_socket.yaml
+++ b/custom_components/tuya_local/devices/smart_motorized_pop_up_socket.yaml
@@ -101,4 +101,3 @@ entities:
             value: "Closing Interrupted"
           - dps_val: "a9"
             value: "Closed"
-


### PR DESCRIPTION
Added support for generic motorized power socket:
![tuya_smart_motorized_pop_up_socket](https://github.com/user-attachments/assets/cef8d575-e65e-40b5-91ac-b47d3257485b)

I wanted to implement it as `cover` entity but was unable to do it properly - commands for each direction are in separate DPS. So I added simple buttons instead. Data model is a mess anyway, none of the descripions match actual device behavior.

I had to use Tuya Developer platform and change `Control Instruction Mode` to `DP Instruction` before receieving Device Data Model since not all commands were visible in tuya-local logs in HA.

<img width="741" height="474" alt="obraz" src="https://github.com/user-attachments/assets/188a8627-9ec9-4372-ab7e-849be1a76118" />


Device Information:
>**Product Name**
智能升降插座
**Device ID**
bfa3f089992fcf874820qj
**Product Category**
clkg

Device Data Model:
```
{
   "modelId":"0000020aop",
   "services":[
      {
         "actions":[
         ],
         "code":"",
         "description":"",
         "events":[
         ],
         "name":"默认服务",
         "properties":[
            {
               "abilityId":1,
               "accessMode":"rw",
               "code":"control",
               "description":"",
               "extensions":{
                  "iconName":"icon-a_power"
               },
               "name":"灯光",
               "typeSpec":{
                  "type":"enum",
                  "range":[
                     "S3",
                     "S2",
                     "S1",
                     "OFF"
                  ]
               }
            },
            {
               "abilityId":3,
               "accessMode":"rw",
               "code":"cur_calibration",
               "description":"",
               "extensions":{
                  "iconName":"icon-dp_loop"
               },
               "name":"电源",
               "typeSpec":{
                  "type":"enum",
                  "range":[
                     "start",
                     "off"
                  ]
               }
            },
            {
               "abilityId":6,
               "accessMode":"rw",
               "code":"cur_calibration_2",
               "description":"",
               "extensions":{
                  "iconName":"icon-dp_loop"
               },
               "name":"上升",
               "typeSpec":{
                  "type":"enum",
                  "range":[
                     "open",
                     "end"
                  ]
               }
            },
            {
               "abilityId":7,
               "accessMode":"rw",
               "code":"switch_backlight",
               "description":"",
               "extensions":{
                  "iconName":"icon-dp_power3"
               },
               "name":"插座",
               "typeSpec":{
                  "type":"bool"
               }
            },
            {
               "abilityId":8,
               "accessMode":"rw",
               "code":"control_back",
               "description":"",
               "extensions":{
                  "iconName":"icon-dp_loop"
               },
               "name":"下降",
               "typeSpec":{
                  "type":"enum",
                  "range":[
                     "open",
                     "end"
                  ]
               }
            },
            {
               "abilityId":101,
               "accessMode":"ro",
               "code":"ZT",
               "description":"状态",
               "name":"状态",
               "typeSpec":{
                  "type":"enum",
                  "range":[
                     "a1",
                     "a2",
                     "a3",
                     "a4",
                     "a5",
                     "a6",
                     "a7",
                     "as8",
                     "a9",
                     "a10",
                     "a11",
                     "a12",
                     "a13",
                     "a14",
                     "a15",
                     "a16",
                     "a17",
                     "a18",
                     "a19",
                     "a20"
                  ]
               }
            }
         ]
      }
   ]
}
```