### PR TITLE
Add button and number entities for learnt remote commands

### DIFF
--- a/custom_components/tuya_local/devices/s11_rfir_remote.yaml
+++ b/custom_components/tuya_local/devices/s11_rfir_remote.yaml
@@ -8,10 +8,6 @@ products:
     name: RF/IR remote
   - id: 0gawnyfgyneswent
     model: IR Controller Pro
-  - id: x0lyfgjuguuh1vof
-    manufacturer: Avatto
-    name: Smart IR+RF Remote Control
-    model: S16Pro
 entities:
   - entity: remote
     dps:


### PR DESCRIPTION
### Summary

When users learn IR/RF commands via the `remote.learn_command` service, the commands are stored but can only be replayed through the `remote.send_command` service call, which requires knowing the exact command and sub-device names. This PR automatically creates **button entities** for each learnt command, allowing one-tap replay from the HA UI, dashboards, and automations.

Additionally, **number entities** are created per sub-device for IR commands to configure delay between repeats and number of repeats, without needing to pass those as service call parameters each time.

### What's new

- **`TuyaRemoteButton`** (`ButtonEntity`) — one button per learnt command, grouped under a virtual sub-device in the device registry. Pressing the button sends the command via the parent remote entity.
- **`TuyaRemoteNumber`** (`NumberEntity`) — two number entities per IR sub-device: *delay* (seconds between repeats) and *repeats* (number of times to send). Values persist across restarts via `RestoreEntity`. Not created for RF commands, which don't use delay/repeats.
- **Virtual sub-devices** — each sub-device (e.g. "TV", "AC") gets its own device registry entry linked to the parent IR/RF blaster via `via_device`.
- **Dynamic entity management** — buttons and number entities are created on learn, and cleaned up (including the virtual device) when all commands for a sub-device are deleted.
- **Startup restore** — on HA restart, all buttons and number entities are recreated from stored codes in `async_added_to_hass`.

### UI

Remote control device with one sub-device called _Screen_
<img width="1328" height="508" alt="image" src="https://github.com/user-attachments/assets/cf19c800-5017-40f3-a124-7f2115acb79c" />

Subdevice _Screen_ with three automatically created buttons
<img width="830" height="355" alt="image" src="https://github.com/user-attachments/assets/240ebace-84fe-4e55-9d80-297f09b9e358" />

Note: this is an RF case, so no further control entities are shown. IR subdevices have additional controls.

### Technical details

- `TuyaLocalRemote` receives `button_platform` and `number_platform` references to dynamically add entities at runtime.
- `_has_ir_codes()` distinguishes IR from RF codes (prefixed with `rf:`) to decide whether number entities are needed.
- `_create_number_entities()` creates the delay/repeats pair for a sub-device.
- Cleanup in `async_delete_command` removes button entities, number entities (when no IR codes remain), and the virtual device entry when all commands are gone.

### Tests

The code has been tested with both, IR and RF operations in a real-life environment.

### Note

Part of the coding was assisted by generative AI