### PR TITLE
Add class `measurement` to power sensor on the Henden Essential Pool Heat Pump

### DIFF
--- a/custom_components/tuya_local/devices/henden_essential_pool_heatpump.yaml
+++ b/custom_components/tuya_local/devices/henden_essential_pool_heatpump.yaml
@@ -138,6 +138,7 @@ entities:
         type: integer
         unit: W
         optional: true
+        class: measurement
         # DPS 113 value is False, but
         # power _is_ correctly reported on DPS 112
         # - id: 113


### PR DESCRIPTION
This allowed me to add the sensor to the energy dashboard to make the "now" tab show the current use power for the heat pump

<kbd><img width="573" height="127" alt="Power Sensor now available" src="https://github.com/user-attachments/assets/4b1f5339-7212-4cef-a7a3-daa3a1790d17" /></kbd>

Inspired by: https://www.home-assistant.io/docs/energy/faq/#resolution