### PR TITLE
Fix dé EV charger stop button

### DIFF
--- a/custom_components/tuya_local/devices/dewall_evcharger.yaml
+++ b/custom_components/tuya_local/devices/dewall_evcharger.yaml
@@ -64,6 +64,9 @@ entities:
         type: boolean
         optional: true
         name: button
+        mapping:
+          - dps_val: false
+            value: true
   - entity: button
     name: Reset
     icon: "mdi:refresh"


### PR DESCRIPTION
To stop charging, a `false` value must be sent to DP 140. This PR adds the required mapping to get the Stop button working.