### PR TITLE
feat(eurom_wifi_thermostat): Add temperature sensor

### DIFF
--- a/custom_components/tuya_local/devices/eurom_wifi_thermostat.yaml
+++ b/custom_components/tuya_local/devices/eurom_wifi_thermostat.yaml
@@ -33,3 +33,13 @@ entities:
             value: eco
           - dps_val: false
             value: comfort
+  - entity: sensor
+    name: Room temperature
+    class: temperature
+    category: diagnostic
+    icon: "mdi:home-thermometer-outline"
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        unit: C


### PR DESCRIPTION
I recently setup this Wifi Thermostat and I wanted to use it paired with a threshold sensor to control multiple heaters at my living room, but the device does not expose the temperature as a sensor, only as a climate entity.

This exposes the `current_temperature` as a temperature sensor like the `eurom_sani_bathroom_towel_radiator` does.

<img width="628" height="802" alt="CleanShot 2026-02-10 at 13 15 50@2x" src="https://github.com/user-attachments/assets/2cda1d09-dda3-4f94-a653-08d86ed89f16" />