### PR TITLE
Add support for Devola Designer Glass Panel Heater.

### DIFF
--- a/custom_components/tuya_local/devices/devola_designer_glass_panel_heater.yaml
+++ b/custom_components/tuya_local/devices/devola_designer_glass_panel_heater.yaml
@@ -1,0 +1,61 @@
+name: Heater
+products:
+  - id: laagtqcj40q1uwg8
+    manufacturer: Devola
+    model: Designer Glass Panel Heater
+entities:
+  - entity: climate
+    translation_key: heater
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 5
+          max: 50
+        unit: C
+        mapping:
+          - constraint: preset_mode
+            conditions:
+              - dps_val: af
+                value: 5
+                range:
+                  min: 5
+                  max: 5
+      - id: 3
+        type: integer
+        name: current_temperature
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: low
+            value: eco
+          - dps_val: high
+            value: comfort
+          - dps_val: af
+            value: away
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 12
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 12
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
Adds support for the Devola Designer Glass Panel Heater.

This device is almost identical to the Devola Intelligent Heater, which already has an existing config and shares a product ID, with some small changes:

- preset_mode value for antifrost mode is now af
- temperature is constrained to 5 degrees in antitrust mode
- temperature range is extended

All changes have been extracted from and tested in Tuya developer portal.

**Additional details:**

- Product webpage: [https://www.devola.co.uk/products/devola-designer-2kw-smart-glass-panel-heater-with-timer-black-dvpw2000b](https://www.devola.co.uk/products/devola-designer-2kw-smart-glass-panel-heater-with-timer-black-dvpw2000b)
- Product manual: [https://www.devola.co.uk/cdn/shop/files/dvpw-instruction-manual.pdf?v=17064640317587403520](https://www.devola.co.uk/cdn/shop/files/dvpw-instruction-manual.pdf?v=17064640317587403520)
