### PR TITLE
Device support for Zemismart SPM02-D2TW 3-phase energy meter

### DIFF
--- a/custom_components/tuya_local/devices/zemismart_spm02d2tw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/zemismart_spm02d2tw_energymeter.yaml
@@ -5,7 +5,7 @@ products:
     model_id: SPM02-D2TW
     model: 3-Phase Energy Meter
 entities:
-    # Total energy consumed
+  # Total energy consumed
   - entity: sensor
     translation_key: energy_consumed
     class: energy
@@ -17,7 +17,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Total energy produced
+  # Total energy produced
   - entity: sensor
     translation_key: energy_produced
     class: energy
@@ -29,7 +29,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Total active power
+  # Total active power
   - entity: sensor
     class: power
     dps:
@@ -38,7 +38,7 @@ entities:
         unit: W
         class: measurement
         type: integer
-    # Active power L1
+  # Active power L1
   - entity: sensor
     translation_key: power_x
     translation_placeholders:
@@ -50,7 +50,7 @@ entities:
         unit: W
         class: measurement
         type: integer
-    # Active power L2
+  # Active power L2
   - entity: sensor
     translation_key: power_x
     translation_placeholders:
@@ -62,7 +62,7 @@ entities:
         unit: W
         class: measurement
         type: integer
-    # Active power L3
+  # Active power L3
   - entity: sensor
     translation_key: power_x
     translation_placeholders:
@@ -74,7 +74,7 @@ entities:
         unit: W
         class: measurement
         type: integer
-    # Voltage L1
+  # Voltage L1
   - entity: sensor
     translation_key: voltage_x
     translation_placeholders:
@@ -89,7 +89,7 @@ entities:
         type: integer
         mapping:
           - scale: 10
-    # Voltage L2
+  # Voltage L2
   - entity: sensor
     translation_key: voltage_x
     translation_placeholders:
@@ -104,7 +104,7 @@ entities:
         type: integer
         mapping:
           - scale: 10
-    # Voltage L3
+  # Voltage L3
   - entity: sensor
     translation_key: voltage_x
     translation_placeholders:
@@ -119,7 +119,7 @@ entities:
         type: integer
         mapping:
           - scale: 10
-    # Current L1
+  # Current L1
   - entity: sensor
     translation_key: current_x
     translation_placeholders:
@@ -134,7 +134,7 @@ entities:
         type: integer
         mapping:
           - scale: 1000
-    # Current L2
+  # Current L2
   - entity: sensor
     translation_key: current_x
     translation_placeholders:
@@ -149,7 +149,7 @@ entities:
         type: integer
         mapping:
           - scale: 1000
-    # Current L3
+  # Current L3
   - entity: sensor
     translation_key: current_x
     translation_placeholders:
@@ -164,7 +164,7 @@ entities:
         type: integer
         mapping:
           - scale: 1000
-    # Power factor L1
+  # Power factor L1
   - entity: sensor
     name: Power factor L1
     class: power_factor
@@ -175,7 +175,7 @@ entities:
         unit: "%"
         class: measurement
         type: integer
-    # Power factor L2
+  # Power factor L2
   - entity: sensor
     name: Power factor L2
     class: power_factor
@@ -186,7 +186,7 @@ entities:
         unit: "%"
         class: measurement
         type: integer
-    # Power factor L3
+  # Power factor L3
   - entity: sensor
     name: Power factor L3
     class: power_factor
@@ -197,7 +197,7 @@ entities:
         unit: "%"
         class: measurement
         type: integer
-    # Total power factor
+  # Total power factor
   - entity: sensor
     class: power_factor
     category: diagnostic
@@ -207,7 +207,7 @@ entities:
         type: integer
         unit: "%"
         class: measurement
-    # Energy consumed L1
+  # Energy consumed L1
   - entity: sensor
     translation_key: energy_consumed_x
     translation_placeholders:
@@ -222,7 +222,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Energy produced L1
+  # Energy produced L1
   - entity: sensor
     translation_key: energy_produced_x
     translation_placeholders:
