### PR TITLE
Add Waterco Electroheat ECO-VS heat pump configuration

### DIFF
--- a/custom_components/tuya_local/devices/waterco_electroheat_eco-vs_heatpump.yaml
+++ b/custom_components/tuya_local/devices/waterco_electroheat_eco-vs_heatpump.yaml
@@ -71,7 +71,6 @@ entities:
   - entity: sensor
     category: diagnostic
     name: Power level
-    class: power_factor
     dps:
       - id: 109
         type: integer


### PR DESCRIPTION
Added configuration for Waterco Electroheat ECO-VS heat pump, which is a rebadged Madimack Elite V3, but requires a scaling factor of 10 on the water inlet and outlet temperatures.