### PR TITLE
Add support for Mini Wi-Fi Curtain Module (uoa3mayicscacseb)

### DIFF
--- a/custom_components/tuya_local/devices/uoa3mayicscacseb_curtain_switch.yaml
+++ b/custom_components/tuya_local/devices/uoa3mayicscacseb_curtain_switch.yaml
@@ -1,0 +1,61 @@
+name: Mini Wi-Fi Curtain Module
+products:
+  - id: uoa3mayicscacseb
+    manufacturer: Tuya
+    model: Mini Wi-Fi Curtain Module
+
+entities:
+  - entity: cover
+    name: Curtain
+    class: curtain
+    dps:
+      # Command open / close / stop
+      - id: 1
+        name: control
+        type: string
+        mapping:
+          - dps_val: "open"
+            value: open
+          - dps_val: "close"
+            value: close
+          - dps_val: "stop"
+            value: stop
+
+      # Current position
+      - id: 2
+        name: position
+        type: integer
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+
+  # Invert engine direction
+  - entity: switch
+    name: Reverse motor direction
+    category: config
+    icon: "mdi:swap-vertical"
+    dps:
+      - id: 8
+        name: switch
+        type: string
+        mapping:
+          - dps_val: "forward"
+            value: false
+          - dps_val: "back"
+            value: true
+
+  # Calibration
+  - entity: select
+    name: Calibration
+    category: config
+    icon: "mdi:tune"
+    dps:
+      - id: 3
+        name: option
+        type: string
+        mapping:
+          - dps_val: "start"
+            value: Start
+          - dps_val: "end"
+            value: End


### PR DESCRIPTION
Tested locally.
DP1 = control (open/close/stop)
DP2 = percent_control used as position (0–100)
Reverse motor supported via DP8.
Calibration supported via DP3.