### PR TITLE
Add support for Martec Viper DC WiFi Ceiling Fans

### DIFF
--- a/custom_components/tuya_local/devices/martec_viper_fan_light.yaml
+++ b/custom_components/tuya_local/devices/martec_viper_fan_light.yaml
@@ -13,6 +13,7 @@ entities:
       - id: 2
         type: string
         name: preset_mode
+        optional: true
         mapping:
           - dps_val: nature
             value: nature
@@ -27,6 +28,7 @@ entities:
       - id: 3
         name: speed
         type: integer
+        optional: true
         range:
           min: 1
           max: 6
@@ -38,9 +40,11 @@ entities:
       - id: 15
         name: switch
         type: boolean
+        optional: true
       - id: 16
         name: brightness
         type: integer
+        optional: true
         range:
           min: 1
           max: 100
@@ -60,6 +64,7 @@ entities:
       - id: 19
         type: string
         name: fixed_color_temp
+        optional: true
         hidden: true
         mapping:
           - dps_val: night


### PR DESCRIPTION
## Summary
Adds support for Martec Viper DC WiFi Ceiling Fans with and without light.

## Devices Added
- **martec_viper_fan.yaml** - Martec Viper DC WiFi Ceiling Fan (fan only model)
- **martec_viper_fan_light.yaml** - Martec Viper DC WiFi Ceiling Fan with Light

## Product Information
- Product ID: `lb9da3os0ihifq7u`
- Manufacturer: Martec
- Protocol: Fan only uses 3.3, Fan with light uses 3.5
- Product pages:
  - With light: https://www.martecaustralia.com.au/product/viper-dc-ceiling-fan-with-light/
  - Fan only: https://www.martecaustralia.com.au/product/viper-dc-ceiling-fan/

## Features Supported

### Fan
- Power switch (DP 1)
- Preset modes: nature, sleep, fresh, smart, custom (DP 2)
- Speed control: 6 speeds, auto-scaled to percentage (DP 3)
- Direction control: forward/reverse (DP 8)
- Timer: cancel, 1h-8h (DP 22)

### Light (with light model only)
- Power switch (DP 15)
- Brightness: 1-100% (DP 16)
- Color temperature: continuous 2700K-6000K (DP 17) or fixed presets (DP 19)
- Fixed color temperature presets: Night, Warm, White, Cool

## Testing
Tested with models MVDC134W (fan only) and MVDC1343W (with light). All functions working as expected.

All Viper DC variants should be compatible if they share the same WiFi module and only differ in physical attributes (color, size, number of blades).