### PR TITLE
Change dps_val from HYB to HYB1

### DIFF
--- a/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
@@ -19,7 +19,7 @@ entities:
                 value: eco
               - dps_val: Stand
                 value: heat_pump
-              - dps_val: HYB
+              - dps_val: HYB1
                 value: performance
               - dps_val: ELE
                 value: electric


### PR DESCRIPTION
dps_val: HYB is not valid for this device and must be changed to HYB1 for the performance mode to function correctly.