### PR TITLE
Expose energy measurement in Gosund SP211

### DIFF
--- a/custom_components/tuya_local/devices/gosund_sp211_dualsmartplug.yaml
+++ b/custom_components/tuya_local/devices/gosund_sp211_dualsmartplug.yaml
@@ -74,15 +74,20 @@ entities:
         type: integer
         name: calibration
         optional: true
+  - entity: sensor
+    name: Energy
+    category: diagnostic
+    hidden: true
+    dps:
       - id: 17
         type: integer
-        name: add_ele
+        name: sensor
+        unit: Wh
+        class: measurement
         optional: true
-        mapping:
-          - scale: 1000
       - id: 25
         type: integer
-        name: ele_calibration
+        name: calibration
         optional: true
   - entity: sensor
     class: voltage


### PR DESCRIPTION
Hi, thank you for adjusting and merging my previous [PR](https://github.com/make-all/tuya-local/pull/3891/) but I noticed the energy measurements do not work with the merged changes (no energy entity is exposed). 

Can you review if these changes are ok to be merged? I tested them locally and they work.

Thanks