### PR TITLE
Improvements on HY Multifunction Heatpump V1.2

### DIFF
--- a/custom_components/tuya_local/devices/hy_combo_heatpump.yaml
+++ b/custom_components/tuya_local/devices/hy_combo_heatpump.yaml
@@ -63,7 +63,7 @@ entities:
           - dps_val: null
             value: true
           - value: false
-      - id: 21
+      - id: 24
         type: integer
         name: current_temperature
         mapping:
@@ -330,6 +330,18 @@ entities:
     category: diagnostic
     dps:
       - id: 23
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Outlet temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
         type: integer
         name: sensor
         unit: C


### PR DESCRIPTION
While using this device, I notice the following points could be improved/added:

1. Missing the Outlet Temperature, since we already have the Inlet Temperature and Tank Temperature
2. Climate current temperature was not displaying the correct temperature because it was not using the correct dps id.