### PR TITLE
Fix incorrect hvac_action entity name for tecxerllon panel heater device

### DIFF
--- a/custom_components/tuya_local/devices/tecxerllon_panel_heater.yaml
+++ b/custom_components/tuya_local/devices/tecxerllon_panel_heater.yaml
@@ -35,7 +35,7 @@ entities:
             value: high
       - id: 22
         type: string
-        name: hvac_mode
+        name: hvac_action
         mapping:
           - dps_val: heating
             value: heating


### PR DESCRIPTION
[Support ](https://github.com/make-all/tuya-local/issues/4301)for the TECXERLLON 1500W Convection Panel Space Heater was added in [2026.2.0](https://github.com/make-all/tuya-local/releases/tag/2026.2.0), but since upgrading I've had a problem with the heating/off and toggling function. I would get this error in the Home Assistant UI:

```
Failed to perform the action climate/set_hvac_mode. expected HVACMode or one of 'off', 'heat', 'cool', 'heat_cool', 'auto', 'dry', 'fan_only' for dictionary value @ data['hvac_mode']
```

I traced it to this line using `hvac_mode` instead of `hvac_action`.  `hvac_mode` only accepts the values `off` and `heat`, `hvac_action` accepts `heating` and `warming`. I patched this in my local HA and restarted it and it worked. So I think this fixes the issue.