### PR TITLE
 Add distance sensor (DP 122) to ZG-205W mmWave profile

### DIFF
--- a/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
@@ -73,12 +73,22 @@ entities:
   - entity: sensor
     name: Distance
     icon: mdi:signal-distance-variant
+    hidden: unavailable
     dps:
       - id: 122
         type: integer
+        optional: true
         name: sensor
         unit: cm
         class: measurement
+      - id: 122
+        type: integer
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
   - entity: number
     name: Stationary sensitivity
     category: config


### PR DESCRIPTION
## Summary
- Add a `Distance` sensor entity to `zg205w_mmWave_presence_sensor.yaml` using DP `122`.
- Configure it as a measurement sensor with `cm` unit and `mdi:signal-distance-variant` icon.
- Keep existing entities unchanged.

## Why
Some ZG-205W devices expose live distance data on DP 122 (`distance`), but the current profile does not surface it in Home Assistant.  
This change makes that data available as a native sensor without affecting existing mappings.

<img width="310" height="306" alt="image" src="https://github.com/user-attachments/assets/8162a0b1-c1d0-4625-a04e-55930c994f5c" />

## Validation
- `pytest tests/test_device_config.py` (passes)
- `yamllint custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml` (passes)
- `ruff check .` (passes)
- `ruff check --select I .` (passes)
- `ruff format --check .` (passes)

