### PR TITLE
Fix preset_mode mapping for Vonroc GPH-XA-HEMAN heater (Tuya firmware…

### DIFF
--- a/custom_components/tuya_local/devices/vonroc_wifi_heater.yaml
+++ b/custom_components/tuya_local/devices/vonroc_wifi_heater.yaml
@@ -30,11 +30,11 @@ entities:
         type: string
         optional: true
         mapping:
-          - dps_val: AF
+          - dps_val: "2"
             value: "away"
-          - dps_val: low
+          - dps_val: "1"
             value: "eco"
-          - dps_val: high
+          - dps_val: "0"
             value: "comfort"
   - entity: lock
     translation_key: child_lock


### PR DESCRIPTION
This PR fixes the preset_mode mapping for the Vonroc GPH-XA-HEMAN heater in the Tuya Local device definition.

Background:
The device previously reported the preset_mode (DP 4) using string values: -AF
-low
-high

The current YAML maps these to:
- id: 4 name: preset_mode type: string optional: true mapping:
    - dps_val: AF value: "away"
    - dps_val: low value: "eco"
    - dps_val: high value: "comfort"

After a Tuya firmware/product template update, the same DP now reports stringified enum values instead: -"0" → Comfort
-"1" → Eco
-"2" → Anti-freeze (Away)

As a result, the existing mapping no longer matches the raw DP values, and preset_mode stops working correctly in Home Assistant.

Changes:
This PR updates the mapping for DP 4 to align with the new enum values exposed by Tuya:
- id: 4 name: preset_mode type: string optional: true mapping:
    - dps_val: "2"
      value: "away"      # Anti-freeze
    - dps_val: "1"
      value: "eco"
    - dps_val: "0"
      value: "comfort"

The entity-facing preset names (away, eco, comfort) are preserved, so existing automations and front-end usage can remain unchanged.

Testing:
*Verified the DP values using Tuya IoT Platform “Device Debugging”: -mode = "0" → Comfort
-mode = "1" → Eco
-mode = "2" → Anti-freeze
*Applied the updated YAML to Tuya Local.
*Restarted Home Assistant.

Confirmed that:
*The correct preset mode is reported in the climate entity. *Changing presets in Home Assistant successfully switches the heater to the expected mode (comfort/eco/anti-freeze).

Notes:
This change reflects a firmware/product template update on Tuya’s side and brings the device definition back in sync with the actual DP values.

No breaking changes are expected for users already relying on away/eco/comfort preset names in Home Assistant; only the underlying DP mapping is updated.