### PR TITLE
fix(vacuum): Mark status 'docked' as entity state 'docked'

### DIFF
--- a/custom_components/tuya_local/vacuum.py
+++ b/custom_components/tuya_local/vacuum.py
@@ -104,7 +104,7 @@ class TuyaLocalVacuum(TuyaLocalEntity, StateVacuumEntity):
             return VacuumActivity.IDLE
         elif status == "paused":
             return VacuumActivity.PAUSED
-        elif status in ["charging", "charged"]:
+        elif status in ["charging", "charged", "docked"]:
             return VacuumActivity.DOCKED
         elif self._power_dps and self._power_dps.get_value(self._device) is False:
             return VacuumActivity.IDLE


### PR DESCRIPTION
When DP value is mapped to **docked** as status state of the device is shown as **idle**

<img width="1051" height="234" alt="image" src="https://github.com/user-attachments/assets/801d7831-7c4c-442c-98c4-dc0709097d0a" />
