### PR TITLE
Add support for Convection Heater - Jocel JCT007452

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -41,6 +41,7 @@
 - Hombli radiator controller
 - INOW Wi-Fi heating element (single and dual air/water temperature control variants)
 - Juskys OH125BW2 oil radiator
+- Jocel JCT007452 convector heater
 - Kennedy II/JR electric fireplace
 - Kesser Infrared 400W wall and 3000W heaters with and without lights.
 - Klarstein Bornholm Smart 1500 convection heater

--- a/custom_components/tuya_local/devices/jocel_jct007452_convector_heater.yaml
+++ b/custom_components/tuya_local/devices/jocel_jct007452_convector_heater.yaml
@@ -1,0 +1,143 @@
+name: Convector Heater
+products:
+  - id: qhpaegcadawabwct
+    manufacturer: Jocel
+    model: JCT007452
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 5
+          max: 37
+      - id: 3
+        type: integer
+        name: current_temperature
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: auto
+            constraint: level
+            conditions:
+              - dps_val: "1"
+                value: "1000W"
+              - dps_val: "2"
+                value: "1300W"
+              - dps_val: "3"
+                value: "2300W"
+              - dps_val: "4"
+                value: "0W"
+          - dps_val: smart
+            value: away
+          - dps_val: standby
+            value: sleep
+      - id: 5
+        type: string
+        name: level
+        hidden: true
+      - id: 9
+        type: boolean
+        name: fan_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: "on"
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: cancel
+          - dps_val: "1"
+            value: "1h"
+          - dps_val: "2"
+            value: "2h"
+          - dps_val: "3"
+            value: "3h"
+          - dps_val: "4"
+            value: "4h"
+          - dps_val: "5"
+            value: "5h"
+          - dps_val: "6"
+            value: "6h"
+          - dps_val: "7"
+            value: "7h"
+          - dps_val: "8"
+            value: "8h"
+          - dps_val: "9"
+            value: "9h"
+          - dps_val: "10"
+            value: "10h"
+          - dps_val: "11"
+            value: "11h"
+          - dps_val: "12"
+            value: "12h"
+          - dps_val: "13"
+            value: "13h"
+          - dps_val: "14"
+            value: "14h"
+          - dps_val: "15"
+            value: "15h"
+          - dps_val: "16"
+            value: "16h"
+          - dps_val: "17"
+            value: "17h"
+          - dps_val: "18"
+            value: "18h"
+          - dps_val: "19"
+            value: "19h"
+          - dps_val: "20"
+            value: "20h"
+          - dps_val: "21"
+            value: "21h"
+          - dps_val: "22"
+            value: "22h"
+          - dps_val: "23"
+            value: "23h"
+          - dps_val: "24"
+            value: "24h"
+  - entity: sensor
+    class: duration
+    translation_key: time_remaining
+    category: diagnostic
+    dps:
+      - id: 12
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 13
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 13
+        type: bitfield
+        name: fault_code
+        optional: true


### PR DESCRIPTION
While setting up my Convection Heater, the integration suggested the device **lehmann_lhohc2013c_radiator**. 

All controls worked as expected. However, the power levels didn't exactly match my device. 

So I copied the file for lehmann_lhohc2013c_radiator, fixed the mapping of the levels to match my device and updated the product data.

Tested locally with my device, it automatically matched it during setup.  