### PR TITLE
Correct preset mode and temporature scale for WarmeHaus Towel Rail

### DIFF
--- a/custom_components/tuya_local/devices/warmehaus_afd02tj_thermostat_c.yaml
+++ b/custom_components/tuya_local/devices/warmehaus_afd02tj_thermostat_c.yaml
@@ -20,9 +20,9 @@ entities:
         name: preset_mode
         mapping:
           - dps_val: hot
-            value: comfort
-          - dps_val: cold
             value: manual
+          - dps_val: cold
+            value: comfort
           - dps_val: eco
             value: boost
           - dps_val: auto
@@ -45,6 +45,8 @@ entities:
       - id: 24
         type: integer
         name: current_temperature
+        mapping:
+          - scale: 10
       - id: 1
         type: boolean
         name: hvac_action


### PR DESCRIPTION
- "cold" is a fixed low temperature - More aligned with "comfort"
- "hot" allows the user to define any temperature
- Missed scale for "current_temperature"

Fix's for https://github.com/make-all/tuya-local/pull/3946