### PR TITLE
Add device Poolstyle Heat Pump

### DIFF
--- a/custom_components/tuya_local/devices/poolstyle_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolstyle_heatpump.yaml
@@ -1,8 +1,8 @@
-name: Poolstyle heat pump
+name: Pool heat pump
 products:
   - id: jzansoxokgvqotyw
     manufacturer: Poolstyle
-    model: Swimming Pool Heat Pump
+    model: PSL-150-00xx
 entities:
   - entity: climate
     translation_only_key: pool_heatpump
@@ -14,7 +14,7 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            value: "auto"
+            value: heat_cool
       - id: 2
         name: temperature
         type: integer
@@ -54,7 +54,6 @@ entities:
           - dps_val: strong
             value: high
   - entity: binary_sensor
-    name: Status
     class: problem
     category: diagnostic
     dps:


### PR DESCRIPTION
Add support for Poolstyle heat pump device.

Here is a link to the manual for the device
https://heatpumps4pools.com/myfiles/file/Poolstyle-user-%20manual-2023-HP4P.pdf