### PR TITLE
Add support for Gidrolock Standard WiFi water leak sensor

### DIFF
--- a/custom_components/tuya_local/devices/gidrolock_standard_wifi.yaml
+++ b/custom_components/tuya_local/devices/gidrolock_standard_wifi.yaml
@@ -12,7 +12,6 @@ entities:
         name: valve
   - entity: binary_sensor
     class: moisture
-    category: diagnostic
     dps:
       - id: 101
         type: boolean


### PR DESCRIPTION
New device configuration, not found in database before.
Device can control water supply valve, automatically close it by leak caught on external sensor.
Guard can be disabled by enabling cleaning mode.