### PR TITLE
Update Tongou SA1-wifi to support more DPs

### DIFF
--- a/custom_components/tuya_local/devices/tongou_sa1_wifi_energy_meter.yaml
+++ b/custom_components/tuya_local/devices/tongou_sa1_wifi_energy_meter.yaml
@@ -157,7 +157,6 @@ entities:
   - entity: sensor
     class: temperature
     category: diagnostic
-    name: Internal temperature
     dps:
       - id: 131
         type: integer
@@ -167,7 +166,6 @@ entities:
         mapping:
           - scale: 10
   - entity: binary_sensor
-    name: Fault
     class: problem
     category: diagnostic
     dps:


### PR DESCRIPTION
This PR updates the configuration for the Tongou SA1 energy meter. Based on a full datapoint dump, I have exposed several previously missing features, primarily related to device protection and monitoring.

**Changes:**
Protection Alarms (Switches): Added switches to toggle alarms for Over Voltage, Under Voltage, Over Current, Over Power, and Temperature. Mapped Alarm/Closed values to boolean switches for better UX.

**Protection Thresholds:** Added number entities to set specific threshold values for all protection parameters (Voltage, Current, Power, Temperature).

**New Sensors:**
Added Internal Temperature sensor.
Added Power Factor sensor.
Added Last Event sensor with full mapping for human-readable status messages and dynamic icons (e.g "Over Voltage Trip", "Manual OFF"), **although I haven't added translations for other languages.**

Device Info:
Manufacturer: Tongou
Model: TOSA1-0150XJWT2A
ID: gnr22vuyz8uis3gr

Tested on my device, all new controls work as expected.