### PR TITLE
Add Tuya temp/humidity sensor PIDs to zigbee_zn373186_temphumid_sensor

### DIFF
--- a/custom_components/tuya_local/devices/zigbee_zn373186_temphumid_sensor.yaml
+++ b/custom_components/tuya_local/devices/zigbee_zn373186_temphumid_sensor.yaml
@@ -8,7 +8,7 @@ products:
     model: WS-ZIGBEE-TEST2
   - id: kkerjand
     manufacturer: Tuya
-    model: SZT06    
+    model: SZT06
 entities:
   - entity: sensor
     class: temperature


### PR DESCRIPTION
This PR adds two Tuya Zigbee temperature/humidity sensors to the existing zigbee_zn373186_temphumid_sensor.yaml device definition for automatic matching.

Added product IDs: dowj6gyi (model WS-ZIGBEE-TEST2), kkerjand (model SZT06)

Same DPS layout as the existing definition:

DP 1: temperature (0.1°C, scale 10)

DP 2: humidity (0.1%, scale 10)

DP 4: battery percentage (0–100, no scaling; optional)

Tested locally with Home Assistant + Tuya Local.