### PR TITLE
Add VERATTI V4 3-phase circuit breaker

### DIFF
--- a/custom_components/tuya_local/devices/veratti_3phase_breaker.yaml
+++ b/custom_components/tuya_local/devices/veratti_3phase_breaker.yaml
@@ -1,4 +1,4 @@
-name: 3-phase circuit breaker
+name: Circuit breaker
 products:
   - id: zxhlsbmhkauiyget
     manufacturer: VERATTI
@@ -11,6 +11,7 @@ entities:
         name: switch
 
   - entity: sensor
+    translation_key: energy_consumed
     class: energy
     dps:
       - id: 1
@@ -22,7 +23,7 @@ entities:
           - scale: 100
 
   - entity: sensor
-    name: Reverse energy
+    translation_key: energy_produced
     class: energy
     dps:
       - id: 110
@@ -218,3 +219,6 @@ entities:
           - dps_val: 0
             value: false
           - value: true
+      - id: 9
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
Adds device configuration for the VERATTI V4 3-phase circuit breaker (product ID `zxhlsbmhkauiyget`).

Structure is similar to the existing EARU 3-phase breaker but with a few differences specific to this device — 8-byte base64 payloads instead of 10, reverse energy metering on DPS 110, built-in temperature sensor (DPS 103), and a leakage current sensor (DPS 15).

### Entities

| Entity | DPS | Notes |
|---|---|---|
| Switch | 16 | Main breaker on/off |
| Energy | 1 | Total forward energy (kWh, scale 100) |
| Reverse energy | 110 | Total reverse energy (kWh, scale 100) |
| Voltage/Current/Power A | 6 | base64 with masks |
| Voltage/Current/Power B | 7 | base64, hidden by default |
| Voltage/Current/Power C | 8 | base64, hidden by default |
| Temperature | 103 | Internal temp sensor |
| Leakage current | 15 | In mA |
| Problem | 9 | Bitfield fault indicator |

Tested on real hardware, running on tuya-local 2026.3.2.