### PR TITLE
Add support for Duux Beam 2

### DIFF
--- a/custom_components/tuya_local/devices/duux_beam2_humidifier.yaml
+++ b/custom_components/tuya_local/devices/duux_beam2_humidifier.yaml
@@ -92,7 +92,6 @@ entities:
             value: 6h
   - entity: switch
     translation_key: sleep
-    icon: "mdi:weather-night"
     category: config
     dps:
       - id: 21


### PR DESCRIPTION
# Description
Adds support for [Duux Beam 2](https://duux.com/en/product/beam-2-black/)

# Device details

- Manufacturer: Duux
- Model: Beam 2
- Product ID: `wksnqcoh6yzpoam9`
- Category: Humidifier

# Home assistant screenshot
<p align="middle">
<img width="200" alt="Screenshot 2026-02-11 102903" src="https://github.com/user-attachments/assets/dd28ac89-be70-4a56-a4c1-ce783d873172" />
<img width="200" alt="Screenshot 2026-02-11 102958" src="https://github.com/user-attachments/assets/20d95701-8159-4b42-9767-de1a0115882b" />
<img width="200" alt="Screenshot 2026-02-11 103018" src="https://github.com/user-attachments/assets/3b8525a1-c7fd-46c5-9698-a9bfb0cb67f6" />
</p>

