### PR TITLE
AlecoAir PU55 Humino Improvements

### DIFF
--- a/custom_components/tuya_local/devices/alecoair_pu55_humino.yaml
+++ b/custom_components/tuya_local/devices/alecoair_pu55_humino.yaml
@@ -55,6 +55,7 @@ entities:
 
   - entity: sensor
     name: Filter Life
+    icon: mdi:air-filter
     dps:
       - id: 5
         name: sensor
@@ -80,6 +81,7 @@ entities:
 
   - entity: sensor
     name: Clean water tank
+    icon: mdi:water-opacity
     dps:
       - id: 106
         name: sensor
@@ -123,6 +125,11 @@ entities:
       - id: 103
         name: switch
         type: boolean
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true
 
   - entity: switch
     name: Dry Fan


### PR DESCRIPTION
I wish to add 3 improvements to the AlecoAir PU55 Humino:
1. reverse the light switch - in orther to correctly map the actual state of the light
2. add icon for filter life 
3. add icon for clean water tank 
