### PR TITLE
Incude Current Temp in Water Heater Entity and Map Fault Codes

### DIFF
--- a/custom_components/tuya_local/devices/ems_waterheater.yaml
+++ b/custom_components/tuya_local/devices/ems_waterheater.yaml
@@ -25,10 +25,10 @@ entities:
       - id: 3
         type: integer
         name: current_temperature
-        unit: C
       - id: 2
         type: integer
         name: temperature
+        unit: C
         range:
           min: 10
           max: 60
@@ -39,7 +39,6 @@ entities:
   - entity: sensor
     # 2025-11-05
     deprecated: water_heater.current_temperature
-    name: Current Temperature
     class: temperature
     dps:
       - id: 3
@@ -61,14 +60,9 @@ entities:
       - id: 9
         type: bitfield
         name: fault_code
-  - entity: sensor
-    name: Fault Description
-    class: enum
-    category: diagnostic
-    dps:
       - id: 9
         type: bitfield
-        name: sensor
+        name: description
         mapping:
           - dps_val: 0
             value: ok
@@ -91,7 +85,7 @@ entities:
           - dps_val: 256
             value: E03 Overheat protection
           - dps_val: 512
-            value: PA Compressor operating limit environment or water tank temperature protection
+            value: PA Compressor limit or water tank temperature protection
           - dps_val: 1024
             value: E08 Communication fault
           - dps_val: 2048


### PR DESCRIPTION
Inclusion of the current temperature in the water heate entity so that the value can be displayed as it is an attribute and is needed on some cards.

Added the fault mapping. Fault mapping was gathered and translated from the JSON output gathered from Tuya IoT Dev Platform under the API Explorer/Device Control/Query Things Data Model

[EMS Waterheater.json](https://github.com/user-attachments/files/23341236/EMS.Waterheater.json)
