### PR TITLE
PlantsIO Ivy Gen2

### DIFF
--- a/custom_components/tuya_local/devices/plantsio_ivy_gen2.yaml
+++ b/custom_components/tuya_local/devices/plantsio_ivy_gen2.yaml
@@ -1,0 +1,309 @@
+name: Smart Planter (Gen2)
+products:
+  - id: il6e0dusjrlxxhgr
+    manufacturer: PlantsIO
+    model: Ivy Gen2
+
+entities:
+  - entity: sensor
+    name: Water level
+    class: volume_storage
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: mL
+        class: measurement
+
+  - entity: sensor
+    name: Ambient light
+    class: illuminance
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: lx
+        class: measurement
+
+  - entity: sensor
+    name: Temperature
+    class: temperature
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Air humidity
+    class: humidity
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: Soil moisture
+    class: moisture
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: Battery status
+    category: diagnostic
+    dps:
+      - id: 128
+        type: integer
+        name: sensor
+
+  - entity: sensor
+    name: PAR intensity
+    category: diagnostic
+    dps:
+      - id: 130
+        type: integer
+        name: sensor
+        unit: "µmol/m²/s"
+        class: measurement
+
+  - entity: switch
+    name: Left touch switch
+    category: config
+    dps:
+      - id: 120
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Right touch switch
+    category: config
+    dps:
+      - id: 121
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Plant touch switch
+    category: config
+    dps:
+      - id: 122
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: Touching (raw)
+    category: diagnostic
+    dps:
+      - id: 119
+        type: integer
+        name: sensor
+
+  - entity: event
+    name: Touch
+    dps:
+      - id: 119
+        type: integer
+        name: event
+        persist: false
+        mapping:
+          - dps_val: 0
+            value: null
+          - dps_val: 1
+            value: left
+          - dps_val: 2
+            value: right
+          - dps_val: 3
+            value: left_right
+          - dps_val: 4
+            value: plant
+          - dps_val: 5
+            value: left_plant
+          - dps_val: 6
+            value: right_plant
+          - dps_val: 7
+            value: hug
+          - value: pressed
+
+  - entity: event
+    name: Left touch
+    dps:
+      - id: 119
+        type: integer
+        name: event
+        persist: false
+        mapping:
+          - dps_val: 1
+            value: pressed
+          - value: null
+
+  - entity: event
+    name: Right touch
+    dps:
+      - id: 119
+        type: integer
+        name: event
+        persist: false
+        mapping:
+          - dps_val: 2
+            value: pressed
+          - value: null
+
+  - entity: event
+    name: Plant touch
+    dps:
+      - id: 119
+        type: integer
+        name: event
+        persist: false
+        mapping:
+          - dps_val: 4
+            value: pressed
+          - value: null
+
+  - entity: event
+    name: Left + Right touch
+    dps:
+      - id: 119
+        type: integer
+        name: event
+        persist: false
+        mapping:
+          - dps_val: 3
+            value: pressed
+          - value: null
+
+  - entity: event
+    name: Hug
+    dps:
+      - id: 119
+        type: integer
+        name: event
+        persist: false
+        mapping:
+          - dps_val: 7
+            value: pressed
+          - value: null
+
+  - entity: sensor
+    name: Water needed status
+    category: diagnostic
+    dps:
+      - id: 123
+        type: integer
+        name: sensor
+
+  - entity: sensor
+    name: Light status
+    category: diagnostic
+    dps:
+      - id: 124
+        type: integer
+        name: sensor
+
+  - entity: sensor
+    name: Secondary status
+    category: diagnostic
+    dps:
+      - id: 125
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Plant selection page
+    category: diagnostic
+    dps:
+      - id: 108
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Device info page
+    category: diagnostic
+    dps:
+      - id: 109
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Plant perception page
+    category: diagnostic
+    dps:
+      - id: 110
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Display page
+    category: diagnostic
+    dps:
+      - id: 111
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Sleep page behavior
+    category: diagnostic
+    dps:
+      - id: 112
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Perception
+    category: diagnostic
+    dps:
+      - id: 113
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Custom animation
+    category: diagnostic
+    dps:
+      - id: 114
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Localization
+    category: diagnostic
+    dps:
+      - id: 115
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Other settings
+    category: diagnostic
+    dps:
+      - id: 116
+        type: string
+        name: sensor
+
+  - entity: sensor
+    name: Tomato timer page
+    category: diagnostic
+    dps:
+      - id: 129
+        type: string
+        name: sensor


### PR DESCRIPTION
Add PlantsIO Ivy Gen2 support using product id `il6e0dusjrlxxhgr` and expose sensors for water level, ambient light, temperature, air humidity, soil moisture, battery and PAR plus touch events and touch enable switches based on DP119

Datapoints
```json
{
"101": "Water Level",
"102": "Ambient Light",
"103": "Temperature",
"104": "Air Humidity",
"105": "Soil Moisture",
"106": "电池检测",
"107": "番茄时钟自定义时长",
"108": "选择植物页面",
"109": "设备信息页面",
"110": "植物感知页面",
"111": "显示页面",
"112": "休眠界面（行为）",
"113": "感知",
"114": "定制动画",
"115": "本地化",
"116": "其他设置",
"117": "系统指令",
"118": "教学完成",
"119": "Touching",
"120": "Left Touch Switch",
"121": "Right Touch Switch",
"122": "Plant Touch Switch",
"123": "需水状态",
"124": "光照状态",
"125": "次要状态",
"126": "导演模式",
"127": "行为树",
"128": "电池状态 ",
"129": "番茄时钟页面",
"130": "光合有效辐射强度",
"131": "备用_字符",
"132": "备用_布尔",
"133": "备用_数值",
"134": "备用_数值"
}
```

Screenshot from HA
<img width="507" height="328" alt="image" src="https://github.com/user-attachments/assets/2daaa357-3ba3-4efc-931e-bb6ffb8e76f4" />
