### PR TITLE
Add configuration for PIR Motion Switch device

### DIFF
--- a/custom_components/tuya_local/devices/moes_pir_wall_switch.yaml
+++ b/custom_components/tuya_local/devices/moes_pir_wall_switch.yaml
@@ -1,10 +1,9 @@
-name: PIR Wall Switch
+name: PIR wall switch
 
 products:
   - id: iii7gagtan21i2of
     model: MFA05
     manufacturer: MOES
-    name: MOES Smart Motion Sensor Switch Single Pole
 
 entities:
   - entity: light
@@ -14,7 +13,9 @@ entities:
         name: switch
 
   - entity: text
-    name: Inching Mode
+    name: Inching
+    category: config
+    hidden: true
     dps:
       - id: 103
         type: string
@@ -22,16 +23,15 @@ entities:
 
   - entity: light
     translation_key: indicator
+    category: config
     dps:
       - id: 104
         type: boolean
         name: switch
 
   - entity: binary_sensor
-    name: Motion Alarm
-    class: motion          # ← Changed from device_class to class
+    class: motion
     dps:
       - id: 106
         type: boolean
         name: sensor
-        readonly: true


### PR DESCRIPTION
This PR adds support for the Tuya MFA05 PIR Motion Switch (product ID iii7gagtan21i2of).

The device exposes the following DPS via the local Tuya protocol (3.3):

- 1: Light relay switch (boolean)
- 103: Inching mode (string)
- 104: LED indicator (boolean)
- 106: Motion alarm (boolean)

Motion is represented by DP 106. DP 1 is the actual relay and can be manually toggled; it may mirror motion depending on device settings, but it is not the motion state.

DP 103 is a string-based inching mode value. The device reports opaque string values (e.g., "AQJY"), so it is exposed as a text entity rather than a select.

receives DPS 1, 103, 104, and 106 from the device.

Below is the DPS cache from the Tuya Local device debug output:

"1": true,
"103": "AQJY",
"104": true,
"106": true

The included YAML definition has been tested locally in Home Assistant with Tuya Local and works reliably.

Let me know if anything needs adjustment.