### PR TITLE
Add Gosund SP211 Dual Smart Plug

### DIFF
--- a/custom_components/tuya_local/devices/gosund_sp211_dualsmartplug.yaml
+++ b/custom_components/tuya_local/devices/gosund_sp211_dualsmartplug.yaml
@@ -114,18 +114,6 @@ entities:
             value: "on"
           - dps_val: "2"
             value: memory
-          - dps_val: "on"
-            value: "on"
-          - dps_val: "off"
-            value: "off"
-          - dps_val: memory
-            value: memory
-          - dps_val: power_off
-            value: "off"
-          - dps_val: power_on
-            value: "on"
-          - dps_val: last
-            value: memory
   - entity: select
     translation_key: light_mode
     category: config


### PR DESCRIPTION
Adds support for the Gosund SP211 dual outlet smart plug (product ID: p2tjkvgdhvuadnlj).

The device was matching `blitzwolf_bwshp6_smartplug` at 89% but only exposed one switch. I combined the dual-outlet structure from `denver_shp200mk2_dualsmartplug` with the full feature set from the Blitzwolf template.

**What works:**
- Both outlets (DP 1, 2)
- Individual countdown timers for each outlet (DP 9, 10)
- Energy monitoring: current, power, voltage, cumulative energy (DP 17-20)
- Initial state, light mode, child lock settings (DP 38-40)
- Schedule/inching support (DP 41-43)

Tested via cloud integration, all DPs reporting correctly. Log data included with device discovery.

