### PR TITLE
Added percentage to battery of Fararo Pet Feeder

### DIFF
--- a/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
+++ b/custom_components/tuya_local/devices/faroro_pet_feeder.yaml
@@ -71,11 +71,11 @@ entities:
   - entity: sensor
     category: diagnostic
     class: battery
-    unit: "%"
     dps:
       - id: 101
         name: sensor
         type: string
+        unit: "%"
         mapping:
           - dps_val: "no"
             value: 10


### PR DESCRIPTION
Missing unit for class battery causes warnings in home assistant. Added % as unit to battery.