### PR TITLE
feat: add Tuya QCSS600ZB 3 gang ZigBee remote control

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1365,6 +1365,7 @@ entity types as sub devices.
 - Smart air box BR V2
 - Temperature and humidity sensor with alarm feature
 - TH02 Z3-P3Z temperature and humidity sensor
+- Tuya QCSS600ZB 3 gang ZigBee remote control
 - WL-898WZ water leak sensor
 - WL-RTCZ-05Z human presence sensor
 - Zemismart SPM01 energy meter

--- a/custom_components/tuya_local/devices/tuya_qcss600zb_zigbee_remote.yaml
+++ b/custom_components/tuya_local/devices/tuya_qcss600zb_zigbee_remote.yaml
@@ -1,0 +1,64 @@
+name: 3 Gang ZigBee Remote
+products:
+  - id: famkxci2
+    manufacturer: Tuya
+    model: qcss600zb
+    name: 3 Gang ZigBee Remote
+
+entities:
+  - entity: event
+    name: Button 1
+    class: button
+    dps:
+      - id: 1
+        name: event
+        type: string
+        persist: false
+        mapping:
+          - dps_val: single_click
+            value: single_click
+          - dps_val: double_click
+            value: double_click
+          - dps_val: long_press
+            value: long_press
+
+  - entity: event
+    name: Button 2
+    class: button
+    dps:
+      - id: 2
+        name: event
+        type: string
+        persist: false
+        mapping:
+          - dps_val: single_click
+            value: single_click
+          - dps_val: double_click
+            value: double_click
+          - dps_val: long_press
+            value: long_press
+
+  - entity: event
+    name: Button 3
+    class: button
+    dps:
+      - id: 3
+        name: event
+        type: string
+        persist: false
+        mapping:
+          - dps_val: single_click
+            value: single_click
+          - dps_val: double_click
+            value: double_click
+          - dps_val: long_press
+            value: long_press
+
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 10
+        name: sensor
+        type: integer
+        unit: "%"


### PR DESCRIPTION
Adds device config for the Tuya QCSS600ZB 3 gang ZigBee remote (product id: famkxci2) with three button event entities supporting single click, double click, and long press actions, plus a battery level diagnostic sensor.