### PR TITLE
Add CO2V1_WiFi_Smart_CO2_detector

### DIFF
--- a/custom_components/tuya_local/devices/co2v1_co2_sensor.yaml
+++ b/custom_components/tuya_local/devices/co2v1_co2_sensor.yaml
@@ -1,4 +1,4 @@
-name: WiFi Smart CO2 detector
+name: CO2 sensor
 entities:
   - entity: sensor
     class: carbon_dioxide


### PR DESCRIPTION
Almost the same as inkbird_pth9cw_airquality, but had to add proper scaling. Device: WiFi Smart CO2 detector
CO2V1
Cheap Aliexpress chinese sensor.
Description: Tuya Wi_Fi Smart Co2 Meter Box Accurate Real Time Indoor Smoke Alarm Detector