### PR TITLE
Add SIME ECOMAXI VB 200 heat pump water heater

### DIFF
--- a/custom_components/tuya_local/devices/sime_ecomaxi_vb200_waterheater.yaml
+++ b/custom_components/tuya_local/devices/sime_ecomaxi_vb200_waterheater.yaml
@@ -1,8 +1,8 @@
-name: Heat pump water heater
+name: Water heater
 products:
   - id: ukqqxsk7vfz8co9z
-    manufacturer: SIME
-    model: ECOMAXI VB 200 WiFi
+    manufacturer: Sime
+    model: EcoMaxi VB 200 WiFi
 entities:
   - entity: water_heater
     dps:
@@ -125,7 +125,7 @@ entities:
   - entity: binary_sensor
     name: Water pump
     icon: "mdi:pump"
-    class: power
+    class: running
     category: diagnostic
     dps:
       - id: 28
@@ -134,7 +134,7 @@ entities:
   - entity: binary_sensor
     name: Compressor
     icon: "mdi:engine"
-    class: power
+    class: running
     category: diagnostic
     dps:
       - id: 29
@@ -143,7 +143,7 @@ entities:
   - entity: binary_sensor
     name: Fan
     icon: "mdi:fan"
-    class: power
+    class: running
     category: diagnostic
     dps:
       - id: 27
@@ -159,7 +159,6 @@ entities:
   - entity: binary_sensor
     name: Electric heater
     icon: "mdi:lightning-bolt"
-    class: power
     category: diagnostic
     dps:
       - id: 33


### PR DESCRIPTION
Added new device config custom_components/tuya_local/devices/sime_ecomaxi_vb200_heatpump.yaml for SIME ECOMAXI VB 200 heat pump water heater: climate (on/off, presets auto/eco/turbo, setpoint 35–65 °C, current temp) + switches (power, anti-legionella, electric anode) + diagnostic sensors/binary_sensors (evaporator/air outlet/ambient/solar collector temps, EEV opening, board temps, pump/compressor/fan, defrost, electric heater, error code). Names/icons inline; no new translation keys or global icons.
<img width="753" height="887" alt="Screenshot 2025-12-11 at 10 26 17" src="https://github.com/user-attachments/assets/cb2be7f7-35d4-4bfd-a008-771b6e88bf75" />

Tests: pytest tests/test_device_config.py; yamllint
 custom_components/tuya_local/devices/sime_ecomaxi_vb200_heatpump.yaml

Product details:
https://doc.sime.it/SimeWSPortale/DownloadPdf?docId=3296f1ce-860e-4115-a285-827b28e28a96&fileName=6333542G%20Ecomaxi%20VB%20200-300%20(IT-EN-ES-DE-EL-FR-NL).pdf&lingua=EN

