### PR TITLE
Remove unsupported HVAC modes from Madimack Eco 9kW heat pump YAML

### DIFF
--- a/custom_components/tuya_local/devices/madimack_eco_heatpump_9kW.yaml
+++ b/custom_components/tuya_local/devices/madimack_eco_heatpump_9kW.yaml
@@ -20,10 +20,6 @@ entities:
             conditions:
               - dps_val: heating
                 value: heat
-              - dps_val: cold
-                value: cool
-              - dps_val: auto
-                value: heat_cool
 
       # Underlying device "mode" (hidden helper for mapping above)
       - id: 2


### PR DESCRIPTION
This update removes non-existent “cool” and “heat_cool” modes for the Madimack Eco 9kW pool heat pump.
