### PR TITLE
Add Treatlife Smart Dimmer Switch to devices list

### DIFF
--- a/custom_components/tuya_local/devices/feit_dimmer.yaml
+++ b/custom_components/tuya_local/devices/feit_dimmer.yaml
@@ -6,6 +6,9 @@ products:
   - id: wfdsj5zxjwmcqezm
     manufacturer: Moes
     model: WS-SY-EUD-WH-MS
+  - id: aahxaxzdyuriashj
+    manufacturer: Treatlife
+    name: Smart Dimmer Switch
 entities:
   - entity: light
     dps:


### PR DESCRIPTION
This PR adds support for the Treatlife Smart Dimmer Switch by including its Tuya Product ID (`aahxaxzdyuriashj`) in the existing FEIT Dimmable Light definition.

The FEIT template works correctly with this device:
- Correct brightness range (10–1000)
- Correct DP mapping
- Correct on/off behavior

Two dimmers were in the list presented during Add Device.  The Gosund dimmer template does not fully work (brightness scaling mismatch).  The FEIT definition works perfectly with the Treatlife dimmer.

This change simply adds the Treatlife PID to the `products` list so Tuya Local can auto-identify it.