### PR TITLE
Add support for a 3-in-1 CO2 device (PV28-AW model)

### DIFF
--- a/custom_components/tuya_local/devices/pv28aw_co2detector.yaml
+++ b/custom_components/tuya_local/devices/pv28aw_co2detector.yaml
@@ -48,7 +48,6 @@ entities:
           - dps_val: false
             icon: "mdi:bell-off"
   - entity: binary_sensor
-    name: Power state
     class: battery_charging
     category: diagnostic
     dps:


### PR DESCRIPTION
Recognized in Tuya as "CO2_DETECTOR" (all capital letters). I checked the existing models and none seem to support all its functions or get the scaling right.