### PR TITLE
Create inkbird_ivc001w_fan.yaml

### DIFF
--- a/custom_components/tuya_local/devices/inkbird_ivc001w_fan.yaml
+++ b/custom_components/tuya_local/devices/inkbird_ivc001w_fan.yaml
@@ -59,7 +59,6 @@ entities:
         optional: true
         mask: "00FFFF00000000000000000000"
         mask_signed: true
-        endianness: big
         name: current_temperature
         mapping:
           - scale: 10
@@ -67,7 +66,6 @@ entities:
         type: base64
         optional: true
         mask: "0000000000FFFF000000000000"
-        endianness: big
         name: current_humidity
         mapping:
           - scale: 10
@@ -128,7 +126,6 @@ entities:
         type: base64
         optional: true
         mask: "000000000000000000FFFF0000"
-        endianness: big
         name: value
         unit: C
         range:
@@ -146,7 +143,6 @@ entities:
         type: base64
         optional: true
         mask: "0000000000000000000000FFFF"
-        endianness: big
         name: value
         unit: C
         range:
@@ -163,6 +159,5 @@ entities:
         type: base64
         optional: true
         mask: "00000000000000FFFF00000000"
-        endianness: big
         name: sensor
         unit: rpm


### PR DESCRIPTION
Device is unusual in that it does not follow the normal design of either a thermostat or HVAC device and is much more similar to a fan with a bunch of extra settings. 

Also does a very non standard base64 encoded string to show current sensor readings that needs a set of template sensors to expose sadly - would be amazing to have the ability to do "virtual" DP's and base64 decoding/encoding natively. 


I left the comments in for the bits that really need explaining as the device is weird - most people using this in HA will purely be looking to easily control the fan and speed rather than using all of the capabilities of the device.