### PR TITLE
Adding support for commonly found SR223 solar controller

### DIFF
--- a/custom_components/tuya_local/devices/shuangri_sr223_solarcontroller.yaml
+++ b/custom_components/tuya_local/devices/shuangri_sr223_solarcontroller.yaml
@@ -1,11 +1,12 @@
-name: SR223 Solar Water Heater
+name: Solar water heater
 products:
   - id: mlezgpkhb08dvjjx
+    manufacturer: Shuangri
     model: SR223
 entities:
   # Solar Collector Temperature (T1)
   - entity: sensor
-    name: Solar Collector Temperature (T1)
+    name: Solar collector temperature
     class: temperature
     category: diagnostic
     dps:
@@ -17,7 +18,7 @@ entities:
           - scale: 10
   # Tank Temperature (T2)
   - entity: sensor
-    name: Tank Temperature (T2)
+    name: Tank temperature
     class: temperature
     category: diagnostic
     dps:
@@ -29,14 +30,14 @@ entities:
           - scale: 10
   # Pump Speed
   - entity: sensor
-    name: Pump
+    name: Pump speed
     dps:
       - id: 112
         type: integer
         name: sensor
+        unit: rpm
   # WiFi Signal Strength
   - entity: sensor
-    name: Wi-Fi Signal
     class: signal_strength
     category: diagnostic
     dps:


### PR DESCRIPTION
Adding basic support for the SR223 Solar controller / water heater. It seems to be sold under many brand names, but all with the same underlying hardware. Manual for the controller can be found here: https://shuangri.com/uploads/soft/240830/SR223-EN(Wifi).pdf

Initially adding support for the most basic installation layout (Solar thermal collector and tank)

Current config supports:
- Temperature of Collector T1
- Temperature of Tank T2
- Pump speed for Pump R1 (Note, this also works in PWM mode for variable pumps)
- WiFi Signal Strength