### PR TITLE
Add new product_id to PIXI water fountain

### DIFF
--- a/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
+++ b/custom_components/tuya_local/devices/catit_pixi_smart_fountain.yaml
@@ -3,6 +3,9 @@ products:
   - id: z3rpyvznfcch99aa
     manufacturer: Catit
     model: Pixi smart fountain
+  - id: aas56qqa3qgstcyz
+    manufacturer: Catit
+    model: PIXI Smart Drinking Fountain
 entities:
   - entity: switch
     icon: "mdi:water-pump"


### PR DESCRIPTION
Hello, the change just adds the product ID of my PIXI water fountain to the component that already exists. The name is the exact name my fountain reports on Tuya IoT Cloud Platform.

Thank you for the useful integration!