### PR TITLE
feat(emos_ip300_camera): add EMOS IP-300 camera with floodlight

### DIFF
--- a/custom_components/tuya_local/devices/emos_ip300_camera.yaml
+++ b/custom_components/tuya_local/devices/emos_ip300_camera.yaml
@@ -27,10 +27,6 @@ entities:
         optional: true
         sensitive: true
         name: snapshot
-      - id: 185
-        type: base64
-        name: log_message
-        optional: true
   - entity: light
     translation_key: indicator
     category: config
@@ -230,18 +226,32 @@ entities:
             value: Continuous
           - dps_val: null
             value: null
-  - entity: switch
-    name: Siren
-    icon: "mdi:bullhorn"
+  - entity: siren
     category: config
     dps:
       - id: 159
         type: boolean
         name: switch
         optional: true
+      - id: 194
+        type: integer
+        name: duration
+        optional: true
+        unit: s
+        range:
+          min: 10
+          max: 600
         mapping:
-          - dps_val: null
-            value: null
+          - step: 10
+      - id: 195
+        type: integer
+        name: volume_level
+        optional: true
+        range:
+          min: 10
+          max: 100
+        mapping:
+          - scale: 100
   - entity: switch
     name: Motion tracking
     icon: "mdi:motion-sensor"
@@ -300,34 +310,6 @@ entities:
         range:
           min: 5
           max: 600
-  - entity: number
-    name: Siren duration
-    icon: "mdi:timer-outline"
-    category: config
-    dps:
-      - id: 194
-        type: integer
-        name: value
-        optional: true
-        unit: s
-        range:
-          min: 10
-          max: 600
-        mapping:
-          - step: 10
-  - entity: number
-    name: Siren volume
-    icon: "mdi:volume-high"
-    category: config
-    dps:
-      - id: 195
-        type: integer
-        name: value
-        optional: true
-        unit: "%"
-        range:
-          min: 10
-          max: 100
   - entity: event
     name: Alarm
     dps:
@@ -340,11 +322,11 @@ entities:
             value: null
           - value: alarm
       - id: 185
-        type: base64
+        type: utf16b64
         name: alarm_message
         optional: true
   - entity: event
-    name: Initiative message
+    name: Notification
     dps:
       - id: 212
         type: base64
@@ -355,7 +337,7 @@ entities:
             value: null
           - value: message
       - id: 212
-        type: base64
+        type: utf16b64
         name: message
         optional: true
   - entity: switch


### PR DESCRIPTION
## Summary
Add support for EMOS IP-300 outdoor camera with integrated floodlight.

**Device Details:**
- Product ID: `wauxpj9p977uxhvb`
- Manufacturer: EMOS
- Model: IP-300
- Protocol: 3.2
- Total DPs: 34 (1 primary camera + 33 configurable options)

## Features
**Primary Entities:**
- Camera entity with motion detection and recording
- Floodlight (brightness 20-100%)

**Configuration Entities:**
- Indicator light control
- Image flip and timestamp overlay
- Motion detection sensitivity and area limiting
- Night vision modes (Auto/On/Off)
- SD card management and recording modes
- PTZ controls (Left/Right/Stop)
- PIR sensor with adjustable sensitivity
- Siren with duration and volume control
- Light warning with duration
- ONVIF stream support (with IP and password management)
- Scene linkage (6 scenes)

**Diagnostic Entities:**
- SD card status and capacity
- Alarm and initiative message events

## Technical Notes
1. **Entity Initialization**: Device sends only 1 DP (101 or 103) at startup, so null mappings with default values added for 17+ DPs to ensure entities show correct initial state instead of 'unknown'.

2. **Brightness Mapping**: Home Assistant auto-scales 0-255 to device's 20-100 range. No manual mapping needed.

3. **ONVIF Configuration**: Consolidated 3 DPs (253, 254, 255) into single switch entity following nedis_outdoor_camera pattern. Uses `sensitive: true` for IP and password fields.

4. **DP Query Behavior**: Most DPs cannot be queried individually - device only sends updates when values change via app or device triggers.

## Testing
- ✅ All 13 unit tests passing
- ✅ Protocol version 3.2 verified
- ✅ Brightness scaling verified (0-255 → 20-100)
- ✅ Entity initialization with null mappings tested
- ✅ All 34 DPs mapped and verified against Tuya Device Data Model