### PR TITLE
add wake_up_light_ii, very similar to moes_zcjk_alarmclock

### DIFF
--- a/custom_components/tuya_local/devices/wake_up_light_ii.yaml
+++ b/custom_components/tuya_local/devices/wake_up_light_ii.yaml
@@ -1,0 +1,241 @@
+name: Alarm clock
+products:
+  - id: ya39qahrcdhvxowz
+    manufacturer: Generic
+    model: Wake Up Light II
+    model_id: ACA002-II-WWA
+entities:
+  - entity: light
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+      - id: 102
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: time
+    icon: "mdi:clock-digital"
+    dps:
+      - id: 103
+        type: string
+        name: hms
+  - entity: select
+    name: Display
+    icon: "mdi:clock-digital"
+    category: config
+    dps:
+      - id: 104
+        type: integer
+        name: option
+        mapping:
+          - dps_val: 0
+            value: "Off"
+          - dps_val: 1
+            value: Day
+          - dps_val: 2
+            value: Night
+          - dps_val: 3
+            value: Auto
+  - entity: switch
+    name: Radio
+    icon: "mdi:radio"
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+  - entity: number
+    translation_key: volume
+    dps:
+      - id: 106
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 16
+  - entity: text
+    name: Station list
+    category: config
+    icon: "mdi:playlist-music"
+    hidden: true
+    dps:
+      - id: 107
+        type: base64
+        optional: true
+        name: value
+  - entity: switch
+    name: Alarm 1
+    icon: "mdi:alarm"
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+  - entity: number
+    name: Snooze time
+    class: duration
+    category: config
+    icon: "mdi:alarm-snooze"
+    dps:
+      - id: 116
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 8
+          max: 15
+  - entity: select
+    name: Snooze type
+    icon: "mdi:alarm-snooze"
+    category: config
+    dps:
+      - id: 117
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: Sound + Radio
+          - dps_val: "2"
+            value: Light
+          - dps_val: "3"
+            value: Radio
+          - dps_val: "4"
+            value: Radio + Sound + Light
+  - entity: switch
+    translation_key: sleep
+    dps:
+      - id: 121
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Alarm 2
+    icon: "mdi:alarm"
+    category: config
+    dps:
+      - id: 122
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Alarm 3
+    icon: "mdi:alarm"
+    category: config
+    dps:
+      - id: 123
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Alarm 4
+    icon: "mdi:alarm"
+    category: config
+    dps:
+      - id: 124
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Internet time
+    icon: "mdi:weather-cloudy-clock"
+    category: config
+    dps:
+      - id: 125
+        type: boolean
+        name: switch
+  - entity: button
+    name: Radio seek
+    icon: "mdi:fast-forward"
+    dps:
+      - id: 126
+        type: boolean
+        name: button
+      - id: 125
+        type: boolean
+        name: available
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true
+  - entity: button
+    name: Radio stop
+    icon: "mdi:stop"
+    dps:
+      - id: 126
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true
+      - id: 125
+        type: boolean
+        name: available
+  - entity: text
+    name: Alarm settings
+    category: config
+    icon: "mdi:alarm"
+    hidden: true
+    dps:
+      - id: 127
+        type: base64
+        optional: true
+        name: value
+  - entity: text
+    name: Sleep settings
+    category: config
+    icon: "mdi:sleep"
+    hidden: true
+    dps:
+      - id: 128
+        type: base64
+        optional: true
+        name: value
+  - entity: light
+    name: Ambient
+    dps:
+      - id: 129
+        type: boolean
+        name: switch
+      - id: 132
+        type: string
+        name: effect
+        mapping:
+          - dps_val: "1"
+            value: Loop
+          - dps_val: "2"
+            value: Red
+          - dps_val: "3"
+            value: Orange
+          - dps_val: "4"
+            value: Yellow
+          - dps_val: "5"
+            value: Green
+          - dps_val: "6"
+            value: Cyan
+          - dps_val: "7"
+            value: Blue
+          - dps_val: "8"
+            value: Purple
+  - entity: switch
+    name: Snooze
+    icon: "mdi:alarm-snooze"
+    dps:
+      - id: 130
+        type: boolean
+        name: switch
+  - entity: select
+    name: Time format
+    icon: "mdi:hours-24"
+    category: config
+    dps:
+      - id: 131
+        type: boolean
+        name: option
+        mapping:
+          - dps_val: false
+            value: "12 hour"
+            icon: "mdi:hours-12"
+            icon_priority: 1
+          - dps_val: true
+            value: "24 hour"


### PR DESCRIPTION
This Wake Up Light II seems to be either a newer version or a variant of Moes Smart Wake Up Light.
As such, the configuration is almost an exact copy of moes_zcjk_alarmclock.yaml.

The only difference is related to the ambient light feature. While the older device has white color for mode 1, my device loops through the colors in that mode.
Also, a couple of other modes have slightly different color names (not sure about actual colors) according to Smart Life app:
- lime -> green;
- magenta -> purple.

I also decided to define color modes as effects rather than named colors.  First reason is that mode 1 (looping) cannot be fit into the named color scheme.  Second reason is that named colors imply that the light supports color (and brightness) control while having presets for select colors.  The reality is that the colors are fixed, there is no real color (and brightness) control.

The only benefit of named color approach that I can think of was that the presets had the matching colors.
 Other than that, everything else was incorrect and misleading.

#### More about the product.

The original product link does not work now.
Here is a very similar product: https://www.aliexpress.com/item/1005010230164271.html

The device itself and its packaging do not have any brand information.
But in online materials there are some references to Moes.


Product identification data:
```json
      "model": "ACA002-II-WWA",
      "name": "Wake Up Light II",
      "product_id": "ya39qahrcdhvxowz",
      "product_name": "WWA-Wake Up Light II",
```

Its DPs are in the attached file.
[tuya-smartlife-wakeup-light.dps.json](https://github.com/user-attachments/files/25817268/tuya-smartlife-wakeup-light.dps.json)
