### PR TITLE
Fix current air temperature too high by factor of 10 in chiltrix_cx50…

### DIFF
--- a/custom_components/tuya_local/devices/chiltrix_cx50_comboheatpump.yaml
+++ b/custom_components/tuya_local/devices/chiltrix_cx50_comboheatpump.yaml
@@ -81,6 +81,8 @@ entities:
       - id: 111
         type: integer
         name: current_temperature
+        mapping:
+          - scale: 10
 
   # DHW WATER HEATER
   - entity: water_heater


### PR DESCRIPTION
Noticed the chiltrix cx50 comboheatpump config from the latest tuya release outputs the current temperature of the air climate entity with the factor of ten. This config change scales it down to the correct value. (e.g. 390C to 39.0C)