### PR TITLE
Fix daewoo dhome heatpump High fan mode

### DIFF
--- a/custom_components/tuya_local/devices/daewoo_dhome_heatpump.yaml
+++ b/custom_components/tuya_local/devices/daewoo_dhome_heatpump.yaml
@@ -43,7 +43,7 @@ entities:
         mapping:
           - dps_val: Low
             value: low
-          - dps_val: Hig
+          - dps_val: High
             value: high
       - id: 101
         type: boolean


### PR DESCRIPTION
While testing my air conditioner (Beltax A011_D2) using the daewoo_dhome_heatpump device config (the one that was suggested and fit best) I found that the High setting for the fan mode didn't work. 

After looking at the debug logs I noticed the High fan mode value was being sent as "Hig":

<img width="797" height="135" alt="image" src="https://github.com/user-attachments/assets/1681c580-5a68-42aa-81f4-5be9de4fbd5e" />

And I confirmed this as well looking at the yaml configuration for the device type.

I manually changed in my Home Assistant and it solved the problem. Hoping to get this fixed for everyone.