### PR TITLE
Update device_config.py - add support for bitwise masking on integer DPs

### DIFF
--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -478,11 +478,7 @@ class TuyaDpsConfig:
         mask = self.mask
         # Get raw value directly avoiding accidental scaling by decoded_value()
         raw_from_device = device.get_property(self.id)
-        # Decode only if strictly required (hex/base64) otherwise assume it's the raw int
-        if self.rawtype in ["hex", "base64", "utf16b64"]:
-            bytevalue = self.decode_value(raw_from_device, device)
-        else:
-            bytevalue = raw_from_device
+        bytevalue = self.decode_value(raw_from_device, device)
 
         if mask and isinstance(bytevalue, bytes):
             value = int.from_bytes(bytevalue, self.endianness)
@@ -1092,10 +1088,7 @@ class TuyaDpsConfig:
             if self.id in pending_map:
                 decoded_value = self.decode_value(pending_map[self.id], device)
             else:
-                if self.rawtype in ["hex", "base64", "utf16b64"]:
-                    decoded_value = self.decode_value(raw_current, device)
-                else:
-                    decoded_value = raw_current
+                decoded_value = self.decode_value(raw_current, device)
 
             if isinstance(decoded_value, int):
                 current_value = decoded_value


### PR DESCRIPTION
Its been a while since I was this deep in the weeds with Python but here we go...
Feel free to edit however you prefer!

This PR addresses an issue where using the mask parameter on data points of type: integer would result in correctable crashes and incorrect data parsing. This is required due to at least one device (Inkbird IVC-001W) that presents DPs in this fashion but I am sure that there are others out there.

Previously, the masking logic in device_config.py assumed that any masked value was a byte array (hex/base64). This caused two issues for packed integers (e.g., two 16-bit values packed into a 32-bit integer):

On read: The mask was ignored, returning the full raw integer instead of the specific bit range.

On write: The integration crashed with cannot convert 'float' object to bytes because it attempted to pass a numeric value into int.from_bytes.

Changes:

Updated get_value to check if the raw value is an integer. If so, it applies the mask and bit-shift directly without byte conversion.

Updated get_values_to_set to implement a "Read-Modify-Write" cycle for integers. It reads the current device state, clears the masked bits, and merges the new value, ensuring the unmasked parts of the integer remain untouched.

Backwards compatibility notes: The new logic only triggers if mask is defined and the raw value is an integer; existing hex/base64 implementations are unaffected.