### PR TITLE
Outdoor Tuya WiFi SmartPlug support added

### DIFF
--- a/custom_components/tuya_local/devices/smart_plug_outdoor_wifi_ble.yaml
+++ b/custom_components/tuya_local/devices/smart_plug_outdoor_wifi_ble.yaml
@@ -1,0 +1,95 @@
+name: Outdoor Smart Plug
+products:
+  - id: as9lf4slujgvu5tm
+    name: Outdoor Smart plug_Wi-Fi_BLE
+    model: ZhiYun-P01
+
+entities:
+  - entity: switch
+    class: outlet
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: Energy added
+    class: energy
+    hidden: true 
+    category: diagnostic
+    dps:
+      - id: 17
+        type: integer
+        name: sensor
+        unit: kWh
+        optional: true
+        force: true
+        mapping:
+          - scale: 1000          
+
+  - entity: sensor
+    name: Current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        class: measurement
+        unit: mA
+        optional: true
+        force: true
+
+  - entity: sensor
+    name: Power
+    class: power
+    state_class: measurement
+    category: diagnostic
+    dps:
+      - id: 19
+        type: integer
+        name: sensor
+        class: measurement
+        unit: W
+        optional: true
+        force: true
+        mapping:
+          - scale: 10
+            constraint: switch
+            conditions:
+              - dps_val: false
+                value: 0
+      - id: 1
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: Voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        class: measurement
+        unit: V
+        optional: true
+        force: true
+        mapping:
+          - scale: 10
+
+  - entity: select
+    name: Power-on state
+    category: config
+    translation_key: initial_state
+    dps:
+      - id: 38
+        type: string
+        name: option
+        mapping:
+          - dps_val: power_on
+            value: "ON"
+          - dps_val: power_off
+            value: "OFF"
+          - dps_val: last
+            value: "Maintain last status"


### PR DESCRIPTION
# Add support for ZhiYun-P01 Outdoor Smart Plug

## Description

This PR adds support for a new outdoor smart plug device with energy monitoring capabilities.

## Device Information

- **Product ID**: `as9lf4slujgvu5tm`
- **Model**: ZhiYun-P01
- **Device Name**: Outdoor Smart plug_Wi-Fi_BLE
- **Type**: EU Smart Plug (Outdoor/Waterproof)
- **Purchase Link**: [AliExpress](https://es.aliexpress.com/item/1005007267944947.html)

## Device Specifications

- Input/Output: 100-240V
- Power: 1000-2400W (Max 16A)
- Connectivity: WiFi 2.4GHz (IEEE 802.11b/g/n)
- Voice Control: Alexa, Google Assistant compatible
- Features: Remote control, energy monitoring, countdown/timing

## Data Points (DPs) Implemented

| DP | Type | Description | Scaling/Notes |
|----|------|-------------|---------------|
| 1 | boolean | Main switch | On/Off control |
| 17 | integer | Energy consumption | Scale: ÷1000 (raw value → kWh) |
| 18 | integer | Current | Unit: mA |
| 19 | integer | Power | Scale: ÷10 (raw value → W) |
| 20 | integer | Voltage | Scale: ÷10 (raw value → V) |
| 38 | string | Power-on state | Values: `power_on`, `power_off`, `last` |

## Features

- ✅ Main switch control (outlet)
- ✅ Energy monitoring (kWh)
- ✅ Current measurement (mA)
- ✅ Power measurement (W)
- ✅ Voltage measurement (V)
- ✅ Configurable power-on state (ON/OFF/Last status)

## Testing

- Device successfully integrated with Home Assistant
- All sensors report correct values
- Switch control works reliably
- Energy monitoring sensors properly scaled

## Screenshots

![img_device2](https://github.com/user-attachments/assets/1e956a07-5024-4beb-8e07-b110b7cbd901)
![img_device1](https://github.com/user-attachments/assets/048d28f7-81af-4ac0-8ce5-893f9ce72f8f)
<img width="587" height="566" alt="outdoor_smart_plug1" src="https://github.com/user-attachments/assets/7947f1dc-a349-475a-97b6-7ebdbe9e344e" />
<img width="701" height="974" alt="outdoor_smart_plug" src="https://github.com/user-attachments/assets/1a7394f7-9edc-4138-a6c9-d33e1180a723" />

## Additional Notes

- All energy monitoring sensors are marked as `optional: true` and `force: true` as they may not be available on all firmware versions
- Power sensor returns 0 when switch is OFF (implemented via constraint)
- Configuration file follows the project's naming conventions and structure
