### PR TITLE
 Update GeyserWise device to also support the GeyserWise Max Solar co…

### DIFF
--- a/custom_components/tuya_local/devices/geyserwise_water_heater.yaml
+++ b/custom_components/tuya_local/devices/geyserwise_water_heater.yaml
@@ -26,10 +26,11 @@ entities:
             value: true
       - id: 10
         type: integer
+        unit: C
         name: current_temperature
       - id: 103
         type: integer
-        name: temperature
+        name: setpoint_temperature
         unit: C
         range:
           min: 30
@@ -190,6 +191,17 @@ entities:
     category: diagnostic
     dps:
       - id: 108
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Geyser temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 10
         type: integer
         name: sensor
         optional: true


### PR DESCRIPTION
#Update GeyserWise device to also support the GeyserWise Max Solar controller  

## Correct variable name 
- entity: water_heater: 
   Id: 103 - changed name to "setpoint_temperature" as it is a config value and not a measurement.
## ID 10 is a measurement, not a Config value - but leave it here for compatibility.  
   Id: 10 - add  Unit: C        
   

## Actual geyser water temperature Id: 10
   Id: 10 is only available under the water heater entity under the config category as indicated above.  Add it as a Diagnostic Sensor entity, similar to Collector temperature, so it can be used separately from the Water heater entity for simpler external automations.   

  - entity: sensor
    name: Geyser temperature
    class: temperature
    category: diagnostic
    dps:
      - id: 10
        type: integer
        name: sensor
        optional: true
        unit: C
        class: measurement