### PR TITLE
Refer to remote buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ used when learning. You can also send codes directly without learning first:
 - **IR inline code**: prefix with `b64:` followed by the base64-encoded IR code
 - **RF inline code**: prefix with `rf:` followed by the base64-encoded RF code
 
+### UI
+
+If you would like to expose the learnt commands as buttons in the user interface
+you might want to take a look at the [Remote buttons](https://github.com/kongo09/remote_buttons)
+integration, which is compatible with Tuya Local.
+
 ## Contributing
 
 Beyond contributing device configs, here are some areas that could benefit from more hands:


### PR DESCRIPTION
I've added a link to the new Remote buttons integration that I wrote as a replacement for adding it here, in case some of the Tuya Local users might come across the same challenge and find that helpful. While it is explicitly written to work with Tuya Local, it also should work with the Broadlink integration.