### PR TITLE
fix(quad_power_timer): schedule DPs 42-44 as string, not base64

### DIFF
--- a/custom_components/tuya_local/devices/quad_power_timer.yaml
+++ b/custom_components/tuya_local/devices/quad_power_timer.yaml
@@ -194,7 +194,7 @@ entities:
     hidden: true
     dps:
       - id: 42
-        type: base64
+        type: string
         optional: true
         name: value
   - entity: text
@@ -204,7 +204,7 @@ entities:
     hidden: true
     dps:
       - id: 43
-        type: base64
+        type: string
         optional: true
         name: value
   - entity: text
@@ -214,6 +214,6 @@ entities:
     hidden: true
     dps:
       - id: 44
-        type: base64
+        type: string
         optional: true
         name: value


### PR DESCRIPTION
## Summary
Follow-up to the generic `quad_power_timer` extensions ([\#4665](https://github.com/make-all/tuya-local/pull/4665)). DPs **42–44** (`cycle_time`, `random_time`, `switch_inching`) are **string** in Tuya's data model for this device family (e.g. [issue discussion for LDNIO-style strips](https://github.com/make-all/tuya-local/issues/1436)).

Using `type: base64` causes failed decode / empty `text` state for devices that send plain string payloads (e.g. LDNIO SCW3451 / similar quad outlet + USB strips).

## Change
- `type: base64` → `type: string` for the three hidden schedule-related `text` entities on dps 42, 43, 44.

## Notes
Upstream [PR #4761](https://github.com/make-all/tuya-local/pull/4761) was closed unmerged; this is a minimal, non-conflicting patch on current `main`.

Made with [Cursor](https://cursor.com)