### PR TITLE
Add new product_id to Petlibro PLAF103 Pet feeder

### DIFF
--- a/custom_components/tuya_local/devices/petlibro_PLAF103_feeder.yaml
+++ b/custom_components/tuya_local/devices/petlibro_PLAF103_feeder.yaml
@@ -3,6 +3,9 @@ products:
   - id: tyjxq8vanjxpn7kb
     manufacturer: Petlibro
     model: PLAF103
+  - id: e6x31cbr0cwhavv1
+    manufacturer: Petlibro
+    model: PLAF103
 entities:
   - entity: sensor
     translation_key: status


### PR DESCRIPTION
Hi, this PR adds a new id to the existing Petlibro PLAF103 feeder. This matches the product_id shown in "Query Device Details" in API Explorer: "product_id": "e6x31cbr0cwhavv1" and works fine with my PLAF103, paired using the Smart Life app.