### PR TITLE
Add support for EARU 3-Phase Breaker (EAMPDW-TY-63)

### DIFF
--- a/custom_components/tuya_local/devices/earu_3phase_breaker.yaml
+++ b/custom_components/tuya_local/devices/earu_3phase_breaker.yaml
@@ -1,4 +1,4 @@
-name: Breaker Meter
+name: Breaker meter
 products:
   - id: nopfbtfxnwqcrg5y
     manufacturer: EARU
@@ -63,8 +63,6 @@ entities:
         optional: true
         unit: W
         mask: "0000000000FFFFFF0000"
-        mapping:
-          - scale: 1
 
   - entity: sensor
     translation_key: voltage_x
@@ -111,8 +109,6 @@ entities:
         optional: true
         unit: W
         mask: "0000000000FFFFFF0000"
-        mapping:
-          - scale: 1
 
   - entity: sensor
     translation_key: voltage_x
@@ -159,8 +155,6 @@ entities:
         optional: true
         unit: W
         mask: "0000000000FFFFFF0000"
-        mapping:
-          - scale: 1
 
   - entity: number
     translation_key: sensor_threshold


### PR DESCRIPTION
**Device Information:**
* **Name:** EARU 3-Phase Breaker Meter
* **Model:** EAMPDW-TY-63
* **Product ID:** `nopfbtfxnwqcrg5y`
* **Config file:** `earu_3phase_breaker.yaml`

**Functionality:**
* **Control:** Main Switch (on/off).
* **Metering:** Total Energy, Energy Today, Energy This Month (working natively).
* **Settings:** Over/Under Voltage, Over Current, Leakage protection.

**Note on Phase Measurements (Complex Data):**
The device transmits real-time metrics (Voltage, Current, Power) for each phase via DPs 6, 7, and 8 encoded as a **Base64 string**.
Currently, I have exposed these DPs as `diagnostic` string sensors (`Phase A raw`, etc.).

**Decoding Logic for Maintainers:**
I have reverse-engineered the Base64 format. It decodes into an 8-byte array (Big Endian):
* **Voltage:** Bytes 0-1 (divide by 10)
* **Current:** Bytes 2-4 (divide by 1000)
* **Power:** Bytes 5-7 (divide by 1)

*Example Python decoding logic:*
```python
# Assuming 'decoded' is the byte array from base64
volts = (decoded[0] << 8 | decoded[1]) / 10.0
amps = (decoded[2] << 16 | decoded[3] << 8 | decoded[4]) / 1000.0
watts = (decoded[5] << 16 | decoded[6] << 8 | decoded[7])
```

I'm submitting the YAML with raw sensors so users can at least control the device and use template sensors for decoding until native base64_struct support is added to the integration.