### PR TITLE
Neopower Heatpump Fix dps value and update temperature range

### DIFF
--- a/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/neopower_heat_pump_water_heater.yaml
@@ -22,7 +22,7 @@ entities:
                 value: heat_pump
               - dps_val: HYB1
                 value: performance
-              - dps_val: ELE
+              - dps_val: Ele
                 value: electric
       - id: 2
         type: string
@@ -33,8 +33,8 @@ entities:
         name: temperature
         unit: C
         range:
-          min: 15
-          max: 75
+          min: 48
+          max: 70
       - id: 16
         type: integer
         name: current_temperature


### PR DESCRIPTION
Updated the device configuration for the neopower heat pump water heater by correcting a dps value and adjusting the temperature range.

"ELE" changed to "Ele" as ELE wasn't accepted as a valid setting to change to Electric/Element only mode.

Adjusted min and max temps to 48 and 70.
Values outside of this range are automatically set to the closest valid value so it makes sense to specifically set these to valid min/max values