### PR TITLE
eeese carl: add defrost binary_sensor (DP 19 bit 2)

### DIFF
--- a/custom_components/tuya_local/devices/eeese_carl_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/eeese_carl_dehumidifier.yaml
@@ -41,6 +41,17 @@ entities:
             value: true
           - value: false
   - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 19
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 2
+            value: true
+          - value: false
+  - entity: binary_sensor
     class: problem
     category: diagnostic
     dps:
@@ -51,6 +62,8 @@ entities:
           - dps_val: 0
             value: false
           - dps_val: 1
+            value: false
+          - dps_val: 2
             value: false
           - value: true
       - id: 19


### PR DESCRIPTION
### Eeese Carl dehumidifier – add defrost status

- Added `defrost` binary_sensor on DP 19 (bit 2)  
- Confirmed in real life: when the room got cold enough, Carl started blinking his power LED and the new sensor correctly turned ON

Tested on an actual Eeese Carl during a proper Scandinavian winter. ❄️