### PR TITLE
Add support for Funai Fuji ERW-150

### DIFF
--- a/custom_components/tuya_local/devices/funai_erw150_ventilation.yaml
+++ b/custom_components/tuya_local/devices/funai_erw150_ventilation.yaml
@@ -1,7 +1,8 @@
-name: Ventilation Breezer
+name: Ventilation fan
 products:
   - id: 9xaunhonta8om3zr
-    name: Funai Fuji ERW-150 Ventilation
+    manufacturer: Funai
+    model: Fuji ERW-150
 entities:
   - entity: fan
     translation_key: ventilation


### PR DESCRIPTION
**Device Information:**
* **Name:** Funai Fuji ERW-150 Ultimate
* **Category:** Ventilation / Air Purifier
* **Product ID:** `9xaunhonta8om3zr`
* **Config file:** `funai_erw150_ventilation.yaml`

**Functionality added:**
* **Primary Entity:** Fan (Ventilator) with 9 speed levels (mapped to percentage) and presets (Auto, Sleep, Manual).
* **Sensors:** PM2.5, CO2, TVOC, Indoor Temperature, Air Quality Text.
* **Configuration:** Damper control (Manual/Auto), Fan speed level (number), Damper position.
* **Switches:** Anion, UV Light.
* **Diagnostics:** Filter reset, Cleaning reminder, Fault codes.

**Notes for Reviewer:**
* **DP 4 (Display):** The mapping for this DP is intentionally inverted (`true` -> `false`, `false` -> `true`). Testing on the physical device confirmed that the boolean logic is reversed compared to standard Tuya behavior (sending `true` turns the light off).

Tested on real hardware.