### PR TITLE
fix(ilife_a30_pro_vacuum): Use pause DP for activation, map correct status

### DIFF
--- a/custom_components/tuya_local/devices/ilife_a30_pro_vacuum.yaml
+++ b/custom_components/tuya_local/devices/ilife_a30_pro_vacuum.yaml
@@ -11,7 +11,7 @@ entities:
         name: power
       - id: 2
         type: boolean
-        name: activate
+        name: pause
       - id: 4
         type: string
         name: command
@@ -39,7 +39,7 @@ entities:
           - dps_val: standby
             value: standby
           - dps_val: smart
-            value: smart
+            value: cleaning
           - dps_val: zone_clean
             value: zone
           - dps_val: part_clean

--- a/custom_components/tuya_local/vacuum.py
+++ b/custom_components/tuya_local/vacuum.py
@@ -45,6 +45,7 @@ class TuyaLocalVacuum(TuyaLocalEntity, StateVacuumEntity):
         self._locate_dps = dps_map.get("locate")
         self._power_dps = dps_map.get("power")
         self._activate_dps = dps_map.get("activate")
+        self._pause_dps = dps_map.get("pause")
         self._direction_dps = dps_map.get("direction_control")
         self._error_dps = dps_map.get("error")
         self._fan_dps = dps_map.pop("fan_speed", None)
@@ -77,7 +78,7 @@ class TuyaLocalVacuum(TuyaLocalEntity, StateVacuumEntity):
         if SERVICE_STOP in cmd_support:
             support |= VacuumEntityFeature.STOP
 
-        if self._activate_dps:
+        if self._activate_dps or self._pause_dps:
             support |= VacuumEntityFeature.START | VacuumEntityFeature.PAUSE
         else:
             if "start" in cmd_support:
@@ -136,6 +137,8 @@ class TuyaLocalVacuum(TuyaLocalEntity, StateVacuumEntity):
             await dps.async_set_value(self._device, "start")
         elif self._activate_dps:
             await self._activate_dps.async_set_value(self._device, True)
+        elif self._pause_dps:
+            await self._pause_dps.async_set_value(self._device, False)
 
     async def async_pause(self):
         """Pause the vacuum cleaner."""
@@ -144,6 +147,8 @@ class TuyaLocalVacuum(TuyaLocalEntity, StateVacuumEntity):
             await dps.async_set_value(self._device, "pause")
         elif self._activate_dps:
             await self._activate_dps.async_set_value(self._device, False)
+        elif self._pause_dps:
+            await self._pause_dps.async_set_value(self._device, True)
 
     async def async_return_to_base(self, **kwargs):
         """Tell the vacuum cleaner to return to its base."""


### PR DESCRIPTION
1. **Tuya DPS structure:**
   - `switch_go` (dp_id: 1, type: bool)
   - `pause` (dp_id: 2, type: bool)
   - `switch_charge` (dp_id: 3, type: bool)

2. Previously, using the **`activate`** DPS caused incorrect behavior:
   - `start` was incorrectly triggering **pause = true**
   - `pause` was incorrectly triggering **pause = false**

3. Updated the logic to use the **`pause` DPS** directly for proper start/pause handling.

4. Adjusted status mapping so that the Tuya `"smart"` mode is now correctly recognized as **`cleaning`**.

 **Tuya DPS structure:**
   ```json
   {
     "code": "switch_go",
     "custom_name": "",
     "dp_id": 1,
     "time": 1764709913492,
     "type": "bool",
     "value": false
   },
   {
     "code": "pause",
     "custom_name": "",
     "dp_id": 2,
     "time": 1764665210045,
     "type": "bool",
     "value": false
   },
   {
     "code": "switch_charge",
     "custom_name": "",
     "dp_id": 3,
     "time": 1764710024252,
     "type": "bool",
     "value": false
   }
 ```  