### PR TITLE
fix casdon_kg1_waterdispenser.yaml bug

### DIFF
--- a/custom_components/tuya_local/devices/casdon_kg1_waterdispenser.yaml
+++ b/custom_components/tuya_local/devices/casdon_kg1_waterdispenser.yaml
@@ -130,14 +130,13 @@ entities:
         name: current_temperature
 
   - entity: sensor
-    name: water_volume
+    class: volume
     category: diagnostic
     dps:
       - id: 26
         type: integer
         name: sensor
         unit: mL
-        class: measurement
 
   - entity: binary_sensor
     class: problem


### PR DESCRIPTION
To fix 
Entity sensor.inline_water_dispenser_ti_ji (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using state class 'measurement' which is impossible considering device class ('volume') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues

This entity only represents the water consumption for this specific instance; no statistics are needed, only measurements.

Entity sensor.inline_water_dispenser_ti_ji (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using native unit of measurement 'ml' which is not a valid unit for the device class ('volume') it is using; expected one of ['mL', 'MCF', 'ft³', 'CCF', 'L', 'gal', 'm³', 'fl. oz.']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues