### PR TITLE
Add Wine Enthusiast Beverage Center config

### DIFF
--- a/custom_components/tuya_local/devices/wineenthusiast_prestiges_beveragecenter.yaml
+++ b/custom_components/tuya_local/devices/wineenthusiast_prestiges_beveragecenter.yaml
@@ -155,16 +155,16 @@ entities:
           - dps_val: 0
             value: ok
           - dps_val: 1
-            value: ntc1_over
+            value: Sensor 1 over temperature
           - dps_val: 2
-            value: ntc1_low
+            value: Sensor 1 under temperature
           - dps_val: 4
-            value: ntc2_over
+            value: Sensor 2 over temperature
           - dps_val: 8
-            value: ntc2_low
+            value: Sensor 2 under temperature
           - dps_val: 16
-            value: ntc1_err
+            value: Sensor 1 fault
           - dps_val: 32
-            value: ntc2_err
+            value: Sensor 2 fault
           - dps_val: 64
-            value: door_open
+            value: Door open


### PR DESCRIPTION
## Summary
- Adds device config for the **Wine Enthusiast Prestige S 24" Undercounter Smart Wi-Fi Beverage Center** (Tuya product ID: `qvcxc9c0wlkcuwto`, category: `jg` / Wine cabinet)
- Tested on real hardware and confirmed working

## Entities
- **Climate** — power on/off, target temperature (1-10°C / 34-50°F), current temperature, with C/F unit switching via device DP
- **Lock** — child lock
- **Light** — interior light with brightness, supports white/yellow lamp color with independent brightness per color
- **Select: Lamp color** — white or yellow
- **Switch: ECO mode** — energy saving toggle
- **Sensor: Humidity** — current cabinet humidity
- **Sensor: Filter days remaining** — days until filter replacement
- **Select: Filter reset interval** — 6 or 12 months
- **Binary sensor: Fault** — NTC sensor error indicator

## DP Mapping
| DP ID | Code | Type | Access |
|-------|------|------|--------|
| 1 | switch | Boolean | rw |
| 2 | temp_set | Integer 1-10°C | rw |
| 4 | temp_unit_convert | Enum c/f | rw |
| 5 | child_lock | Boolean | rw |
| 6 | temp_current | Integer -10-99°C | ro |
| 7 | humidity_current | Integer 0-99%RH | ro |
| 10 | fault | Bitmap | ro |
| 13 | bright_value | Integer 0-100% | rw |
| 101 | Lamp_switch | Boolean | rw |
| 102 | ECO | Boolean | rw |
| 103 | temp_current_f | Integer 10-200°F | ro |
| 104 | temp_set_f | Integer 34-50°F | rw |
| 106 | interval_left_time_day | Integer 0-360 | ro |
| 108 | reset_filter_time | Enum M_6/M_12 | rw |
| 109 | lamp_color | Enum white/yellow | rw |
| 110 | yellow_bright_value | Integer 0-100% | rw |

🤖 Generated with [Claude Code](https://claude.com/claude-code)