### PR TITLE
Add support for Fisher F-ERVQ-B150CO2-I heat recovery ventilator

### DIFF
--- a/custom_components/tuya_local/devices/fisher_ervq_hd_hrv.yaml
+++ b/custom_components/tuya_local/devices/fisher_ervq_hd_hrv.yaml
@@ -1,8 +1,8 @@
-name: Heat Recovery Ventilator
-products:
-  - id: 000003vwap
-    manufacturer: Fisher
-    model: F-ERVQ-B150CO2-I
+name: Heat recovery ventilator
+# products:
+#  - id: UNKNOWN
+#    manufacturer: Fisher
+#    model: F-ERVQ-B150CO2-I
 entities:
   - entity: fan
     translation_only_key: ventilation
@@ -17,9 +17,9 @@ entities:
           - dps_val: "0"
             value: Manual
           - dps_val: "1"
-            value: Auto
+            value: auto
           - dps_val: "2"
-            value: Sleep
+            value: sleep
           - dps_val: "3"
             value: Pure L
           - dps_val: "4"
@@ -61,6 +61,7 @@ entities:
   - entity: sensor
     name: Filter remaining
     class: duration
+    icon: "mdi:air-filter"
     category: diagnostic
     dps:
       - id: 11
@@ -83,6 +84,7 @@ entities:
         name: fault_code
   - entity: number
     name: Supply fan speed
+    icon: "mdi:fan"
     category: config
     dps:
       - id: 103
@@ -93,6 +95,7 @@ entities:
           max: 8
   - entity: number
     name: Exhaust fan speed
+    icon: "mdi:fan"
     category: config
     dps:
       - id: 104
@@ -102,7 +105,8 @@ entities:
           min: 1
           max: 8
   - entity: select
-    name: Filter time setting
+    name: Filter lifespan
+    icon: "mdi:air-filter"
     category: config
     dps:
       - id: 105


### PR DESCRIPTION
Add support for Fisher F-ERVQ-B150CO2-I heat recovery ventilator

Adds configuration for Fisher F-ERVQ-B150CO2-I (ERVQ-HD) single-room dual-pipe heat recovery ventilation system.

Features:
- Fan control with 6 operating modes (Manual, Auto, Sleep, Pure L, Pure M, Pure H)
- PM2.5 and CO₂ sensors
- Indoor temperature and humidity monitoring
- Filter life tracking with reset button
- Independent supply and exhaust fan speed controls
- Configurable filter replacement intervals (90/120/150/180 days)
- Fault detection with error codes (E1-E5)

Product ID: 000003vwap
Model: F-ERVQ-B150CO2-I