### PR TITLE
Add Fairland Mr.Pure salt chlorinator alternative product

### DIFF
--- a/custom_components/tuya_local/devices/mrpure_saltchlorinator.yaml
+++ b/custom_components/tuya_local/devices/mrpure_saltchlorinator.yaml
@@ -159,6 +159,7 @@ entities:
     dps:
       - id: 114
         type: boolean
+        optional: true
         name: sensor
         mapping:
           - dps_val: true
@@ -171,6 +172,7 @@ entities:
     dps:
       - id: 115
         type: boolean
+        optional: true
         name: sensor
         mapping:
           - dps_val: true
@@ -183,6 +185,7 @@ entities:
     dps:
       - id: 116
         type: boolean
+        optional: true
         name: sensor
         mapping:
           - dps_val: true
@@ -195,6 +198,7 @@ entities:
     dps:
       - id: 117
         type: boolean
+        optional: true
         name: sensor
         mapping:
           - dps_val: true


### PR DESCRIPTION
My Fairland InverX Mr.Pure salt chlorinator wasn't detected as such by tuya-local. The front of the device has "Fairland InverX" instead of the Aquark logo. I looked up the product ID in the Tuya platform, added it to the yaml locally, after which it was detected correctly.

Product: https://www.fairlandgroup.com/product-18/200.html