### PR TITLE
Add MiBoxer WL-Box2 2.4GHz Gateway

### DIFF
--- a/custom_components/tuya_local/devices/miboxer_wlbox2_lighting.yaml
+++ b/custom_components/tuya_local/devices/miboxer_wlbox2_lighting.yaml
@@ -1,11 +1,10 @@
-name: Lighting Controller
+name: Lighting controller
 products:
   - id: "2vc0xj19d766eq0k"
     manufacturer: "MiBoxer"
     model: "WL-Box2"
 entities:
   - entity: light
-    name: Light
     dps:
       - id: 20
         type: boolean


### PR DESCRIPTION
Adds support for MiBoxer WL-Box2 2.4GHz Gateway including switching lighting zones.