### PR TITLE
Add support for EFENZ Kith ceiling fan

### DIFF
--- a/custom_components/tuya_local/devices/efenz_kith_fanlight.yaml
+++ b/custom_components/tuya_local/devices/efenz_kith_fanlight.yaml
@@ -1,4 +1,3 @@
----
 name: Ceiling Fan
 products:
   - id: knhfgnbpneqras2y
@@ -37,6 +36,9 @@ entities:
         type: string
         optional: true
         name: direction
+      - id: 1
+        type: boolean
+        name: available
   - entity: light
     dps:
       - id: 15
@@ -58,3 +60,13 @@ entities:
           - target_range:
               min: 2700
               max: 6500
+      - id: 1
+        type: boolean
+        name: available
+  - entity: switch
+    name: Power
+    category: config
+    dps:
+      - id: 1
+        type: boolean
+        name: switch


### PR DESCRIPTION
Adding support for EFENZ Ceiling Fan ("Hugger" model from Kith collection)
https://www.efenz.com.sg/Products/Hugger-Ceiling-Fan.
Their site seems to have an issue displaying the product, alternative [link](https://www.mynewfan.com/products/efenz-kith-series-hugger-ceiling-fan) from a distributor's website.

This is a ceiling fan with controls as follows:
1. Fan speed control (1 to 5)
2. Fan preset modes (Nature/Sleep)
3. Light On/Off
4. Tri-tone light control (color temperature)

Note: I opted to use id 101 instead of "1" for fan control as id "1" will turn off the entire unit, fan and light included.