### PR TITLE
New device: Stadler Form Noah and Noah Pro

### DIFF
--- a/custom_components/tuya_local/devices/stadlerform_noah_humidifier.yaml
+++ b/custom_components/tuya_local/devices/stadlerform_noah_humidifier.yaml
@@ -58,7 +58,7 @@ entities:
         type: boolean
         name: lock
   - entity: sensor
-    name: Filter Usage
+    name: Filter usage
     icon: mdi:filter
     category: diagnostic
     dps:
@@ -67,7 +67,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Water Level
+    name: Water level
     icon: mdi:cup-water
     category: diagnostic
     dps:
@@ -90,7 +90,7 @@ entities:
           - dps_val: Light_off
             value: 0
   - entity: binary_sensor
-    name: Filter Change Required
+    name: Filter change
     class: problem
     category: diagnostic
     dps:


### PR DESCRIPTION
Stadler Form Noah Pro Humidifier support added.

Implemented:
1. Humidifier with switch, current humidity, humidity and mode
2. Fan Speed
3. Child Lock
4. Filter Usage
5. Water Level
6. Display night mode
7. Filter Change Warning
8. Empty Tank Warning

![Stadler Form Noah Pro Home Assistant](https://github.com/user-attachments/assets/7ba9b5de-52c3-4e07-b488-e5c14e4cbfd2)