### PR TITLE
AC Doorbell Support added

### DIFF
--- a/custom_components/tuya_local/devices/ac_video_doorbell.yaml
+++ b/custom_components/tuya_local/devices/ac_video_doorbell.yaml
@@ -25,7 +25,7 @@ entities:
         name: raw_event
         optional: true
         persist: false
-        
+
   # Indicator and video settings
   - entity: switch
     name: Status indicator


### PR DESCRIPTION
## Summary
Adds local support for the **AC Doorbell Pro** (Tuya product `asw99ynhd4dgwi37`, hardware model **DDV207-Pro / Chamous video doorbell**) to Tuya Local.  
The config exposes doorbell press events, motion/recording controls, siren, SD-card management and other options. Video streaming remains out of scope for Tuya Local; snapshots are surfaced when the device sends them.

## Device information
- Brand / listing: [Chamous AC Doorbell Pro WiFi Video Doorbell](https://es.aliexpress.com/item/1005005086039609.html)  
- Tuya product: `asw99ynhd4dgwi37`  
- Model reported by device: `DDV207-Pro`  
- Category: `sp`  
- Protocol version: 3.5

## DP mapping highlights
| DP  | Code                  | Purpose                              | Notes                               |
|-----|----------------------|---------------------------------------|-------------------------------------|
| 101 | `basic_indicator`    | Status LED                            | Switch entity                       |
| 103 | `basic_flip`         | Image flip                            | Switch                               |
| 104 | `basic_osd`          | Time watermark                        | Switch                               |
| 106 | `motion_sensitivity` | Motion sensitivity                    | Select (Low/Medium/High)            |
| 108 | `basic_nightvision`  | Night vision mode                     | Select (Auto/Infrared/Color)        |
| 111 | `sd_format`          | SD card format                        | Button + diagnostic attributes      |
| 134 | `motion_switch`      | Motion detection enable               | Switch (mirrors Tuya app toggle)    |
| 136 | `doorbell_active`    | Legacy bell DP                        | Exposed as diagnostic sensor        |
| 150 | `record_switch`      | SD recording                          | Switch                              |
| 151 | `record_mode`        | Recording mode                        | Select (continuous/events)          |
| 159 | `siren_switch`       | Built-in siren                        | Switch                              |
| 160 | `basic_device_volume`| Doorbell volume                       | Number 1–10                         |
| 168 | `motion_area_switch` | Motion area enable                    | Switch                              |
| 169 | `motion_area`        | Motion mask definition                | Text entity                         |
| 170 | `humanoid_filter`    | Human-shape filter                    | Switch                              |
| 185 | `alarm_message`      | Alarm payload                         | Diagnostic sensor (base64/raw)      |
| 197 | `ipc_mute_record`    | Mute SD recordings                    | Switch                              |
| 212 | `initiative_message` | Doorbell press payload                | Event entity (`ring`) + raw payload |
| 231 | `ipc_anti_dismantle` | Anti-tamper alarm                     | Switch                              |

Doorbell presses are reported by DP 212 (base64 JSON `cmd: "ipc_doorbell"`); DP 136 stayed empty in testing.

Please note, the already existing integrations (like kw02 doesn't work with this doorbell!!!)

## Entities exposed
- `event` – doorbell ringing (class `doorbell`, emits `ring`)
- `camera` – still snapshot / motion enable (no live video)
- `switch` – status LED, image flip, watermark, motion detection, motion area enable, human filter, SD recording, mute recording, siren, anti-dismantle alarm
- `select` – motion sensitivity, night vision mode, recording mode
- `number` – doorbell volume
- `text` – motion area mask
- `button` – format SD card (with capacity/status attributes)
- Diagnostic sensors for snapshots, alarm/push payloads, SD info, legacy doorbell DP

## Testing
- Home Assistant OS 2025.12.5 on Home Assistant Green (aarch64)
- Tuya Local 2025.12.3 (tinytuya 1.17.4)
- Doorbell press events confirmed (DP 212 → `ring`)
- Motion detection, siren, controls, etc. verified via Tuya app & HA
- Snapshots appear only when the doorbell publishes them (otherwise camera returns HTTP 503, expected)

## Screenshots
1. Screenshot 1 – 
<img width="1120" height="877" alt="db1" src="https://github.com/user-attachments/assets/ebd893aa-8480-478d-9fb5-2248b5768352" />

2. Screenshot 2 – 
<img width="774" height="806" alt="db2" src="https://github.com/user-attachments/assets/626a0c81-6595-4121-95c8-95735438392f" />

3. Screenshot 3 – 
<img width="742" height="908" alt="db3" src="https://github.com/user-attachments/assets/0291659a-f536-495e-8b98-778afe74493c" />

P.S. Most important for me is to receive events when somebody ringing. This very useful for the automations.
I didn't found in any existing integrations with correct ring events (i.e. kw02 doesn't work).