### PR TITLE
Add support for Goldair GPOC2415 Oil Heater

### DIFF
--- a/custom_components/tuya_local/devices/goldair_gpoc2415_oilheater.yaml
+++ b/custom_components/tuya_local/devices/goldair_gpoc2415_oilheater.yaml
@@ -121,4 +121,3 @@ entities:
         range:
           min: 0
           max: 24
-


### PR DESCRIPTION
## Device Information
- **Brand**: Goldair  
- **Model**: GPOC2415 (Platinum 2400W Oil Heater)
- **Product ID**: ebbac89343b5fc10624myw

## Features
- Climate control with temperature range 5-35°C
- Preset modes: eco, low, medium, high
- Child lock, sound control, countdown timer
- Fault detection sensor
- Preheat timer and auto shutoff

## Implementation Details
- 57 tests passed
- QA checks (ruff,yamllint) done

have been using this in my own HA instance for the last month or two and works as expected.