### PR TITLE
Fix typo in dps_val for electric value

### DIFF
--- a/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
@@ -22,7 +22,7 @@ entities:
                 value: heat_pump
               - dps_val: HYB1
                 value: performance
-              - dps_val: ELE
+              - dps_val: Ele
                 value: electric
       - id: 2
         type: string


### PR DESCRIPTION
Captialised "ELE" doesn't work for electric mode, it needs to be "Ele". Tested and confirmed working.