### PR TITLE
Fix (time): update hour before updating minute for masked dps with the same id

### DIFF
--- a/custom_components/tuya_local/time.py
+++ b/custom_components/tuya_local/time.py
@@ -105,11 +105,31 @@ class TuyaLocalTime(TuyaLocalEntity, TimeEntity):
         seconds = value.second
         if self._hour_dps:
             settings.update(self._hour_dps.get_values_to_set(self._device, hours))
+
+            # If hour dps is using the same masked ID as minute dps, it's important to update hours before processing minute
+            if (
+                self._minute_dps
+                and self._hour_dps.id == self._minute_dps.id
+                and self._hour_dps.mask
+                and self._minute_dps.mask
+            ):
+                await self._device.async_set_properties(settings)
+                settings = {}
         else:
             minutes = minutes + hours * 60
 
         if self._minute_dps:
             settings.update(self._minute_dps.get_values_to_set(self._device, minutes))
+
+            # If minute dps is using the same masked ID as second dps, it's important to update minute before processing second
+            if (
+                self._second_dps
+                and self._minute_dps.id == self._second_dps.id
+                and self._minute_dps.mask
+                and self._second_dps.mask
+            ):
+                await self._device.async_set_properties(settings)
+                settings = {}
         else:
             seconds = seconds + minutes * 60
 


### PR DESCRIPTION
**Issue:** If a time entity uses the same DPS ID with a masked value for hour and minute or minute and second, you are not able to update the hour or minute value, because the following minute or second value overrides the updated value

**Reason:** The updated hour in masked value is overridden during the minute value processing.

**Config example:**
```
  - entity: time
    category: config
    name: "Start time"
    dps:
      - id: 106
        optional: true
        type: base64
        mask: "00FF00"
        name: hour
        range:
          min: 0
          max: 23
      - id: 106
        optional: true
        type: base64
        mask: "0000FF"
        name: minute
        range:
          min: 0
          max: 59
```

**Proposed solution:** in case if we have such configuration, set hour value to device before processing minute value