### PR TITLE
fix(ilife_a30_pro_vacuum): Use switch_go as activate and pasuse as pause 

### DIFF
--- a/custom_components/tuya_local/devices/ilife_a30_pro_vacuum.yaml
+++ b/custom_components/tuya_local/devices/ilife_a30_pro_vacuum.yaml
@@ -8,15 +8,39 @@ entities:
     dps:
       - id: 1
         type: boolean
-        name: power
+        name: activate
+        optional: true
+        mapping:
+          - dps_val: false
+            constraint: pause
+            conditions:
+              - dps_val: true
+                value: false
+              - dps_val: false
+                value: false
+                hidden: true
+              - dps_val: null
+                value: false
+                hidden: true
+          - dps_val: true
+            constraint: pause
+            conditions:
+              - dps_val: false
+                value: true
+              - dps_val: true
+                value: true
+                hidden: true
+              - dps_val: null
+                value: true
+                hidden: true
+          - dps_val: null
+            value: false
+            hidden: true
       - id: 2
         type: boolean
-        name: activate
-        mapping:
-          - dps_val: true
-            value: false
-          - dps_val: false
-            value: true
+        optional: true
+        name: pause
+        hidden: true
       - id: 4
         type: string
         name: command


### PR DESCRIPTION
Still there is issue when device is in sleep - "start" does not wake the device, only clicking "pause" makes it start cleaning (previous was the same)
But I fixed it with local automation/scripts 

This change was copied from another ilife vac config to match properties from Tuya cloud of my device, and expected behaviour
```
  "result": {
    "properties": [
      {
        "code": "switch_go",
        "custom_name": "",
        "dp_id": 1,
        "time": 1766253794142,
        "type": "bool",
        "value": false
      },
      {
        "code": "pause",
        "custom_name": "",
        "dp_id": 2,
        "time": 1766252969952,
        "type": "bool",
        "value": false
      },
```