```
025-10-26 15:20:52.559 DEBUG (MainThread) [custom_components.tuya_local.cloud] Datamodel response: {'t': 1761492052540, 'sign': 'cac35d869bc2843dc997c5616f0c21ec', 'tid': '5c2073bdb27f11f095bf56aa5aaefb1d', 'success': True, 'result': {'category': 'pc', 'dpStatusRelationDTOS': [{'dpCode': 'switch_1', 'dpId': 1, 'enumMappingMap': {}, 'statusCode': 'switch_1', 'statusFormat': '{"switch_1":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{}', 'valueType': 'Boolean'}, {'dpCode': 'switch_2', 'dpId': 2, 'enumMappingMap': {}, 'statusCode': 'switch_2', 'statusFormat': '{"switch_2":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{}', 'valueType': 'Boolean'}, {'dpCode': 'countdown_1', 'dpId': 9, 'enumMappingMap': {}, 'statusCode': 'countdown_1', 'statusFormat': '{"countdown_1":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}', 'valueType': 'Integer'}, {'dpCode': 'countdown_2', 'dpId': 10, 'enumMappingMap': {}, 'statusCode': 'countdown_2', 'statusFormat': '{"countdown_2":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}', 'valueType': 'Integer'}, {'dpCode': 'add_ele', 'dpId': 17, 'enumMappingMap': {}, 'statusCode': 'add_ele', 'statusFormat': '{"add_ele":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"unit":"kwh","min":0,"max":50000,"scale":3,"step":100}', 'valueType': 'Integer'}, {'dpCode': 'cur_current', 'dpId': 18, 'enumMappingMap': {}, 'statusCode': 'cur_current', 'statusFormat': '{"cur_current":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"unit":"mA","min":0,"max":30000,"scale":0,"step":1}', 'valueType': 'Integer'}, {'dpCode': 'cur_power', 'dpId': 19, 'enumMappingMap': {}, 'statusCode': 'cur_power', 'statusFormat': '{"cur_power":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"unit":"W","min":0,"max":50000,"scale":1,"step":1}', 'valueType': 'Integer'}, {'dpCode': 'cur_voltage', 'dpId': 20, 'enumMappingMap': {}, 'statusCode': 'cur_voltage', 'statusFormat': '{"cur_voltage":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"unit":"V","min":0,"max":5000,"scale":1,"step":1}', 'valueType': 'Integer'}, {'dpCode': 'relay_status', 'dpId': 38, 'enumMappingMap': {'0': {'code': 'relay_status', 'value': 'power_off'}, '1': {'code': 'relay_status', 'value': 'power_on'}, '2': {'code': 'relay_status', 'value': 'last'}, 'memory': {'code': 'relay_status', 'value': 'last'}, 'off': {'code': 'relay_status', 'value': 'power_off'}, 'on': {'code': 'relay_status', 'value': 'power_on'}}, 'statusCode': 'relay_status', 'statusFormat': '{"relay_status":"$"}', 'supportLocal': True, 'valueConvert': 'enum', 'valueDesc': '{"range":["power_off","power_on","last"]}', 'valueType': 'Enum'}, {'dpCode': 'light_mode', 'dpId': 39, 'enumMappingMap': {}, 'statusCode': 'light_mode', 'statusFormat': '{"light_mode":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{"range":["none","relay","pos"]}', 'valueType': 'Enum'}, {'dpCode': 'child_lock', 'dpId': 40, 'enumMappingMap': {}, 'statusCode': 'child_lock', 'statusFormat': '{"child_lock":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{}', 'valueType': 'Boolean'}, {'dpCode': 'cycle_time', 'dpId': 41, 'enumMappingMap': {}, 'statusCode': 'cycle_time', 'statusFormat': '{"cycle_time":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{}', 'valueType': 'String'}, {'dpCode': 'random_time', 'dpId': 42, 'enumMappingMap': {}, 'statusCode': 'random_time', 'statusFormat': '{"random_time":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{}', 'valueType': 'String'}, {'dpCode': 'switch_inching', 'dpId': 43, 'enumMappingMap': {}, 'statusCode': 'switch_inching', 'statusFormat': '{"switch_inching":"$"}', 'supportLocal': True, 'valueConvert': 'default', 'valueDesc': '{}', 'valueType': 'String'}], 'productKey': 'p2tjkvgdhvuadnlj'}}
2025-10-26 15:20:52.560 WARNING (MainThread) [custom_components.tuya_local.config_flow] Cloud device spec:
[{"id": 1, "name": "switch_1", "type": "Boolean", "format": "{}", "enumMap": {}}, {"id": 2, "name": "switch_2", "type": "Boolean", "format": "{}", "enumMap": {}}, {"id": 9, "name": "countdown_1", "type": "Integer", "format": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}", "enumMap": {}}, {"id": 10, "name": "countdown_2", "type": "Integer", "format": "{\"unit\":\"s\",\"min\":0,\"max\":86400,\"scale\":0,\"step\":1}", "enumMap": {}}, {"id": 17, "name": "add_ele", "type": "Integer", "format": "{\"unit\":\"kwh\",\"min\":0,\"max\":50000,\"scale\":3,\"step\":100}", "enumMap": {}}, {"id": 18, "name": "cur_current", "type": "Integer", "format": "{\"unit\":\"mA\",\"min\":0,\"max\":30000,\"scale\":0,\"step\":1}", "enumMap": {}}, {"id": 19, "name": "cur_power", "type": "Integer", "format": "{\"unit\":\"W\",\"min\":0,\"max\":50000,\"scale\":1,\"step\":1}", "enumMap": {}}, {"id": 20, "name": "cur_voltage", "type": "Integer", "format": "{\"unit\":\"V\",\"min\":0,\"max\":5000,\"scale\":1,\"step\":1}", "enumMap": {}}, {"id": 38, "name": "relay_status", "type": "Enum", "format": "{\"range\":[\"power_off\",\"power_on\",\"last\"]}", "enumMap": {"0": {"code": "relay_status", "value": "power_off"}, "1": {"code": "relay_status", "value": "power_on"}, "2": {"code": "relay_status", "value": "last"}, "memory": {"code": "relay_status", "value": "last"}, "off": {"code": "relay_status", "value": "power_off"}, "on": {"code": "relay_status", "value": "power_on"}}}, {"id": 39, "name": "light_mode", "type": "Enum", "format": "{\"range\":[\"none\",\"relay\",\"pos\"]}", "enumMap": {}}, {"id": 40, "name": "child_lock", "type": "Boolean", "format": "{}", "enumMap": {}}, {"id": 41, "name": "cycle_time", "type": "String", "format": "{}", "enumMap": {}}, {"id": 42, "name": "random_time", "type": "String", "format": "{}", "enumMap": {}}, {"id": 43, "name": "switch_inching", "type": "String", "format": "{}", "enumMap": {}}]
2025-10-26 15:20:52.560 WARNING (MainThread) [custom_components.tuya_local.config_flow] Device matches blitzwolf_bwshp6_smartplug with quality of 89%. DPS: {"updated_at": 1761492049.6950607, "1": true, "2": true, "9": 0, "10": 0, "17": 2, "18": 0, "19": 0, "20": 2431, "21": 1, "22": 746, "23": 29200, "24": 19871, "25": 1048, "38": "2", "39": "none", "40": false, "41": "", "42": "", "43": ""}
2025-10-26 15:20:52.560 WARNING (MainThread) [custom_components.tuya_local.config_flow] Include the previous log messages with any new device request to https://github.com/make-all/tuya-local/issues/
```
