### PR TITLE
Update catit_pixi_smart_feeder.yaml

### DIFF
--- a/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_feeder.yaml
@@ -150,7 +150,6 @@ entities:
         # Present at all times on Catit 43752 but unsure about other products
         optional: true
   - entity: binary_sensor
-    name: Plug
     category: diagnostic
     class: plug
     dps:


### PR DESCRIPTION
Add outlet power status (id: 105) to the catit pixi smart feeder. This bit corresponds to the used power source:
- 0: Power outlet (USB-C).
- 1: Batteries.

The condition was negated, as the monitor point name is Outlet power.