### PR TITLE
Add support for Beltax BAC-1009 (Air Condition-A011_D2)

### DIFF
--- a/custom_components/tuya_local/devices/beltax_aircondition.yaml
+++ b/custom_components/tuya_local/devices/beltax_aircondition.yaml
@@ -19,9 +19,10 @@ entities:
                 value: cool
               - dps_val: Heat
                 value: heat
+                available: heat_supported
               - dps_val: Fan
                 value: fan_only
-              - dps_val: Dyr # Tuya model says "Dyr", but app/UI may show "Dry"
+              - dps_val: Dyr  # Tuya model says "Dyr", but app/UI may show "Dry"
                 value: dry
 
       - id: 2
@@ -30,15 +31,23 @@ entities:
         range:
           min: 16
           max: 32
-        unit: C
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temperature_f
+                range:
+                  min: 61
+                  max: 90
 
       - id: 3
         type: integer
         name: current_temperature
-        range:
-          min: 0
-          max: 99
-        unit: C
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: current_temperature_f
 
       - id: 4
         type: string
@@ -67,20 +76,26 @@ entities:
       - id: 23
         type: integer
         name: temperature_f
+        hidden: true
         range:
           min: 61
           max: 90
-        unit: F
         optional: true
 
       - id: 24
         type: integer
         name: current_temperature_f
-        range:
-          min: 0
-          max: 99
-        unit: F
+        hidden: true
         optional: true
+
+      - id: 103
+        type: string
+        name: heat_supported
+        hidden: true
+        mapping:
+          - dps_val: C_H
+            value: true
+          - value: false
 
       - id: 101
         type: boolean


### PR DESCRIPTION
Created a device configuration according to the documentation in the project. Used Tuya IoT Developer Platform to get all the DPs and mapped them in the configuration. Already tested with my device and all features are fully working, let me know if you need me to provide any evidence of it.

FYI the dry mode is mapped as Dyr because that's what I got from the DP:
<img width="530" height="231" alt="image" src="https://github.com/user-attachments/assets/1c5fa2e9-9437-4867-8048-26eff8f997cd" />