@@ -237,7 +237,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Energy consumed L2
+  # Energy consumed L2
   - entity: sensor
     translation_key: energy_consumed_x
     translation_placeholders:
@@ -252,7 +252,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Energy produced L2
+  # Energy produced L2
   - entity: sensor
     translation_key: energy_produced_x
     translation_placeholders:
@@ -267,7 +267,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Energy consumed L3
+  # Energy consumed L3
   - entity: sensor
     translation_key: energy_consumed_x
     translation_placeholders:
@@ -282,7 +282,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Energy produced L3
+  # Energy produced L3
   - entity: sensor
     translation_key: energy_produced_x
     translation_placeholders:
@@ -297,7 +297,7 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-    # Frequency
+  # Frequency
   - entity: sensor
     class: frequency
     category: diagnostic
@@ -309,7 +309,7 @@ entities:
         type: integer
         mapping:
           - scale: 100
-    # Phase current imbalance
+  # Phase current imbalance
   - entity: sensor
     name: Current imbalance
     category: diagnostic
@@ -319,7 +319,7 @@ entities:
         type: integer
         unit: "%"
         class: measurement
-    # Fault status
+  # Fault status
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -374,7 +374,7 @@ entities:
             value: credit_low
           - dps_val: 65536
             value: credit_expired
-    # Clear energy counters
+  # Clear energy counters
   - entity: button
     name: Reset energy
     class: restart
@@ -383,7 +383,7 @@ entities:
       - id: 12
         type: boolean
         name: button
-    # Report interval
+  # Report interval
   - entity: number
     name: Reporting interval
     category: config


