### PR TITLE
Add support for Jafanda JF500 air purifier

### DIFF
--- a/custom_components/tuya_local/devices/jafanda_jf500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/jafanda_jf500_airpurifier.yaml
@@ -107,4 +107,3 @@ entities:
         range:
           min: 0
           max: 12
-


### PR DESCRIPTION
Submitting config for [Jafända JF500 Air Purifier](https://www.jafanda.com/en-ca/products/jafanda-jf500-air-purifier)

First submission, have referenced `devices/README.md` and done my best to follow guidelines, while reviewing other yaml and PRs to find and follow conventions and best practice.

#### Device details
- Manufacturer: Jafanda
- Model: JF500
- Product ID (PID): `vpb3fd5rhtgd7b4t`

#### Supported features
- Fan control with preset modes (`manual`, `auto`)
- Fan speed control (DP101, range 1–5)
- PM2.5 sensor
- Air quality sensor (`excellent`, `good`, `average`, `poor`)
  - `average` normalized to `moderate` for HA consistency
- Filter life sensor (%)
- Filter reset button
- Child lock
- Countdown timer (DP102, 0–12 hours)
- Dial lighting exposed as a `light` entity with stepped brightness:
  - Off → 0
  - 50% → 128
  - 100% → 255  
  (DP103 enum values: `lightoff`, `fifty_percent`, `a_hundred_percent`)

#### Notes / implementation details
- Dial lighting is modeled as a `light` with fixed brightness mappings, per `/devices/README.md` guidance
- Name "Dial lighting" chosen based on it literally being a rotary dial / knob (see screenshot), which includes three components, two of which illuminate (third is rotation for fan speed)
  1. RGB ring
  1. The central display
  - States are:
    - 0 → both off
    - 50 → ring dimmed, display on
    - 100 → ring full, display on
  - So the "thing" is neither just a light nor just a display, or an atmosphere/ambiance lamp (like the JF260S[^1]).
  - Couldn't find an appropriate `translation_key` so added literal `name:`
- Verified correct behavior for:
  - `light.turn_on` / `light.turn_off`
  - Brightness slider snapping to nearest supported value
- Air quality values confirmed via Tuya Cloud “Things Data Model” API and LAN DP logging
  - `average` normalized to `moderate` for HA consistency
- All DP mappings validated against live device traffic using Tuya Local debug logging
- Wasn't sure if filename should be suffixed to include the type, seems a slightly mixed bag
  - `jafanda_jf500.yaml` → `jafanda_jf500_airpurifier.yaml`

#### Testing
- Tested locally on a physical Jafanda JF500
- All entities update correctly and reflect state changes from:
  - Home Assistant
  - Physical device controls
  - Tuya app

---

<img width="704" height="340" alt="image" src="https://github.com/user-attachments/assets/5ea342f8-b4fd-4397-b109-1287be91cd8b" />


<img width="1050" height="963" alt="image" src="https://github.com/user-attachments/assets/9f047f51-3bee-4700-96d0-eb7f44497729" />


Payload from Query Things Data Model
```json
{
  "modelId": "emqj38",
  "services": [
    {
      "actions": [],
      "code": "",
      "description": "",
      "events": [],
      "name": "默认服务",
      "properties": [
        {
          "abilityId": 1,
          "accessMode": "rw",
          "code": "switch",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_power2",
            "attribute": "1152"
          },
          "name": "开关",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 2,
          "accessMode": "ro",
          "code": "pm25",
          "description": "",
          "extensions": {
            "iconName": "icon-pm",
            "attribute": "1152"
          },
          "name": "PM2.5",
          "typeSpec": {
            "type": "value",
            "max": 999,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "ug/m3"
          }
        },
        {
          "abilityId": 3,
          "accessMode": "rw",
          "code": "mode",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_mode",
            "attribute": "1152"
          },
          "name": "模式",
          "typeSpec": {
            "type": "enum",
            "range": [
              "manual",
              "auto"
            ]
          }
        },
        {
          "abilityId": 5,
          "accessMode": "ro",
          "code": "filter_life",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_time2",
            "attribute": "1152"
          },
          "name": "滤芯寿命",
          "typeSpec": {
            "type": "value",
            "max": 100,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "%"
          }
        },
        {
          "abilityId": 7,
          "accessMode": "rw",
          "code": "child_lock",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_power2",
            "attribute": "1152"
          },
          "name": "童锁",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 11,
          "accessMode": "rw",
          "code": "filter_reset",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_loop",
            "attribute": "1152"
          },
          "name": "滤芯复位",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 21,
          "accessMode": "ro",
          "code": "air_quality",
          "description": "",
          "extensions": {
            "iconName": "icon-air_quality",
            "attribute": "1152"
          },
          "name": "空气质量",
          "typeSpec": {
            "type": "enum",
            "range": [
              "excellent",
              "good",
              "average",
              "poor"
            ]
          }
        },
        {
          "abilityId": 101,
          "accessMode": "rw",
          "code": "fanspeed",
          "description": "",
          "name": "风速",
          "typeSpec": {
            "type": "value",
            "max": 5,
            "min": 1,
            "scale": 0,
            "step": 1,
            "unit": "档"
          }
        },
        {
          "abilityId": 102,
          "accessMode": "rw",
          "code": "countdown",
          "description": "",
          "name": "倒计时",
          "typeSpec": {
            "type": "value",
            "max": 12,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "小时"
          }
        },
        {
          "abilityId": 103,
          "accessMode": "rw",
          "code": "userlight",
          "description": "",
          "name": "灯光",
          "typeSpec": {
            "type": "enum",
            "range": [
              "lightoff",
              "fifty_percent",
              "a_hundred_percent"
            ]
          }
        }
      ]
    }
  ]
}
```

[^1]: https://github.com/make-all/tuya-local/blob/main/custom_components/tuya_local/devices/jafanda_jf260s_airpurifier.yaml