### PR TITLE
Add Kogan VOSTOK Portable AC device config

### DIFF
--- a/custom_components/tuya_local/devices/kogan_vostok_portable_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kogan_vostok_portable_airconditioner.yaml
@@ -50,19 +50,8 @@ entities:
             value: high
           - dps_val: low
             value: low
-      - id: 105
-        type: integer
-        name: countdown
-        optional: true
-  - entity: switch
-    name: Power
-    icon: "mdi:power"
-    dps:
-      - id: 1
-        type: boolean
-        name: switch
   - entity: number
-    name: Timer
+    translation_key: timer
     category: config
     class: duration
     dps:
@@ -84,3 +73,6 @@ entities:
           - dps_val: 0
             value: false
           - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
## Summary

- Adds device configuration for the **Kogan VOSTOK Portable AC** (product ID: `emoxxvomv8xpvxfg`)
- Protocol 3.3

## Entities

| Entity | DPs | Description |
|--------|-----|-------------|
| `climate` | 1, 2, 3, 101, 103, 104, 105 | Cool/dry/fan_only modes, 16-31°C range, sleep preset, high/low fan speed |
| `switch` (Power) | 1 | On/off control |
| `number` (Timer) | 105 | Countdown timer, 0-24h |
| `binary_sensor` (Problem) | 20 | Fault/error detection via bitfield |

## Testing

Tested on two physical units running firmware protocol 3.3, integrated via tuya-local in Home Assistant.