### PR TITLE
Add support for Infrared Heater Panels from Termoplaza

### DIFF
--- a/custom_components/tuya_local/devices/termoplaza_panel_heater.yaml
+++ b/custom_components/tuya_local/devices/termoplaza_panel_heater.yaml
@@ -21,6 +21,7 @@ entities:
         range:
           min: 5
           max: 30
+        unit: C
         optional: true
       - id: 3
         name: current_temperature
@@ -30,11 +31,11 @@ entities:
         type: string
         optional: true
         mapping:
-          - dps_val: "ECO"
+          - dps_val: ECO
             value: eco
-          - dps_val: "Comfort"
+          - dps_val: Comfort
             value: comfort
-          - dps_val: "Night"
+          - dps_val: Night
             value: sleep
           - dps_val: "Off"
             value: none
@@ -48,6 +49,7 @@ entities:
   - entity: sensor
     name: Surface status
     class: enum
+    translation_key: status
     category: diagnostic
     dps:
       - id: 11
@@ -55,11 +57,11 @@ entities:
         name: sensor
         mapping:
           - dps_val: heating
-            value: Heating
+            value: heating
           - dps_val: warm
-            value: Warm
+            value: warm
           - dps_val: cold
-            value: Cold
+            value: cold
   - entity: sensor
     name: Duty cycle
     dps:
@@ -70,6 +72,7 @@ entities:
         unit: "%"
   - name: Turbo mode timer
     entity: select
+    translation_key: timer
     category: config
     dps:
       - id: 19
@@ -77,31 +80,31 @@ entities:
         type: string
         optional: true
         mapping:
-          - dps_val: 0
-            value: "Off"
-          - dps_val: 1
+          - dps_val: "0"
+            value: cancel
+          - dps_val: "1"
             value: 2h
-          - dps_val: 2
+          - dps_val: "2"
             value: 4h
-          - dps_val: 3
+          - dps_val: "3"
             value: 6h
-          - dps_val: 4
+          - dps_val: "4"
             value: 8h
-          - dps_val: 5
+          - dps_val: "5"
             value: 10h
-          - dps_val: 6
+          - dps_val: "6"
             value: 12h
-          - dps_val: 7
+          - dps_val: "7"
             value: 14h
-          - dps_val: 8
+          - dps_val: "8"
             value: 16h
-          - dps_val: 9
+          - dps_val: "9"
             value: 18h
-          - dps_val: 10
+          - dps_val: "10"
             value: 20h
-          - dps_val: 11
+          - dps_val: "11"
             value: 22h
-          - dps_val: 12
+          - dps_val: "12"
             value: 24h
   - name: Program mode
     entity: switch


### PR DESCRIPTION
I added support for Termoplaza Wifi models (https://termoplaza.de/produkt/termoplaza-1100-wifi-heizpaneel/). Values have been extracted from Tuya via API, integrated and double-checked with the Tuya app. Works smoothly for 2 heater panels in my local HA on my fork for about a week now.
Any feedback appreciated, especially on entity best practices - structure and naming ist best guess and what I have seen for similar device configurations.