### PR TITLE
Add Olantern Classic 2 Pro Smart (Olight) Bluetooth over Hub

### DIFF
--- a/custom_components/tuya_local/devices/olight_olantern_classic_2_pro_smart.yaml
+++ b/custom_components/tuya_local/devices/olight_olantern_classic_2_pro_smart.yaml
@@ -1,0 +1,89 @@
+name: Olantern Classic 2 Pro Smart
+manufacturer: Olight
+model: Olantern Classic 2 Pro Smart
+product_id: sccicczk
+category: dj
+entities:
+  - name: Light Power
+    entity: light
+    dps:
+      - id: 1
+        name: switch_led
+        type: boolean
+      - id: 101
+        name: light_model
+        type: enum
+        mapping:
+          - dps_val: warm
+            value: warm
+          - dps_val: cold
+            value: cold
+      - id: 102
+        name: brightness
+        type: integer
+        range: [1, 100]
+  - name: Countdown
+    entity: number
+    icon: mdi:timer
+    dps:
+      - id: 7
+        name: countdown
+        type: integer
+        unit: s
+        range: [0, 86400]
+  - name: Battery
+    entity: sensor
+    device_class: battery
+    unit: "%"
+    dps:
+      - id: 103
+        name: battery_percentage
+        type: integer
+        range: [0, 100]
+  - name: Sleep Switch
+    entity: switch
+    icon: mdi:sleep
+    dps:
+      - id: 104
+        name: sleep_switch
+        type: boolean
+  - name: Do Not Disturb
+    entity: switch
+    icon: mdi:minus-circle
+    dps:
+      - id: 34
+        name: do_not_disturb
+        type: boolean
+  - name: Power Memory
+    entity: sensor
+    icon: mdi:power-settings
+    dps:
+      - id: 33
+        name: power_memory
+        type: raw
+  - name: Runtime
+    entity: sensor
+    unit: min
+    dps:
+      - id: 105
+        name: runtime
+        type: integer
+        range: [0, 99999]
+  - name: Runtime Type
+    entity: select
+    icon: mdi:clock-outline
+    dps:
+      - id: 106
+        name: runtime_type
+        type: enum
+        mapping:
+          - dps_val: hide
+            value: hidden
+          - dps_val: second
+            value: Seconds
+          - dps_val: minute
+            value: Minutes
+          - dps_val: hour
+            value: Hours
+          - dps_val: day
+            value: Days


### PR DESCRIPTION
This PR adds support for the Olantern Classic 2 Pro Smart by Olight. 

- Added YAML device template for local Tuya integration.
- Includes switch, light mode (warm/cold), brightness per color, countdown, sleep switch, power memory, battery status, and runtime.
- Brightness values are saved separately for warm and cold light modes.

Bluetooth LED Lamp use with Bluetooth MESH SIG Gateway


Title:
Add Olantern Classic 2 Pro Smart (Olight)

Description:
This pull request adds support for the Olantern Classic 2 Pro Smart by Olight to the Tuya Local integration.

Changes included:
	•	Added a YAML device template for local Tuya integration.
	•	Supports:
	•	Light Power (on/off)
	•	Light Mode (warm/cold)
	•	Brightness per light mode (warm and cold values stored separately)
	•	Countdown timer
	•	Sleep Switch
	•	Do Not Disturb mode
	•	Power Memory
	•	Battery percentage
	•	Runtime and Runtime Type
	•	Brightness values are saved and restored separately for warm and cold light modes, matching the official app behavior.

Notes:
	•	The device category is "dj" and was not previously supported.
	•	This PR does not affect other devices.
