### PR TITLE
Add configuration for Tary TA-AC380/22 EV charger

### DIFF
--- a/custom_components/tuya_local/devices/tary_taac380_evcharger.yaml
+++ b/custom_components/tuya_local/devices/tary_taac380_evcharger.yaml
@@ -218,16 +218,18 @@ entities:
     category: config
     class: current
     icon: "mdi:current-ac"
+    mode: slider
     dps:
       - id: 115
         type: integer
         name: value
         unit: A
         range:
-          min: 0
-          max: 200
+          min: 900
+          max: 3200
         mapping:
           - scale: 100
+            step: 100
 
   # DP 117: load_balancing_current (Value / integer, scale 2)
   - entity: number
@@ -235,16 +237,18 @@ entities:
     category: config
     class: current
     icon: "mdi:current-ac"
+    mode: slider
     dps:
       - id: 117
         type: integer
         name: value
         unit: A
         range:
-          min: 0
-          max: 200
+          min: 100
+          max: 10000
         mapping:
           - scale: 100
+            step: 100
 
   # DP 116: load_balancing_state (Boolean)
   - entity: binary_sensor


### PR DESCRIPTION
Fixed scaling and step handling for DP115 (rated_current) and DP117 (load_balancing_current) to use integer amps in Home Assistant while respecting the device’s x100 raw values.