### PR TITLE
Add Boost countdown to Mi-Heat TH11 WF thermostat

### DIFF
--- a/custom_components/tuya_local/devices/miheat_th11wf_thermostat.yaml
+++ b/custom_components/tuya_local/devices/miheat_th11wf_thermostat.yaml
@@ -105,6 +105,8 @@ entities:
         precision: 0
         unit: kWh
         class: total_increasing
+        mapping:
+          - scale: 100
   - entity: binary_sensor
     class: window
     dps:


### PR DESCRIPTION
- **Add support for Mi-Heat TH11-WF thermostat**
- **Fixed lint and type errors**
- **cleanup (miheat_th11wf_thermostat): changes from review**
- **Fix typo in measurement class for thermostat**
- **Add Boost countdown to Mi-Heat TH11 WF thermostat**
