### PR TITLE
Add device support for Nivian NVS-A6WG alarm

### DIFF
--- a/custom_components/tuya_local/devices/nivian_nvs_a6wg_alarm.yaml
+++ b/custom_components/tuya_local/devices/nivian_nvs_a6wg_alarm.yaml
@@ -199,7 +199,7 @@ entities:
         mapping:
           - dps_val: "OFF"
             value: false
-          - dps_val:  "ON"
+          - dps_val: "ON"
             value: true
   - entity: switch
     name: Wireless siren


### PR DESCRIPTION
## Description

Add support for the Nivian NVS-A6WG alarm system.

## Product information

Product ID: `p3sdak6d9jznh14x`
Manufacturer: `Nivian`
Model: `NVS-A6WG`
[Link](https://www.nivianhome.com/en/product/nvs-a6wg/)

## Locally observed DPS

`{'101': 'home', '102': 'NoSimCard', '103': 'English', '104': 'normal', '105': 100, '106': 10, '107': 15, '108': 3, '109': 3, '110': 3, '111': 'OFF', '112': True, '113': True, '114': True, '115': True, '116': False, '117': False, '118': False, '119': False, '120': False, '121': False, '122': '*******************', '125': 'MODEL:NVS-A6WG\r\nPID:572382123896274505D7FF33\r\nIMEI:***************\r\nFIRMWARE VER:1.0.9'}`

## Tuya Cloud model

- 101 system_arm_type enum: disarmed, armed, home
- 102 gsm_status enum: NoSimCard, NoNetWork, Normal, GsmOff
- 103 language enum: English, French, Italian, German, Spanish, Danish, Dutch, Portuguese
- 104 dc_status enum: low, normal, high, off
- 105 bat_status value, 0 to 100 percent
- 106 arm_delay value, 0 to 300 seconds
- 107 alarm_delay value, 0 to 300 seconds
- 108 alarm_sound_duration value, 1 to 9 minutes
- 109 ring_times value, 1 to 9
- 110 tel_alarm_cycle value, 1 to 9
- 111 inside_siren_sound enum: ON, OFF
- 112 gsm_en bool
- 113 tel_ctrl_en bool
- 114 arm_sms_en bool
- 115 disarm_sms_en bool
- 116 keyboard_tone_en bool
- 117 arm_delay_tone_en bool
- 118 alarm_delay_tone_en bool
- 119 arm_disarm_tone_en bool
- 120 inside_siren_en bool
- 121 wireless_siren_en bool
- 122 password string
- 125 device_info string
- 124, 126, 127, 128, 129 are raw payload types and are not exposed in this initial config

## How the device functions

- DP 101 controls arm mode, mapped to Home Assistant alarm states:
  - disarmed -> disarmed
  - armed -> armed_away
  - home -> armed_home
- DP 102 reports GSM status

- DP 103 selects system language

- DP 104 reports DC status

- DP 105 reports battery percentage

- DP 106 to 110 are numeric configuration values

- DP 111 to 121 are siren and notification feature toggles

- DP 125 reports device information

## Notes

DP 122 (password) was intentionally not exposed due to sensitivity

Raw DPs 124, 126, 127, 128, and 129 were left out pending payload examples and a suitable entity mapping