### PR TITLE
Change class key to translation_only_key for meaco dd8l dehumidifier

### DIFF
--- a/custom_components/tuya_local/devices/meaco_dd8l_pro_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/meaco_dd8l_pro_dehumidifier.yaml
@@ -6,7 +6,7 @@ products:
 
 entities:
   - entity: humidifier
-    class: dehumidifier
+    translation_only_key: dehumidifier
     dps:
       - id: 1
         name: switch


### PR DESCRIPTION
Changes class to translation_only_key allowing modes to show with full names (e.g. 'laundry' becomes 'Dry clothes')