### PR TITLE
Add Curv Smart Alarm System support

### DIFF
--- a/custom_components/tuya_local/devices/curv_smart_alarm.yaml
+++ b/custom_components/tuya_local/devices/curv_smart_alarm.yaml
@@ -31,7 +31,6 @@ entities:
 
   - entity: select
     translation_key: language
-    name: Language
     category: config
     dps:
       - id: 103


### PR DESCRIPTION
## Description

Add support for the Curv Smart Alarm System.

This device currently does not auto-match correctly in Tuya Local and falls back to an unrelated device profile during config flow. This PR adds a dedicated YAML definition based on the Tuya Cloud data model and confirmed locally reported DPS.

## Product information

- Product ID: `mrwxwgtnpnemqwa1`
- Model ID: `000003csuo`
- Manufacturer: `Curv`
- Model: `Smart Alarm System`
- [Link](https://support.curv360.com/hc/en-gb/categories/360003358234-Curv-Smart-Alarm-System)

## Log message

```text
2026-03-07 00:03:53.604 WARNING (MainThread) [custom_components.tuya_local.config_flow] Device matches speaka_sptvcm510_tvmount with quality of 17%. LOCAL DPS: {"updated_at": 1772841824.6704078, "101": "home", "102": "Normal", "103": "English", "104": "normal", "105": 100, "106": 60, "107": 60, "108": 5, "109": 3, "110": 3, "111": "OFF", "112": true, "113": true, "114": false, "115": false, "116": false, "117": true, "118": true, "119": true, "120": true, "121": true, "122": "3232640133788880000", "125": "MODEL:Curv Smart Alarm System\r\nHK UID:4A3853FF005E003701FF504A\r\nIMEI:860665050294106\r\nFIRMWARE VER:1.0.1"}
2026-03-07 00:03:53.604 WARNING (MainThread) [custom_components.tuya_local.config_flow] Include the previous log messages with any new device request to https://github.com/make-all/tuya-local/issues/
```

## Locally observed DPS

`{
  "101": "home",
  "102": "Normal",
  "103": "English",
  "104": "normal",
  "105": 100,
  "106": 60,
  "107": 60,
  "108": 5,
  "109": 3,
  "110": 3,
  "111": "OFF",
  "112": true,
  "113": true,
  "114": false,
  "115": false,
  "116": false,
  "117": true,
  "118": true,
  "119": true,
  "120": true,
  "121": true,
  "122": "3232640133788880000",
  "125": "MODEL:Curv Smart Alarm System\r\nHK UID:4A3853FF005E003701FF504A\r\nIMEI:860665050294106\r\nFIRMWARE VER:1.0.1"
}
`

## Tuya Cloud model

- 101 system_arm_type enum: disarmed, armed, home
- 102 gsm_status enum: NoSimCard, NoNetWork, Normal, GsmOff
- 103 language enum: English, French, Italian, German, Spanish, Danish, Dutch, Portuguese
- 104 dc_status enum: low, normal, high, off
- 105 bat_status value, 0 to 100 percent
- 106 arm_delay value, 0 to 300 seconds
- 107 alarm_delay value, 0 to 300 seconds
- 108 alarm_sound_duration value, 1 to 9 minutes
- 109 ring_times value, 1 to 9
- 110 tel_alarm_cycle value, 1 to 9
- 111 inside_siren_sound enum: ON, OFF
- 112 gsm_en bool
- 113 tel_ctrl_en bool
- 114 arm_sms_en bool
- 115 disarm_sms_en bool
- 116 keyboard_tone_en bool
- 117 arm_delay_tone_en bool
- 118 alarm_delay_tone_en bool
- 119 arm_disarm_tone_en bool
- 120 inside_siren_en bool
- 121 wireless_siren_en bool
- 122 password string
- 125 device_info string
- 124, 126, 127, 128, 129 are raw payload types and are not exposed in this initial config

## How the device functions

- DP 101 controls arm mode, mapped to Home Assistant alarm states:
  - disarmed -> disarmed
  - armed -> armed_away
  - home -> armed_home

- DP 102 reports GSM status
- DP 103 selects system language
- DP 104 reports DC status
- DP 105 reports battery percentage
- DP 106 to 110 are numeric configuration values
- DP 111 to 121 are siren and notification feature toggles
- DP 125 reports device information

## Notes

DP 122 (password) was intentionally not exposed due to sensitivity

Raw DPs 124, 126, 127, 128, and 129 were left out pending payload examples and a suitable entity mapping