### PR TITLE
Add Engo E901WiFi Thermostat (X3TH09RW) configuration

### DIFF
--- a/custom_components/tuya_local/devices/engo_e901wifi_thermostat.yaml
+++ b/custom_components/tuya_local/devices/engo_e901wifi_thermostat.yaml
@@ -19,7 +19,7 @@ entities:
         name: hvac_action
         type: string
         mapping:
-          - dps_val: heating_on           
+          - dps_val: heating_on
             value: heating
             constraint: hvac_mode
             conditions:


### PR DESCRIPTION
New device configuration, not found in database before.

The work was checked on a personal HA.