### PR DESCRIPTION
Device support for [Zemismart SPM02-D2TW Wifi 3-phase energy meter](https://www.zemismart.com/products/spm02-d2tw?srsltid=AfmBOopOxxSOKuiLwyUhMMYJP90M3udMWaNUonjUptTyakJTo6FoUjDy), and many other identical devices under different brand names. Omitted some of the redundant and unhelpful entities. Config tested with 2 devices.

The table below is derived from the data returned by "Query Things Data Model" from Tuya IoT: 

| abilityId | code | name (EN) | access | type (summary) | unit / scale | Description (English) |
|---:|---|---|---:|---|---|---|
| 1 | forward_energy_total | Total forward active energy | ro | value | kW.h (scale 2) | Cumulative forward active energy. |
| 6 | phase_a | Phase A voltage, current & power (raw) | ro | raw (maxlen 128) | HEX, 8 bytes | 1) Phase A voltage, current and active power. 2) Big-endian HEX, 8 bytes. 3) Units: voltage 2 bytes (0.1 V); current 3 bytes (0.001 A); active power 3 bytes (0.0001 kW). 4) Example: 08 80 00 03 E8 00 27 10 → A: 217.6 V, I: 1.000 A, P: 10.000 kW. 5) Communication: panel can actively query when user opens UI; recommended periodic reporting Wi‑Fi: 15s, NB: 1h. |
| 7 | phase_b | Phase B voltage, current & power (raw) | ro | raw (maxlen 128) | HEX, 8 bytes | Same format/logic as phase_a. Example shows B-phase data. |
| 8 | phase_c | Phase C voltage, current & power (raw) | ro | raw (maxlen 128) | HEX, 8 bytes | Same format/logic as phase_a. |
| 9 | fault | Fault / alarm bitmap | ro | bitmap | 4 bytes (bitmap) | 4-byte big-endian bitmap of alarms. Bit=1 means alarm active. Example 00 00 00 09 indicates specific alarms (leakage self-test abnormal + short circuit). Device sends full 4 bytes whenever any alarm occurs or clears. |
| 12 | clear_energy | Clear energy | rw | bool | — | Command to clear/reset energy. |
| 17 | alarm_set_1 | Alarm settings 1 | rw | raw (maxlen 128) | HEX (n * 4 bytes) | Alarm threshold enable/settings. Each alarm = 4 bytes: byte1 = supported flag; byte2 = action (0x01 = trip, 0x00 = alarm only); bytes3–4 = threshold. Device uploads supported alarms after pairing and on power-on; panel sets thresholds per protocol. APP first-byte mapping: 01 short-circuit, 02 surge, 03 overload, 04 leakage, 05 high-temp, 06 arcing, 07 high-power, 08 leakage self-test abnormal. |
| 18 | alarm_set_2 | Alarm settings 2 | rw | raw (maxlen 128) | HEX (n * 4 bytes) | Same format as alarm_set_1. Example supports overcurrent (trip at 60 A) and overvoltage (trip at 245 V). |
| 19 | breaker_id | Device ID display | ro | string (maxlen 255) | string | Device number (string). Reported multiple times during pairing and on power-on to ensure display in panel. |
| 23 | reverse_energy_total | Total reverse active energy | ro | value | kW.h (scale 2) | Cumulative reverse active energy. |
| 29 | active_power | Total active power | rw | value | kW (scale 3) | Total active power. Range includes negative values for export. |
| 32 | supply_frequency | Frequency | ro | value | Hz (scale 2) | Supply frequency. |
| 35 | online_state | Panel online / trigger update | rw | enum | — | Enum ["online","offline"]. Used by app to trigger device to immediately report latest realtime data for UI refresh. |
| 50 | power_factor | Total power factor | rw | value | (scale 2) | Total power factor. |
| 101 | device_locating | Device locating | rw | bool | — | When enabled, green LED blinks for a period then returns to normal. |
| 102 | data_report_duration | Data reporting interval | rw | value | seconds (min 225 / max 3600) | How often the device reports data, in seconds. |
| 103 | cur_voltage_x | X-phase voltage | ro | value | V (scale 1) | Phase X voltage. |
| 104 | cur_current_x | X-phase current | ro | value | A (scale 3) | Phase X current. |
| 105 | cur_power_x | X-phase active power | ro | value | kW (scale 3) | Phase X active power. |
| 108 | power_factor_x | X-phase power factor | ro | value | (scale 2) | Phase X power factor. |
| 109 | x_total_import_energy | X-phase forward energy | ro | value | kW.h (scale 2) | Phase X cumulative forward energy. |
| 110 | x_total_export_energy | X-phase reverse energy | ro | value | kW.h (scale 2) | Phase X cumulative reverse energy. |
| 112 | cur_voltage_y | Y-phase voltage | ro | value | V (scale 1) | Phase Y voltage. |
| 113 | cur_current_y | Y-phase current | ro | value | A (scale 3) | Phase Y current. |
| 114 | cur_power_y | Y-phase active power | ro | value | kW (scale 3) | Phase Y active power. |
| 117 | power_factor_y | Y-phase power factor | ro | value | (scale 2) | Phase Y power factor. |
| 118 | y_total_import_energy | Y-phase forward energy | ro | value | kW.h (scale 2) | Phase Y cumulative forward energy. |
| 119 | y_total_export_energy | Y-phase reverse energy | ro | value | kW.h (scale 2) | Phase Y cumulative reverse energy. |
| 121 | cur_voltage_z | Z-phase voltage | ro | value | V (scale 1) | Phase Z voltage. |
| 122 | cur_current_z | Z-phase current | ro | value | A (scale 3) | Phase Z current. |
| 123 | cur_power_z | Z-phase active power | ro | value | kW (scale 3) | Phase Z active power. |
| 126 | power_factor_z | Z-phase power factor | ro | value | (scale 2) | Phase Z power factor. |
| 127 | z_total_import_energy | Z-phase forward energy | ro | value | kW.h (scale 2) | Phase Z cumulative forward energy. |
| 128 | z_total_export_energy | Z-phase reverse energy | ro | value | kW.h (scale 2) | Phase Z cumulative reverse energy. |
| 130 | current_unbalance | Three-phase current unbalance | ro | value | % (scale 0) | Three-phase current unbalance percentage (0–1000). |