### PR TITLE
Add Ventilation RPM sensor to heatpump configuration

### DIFF
--- a/custom_components/tuya_local/devices/steinbach_solid_4.3_heatpump.yaml
+++ b/custom_components/tuya_local/devices/steinbach_solid_4.3_heatpump.yaml
@@ -73,7 +73,7 @@ entities:
         type: bitfield
         name: fault_code
   - entity: sensor
-    name: Fan
+    name: Fan speed
     category: diagnostic
     icon: mdi:fan
     dps:
@@ -81,4 +81,4 @@ entities:
         type: integer
         optional: true
         name: sensor
-        unit: "rpm"
+        unit: rpm


### PR DESCRIPTION
Nothing special, just added a new sensor: added Ventilation RPM sensor with diagnostic category.