### PR TITLE
fix: Handle mixed temperature units in climate entities (starlight_heatpump)

### DIFF
--- a/custom_components/tuya_local/climate.py
+++ b/custom_components/tuya_local/climate.py
@@ -304,6 +304,30 @@ class TuyaLocalClimate(TuyaLocalEntity, ClimateEntity):
                 temp = round(
                     temp, self._current_temperature_dps.suggested_display_precision
                 )
+            # Convert if current_temperature DPS unit differs from the
+            # entity's native temperature unit. Some devices report target
+            # and current temperatures in different units (e.g. target in
+            # Fahrenheit, current in Celsius).
+            if temp is not None and self._current_temperature_dps.unit:
+                current_unit = validate_temp_unit(
+                    self._current_temperature_dps.unit
+                )
+                entity_unit = self.temperature_unit
+                if (
+                    current_unit
+                    and entity_unit
+                    and current_unit != entity_unit
+                ):
+                    if (
+                        current_unit == UnitOfTemperature.CELSIUS
+                        and entity_unit == UnitOfTemperature.FAHRENHEIT
+                    ):
+                        temp = temp * 9.0 / 5.0 + 32.0
+                    elif (
+                        current_unit == UnitOfTemperature.FAHRENHEIT
+                        and entity_unit == UnitOfTemperature.CELSIUS
+                    ):
+                        temp = (temp - 32.0) * 5.0 / 9.0
             return temp
 
     @property

--- a/custom_components/tuya_local/devices/starlight_heatpump.yaml
+++ b/custom_components/tuya_local/devices/starlight_heatpump.yaml
@@ -26,10 +26,10 @@ entities:
       - id: 2
         name: temperature
         type: integer
-        unit: C
+        unit: F
         range:
-          min: 160
-          max: 310
+          min: 600
+          max: 860
         mapping:
           - scale: 10
             step: 5
@@ -42,6 +42,7 @@ entities:
       - id: 3
         name: current_temperature
         type: integer
+        unit: C
       - id: 4
         name: mode
         type: string


### PR DESCRIPTION
## Problem

Some devices report target temperature and current temperature in different units. The StarLight heatpump (`starlight_heatpump.yaml`) reports:
- **DPS 2 (target temperature):** Values in deci-Fahrenheit (e.g., raw 850 = 85.0°F)
- **DPS 3 (current temperature):** Values in Celsius (e.g., raw 22 = 22°C)

The device config previously declared DPS 2 as `unit: C` with range 160-310, which caused:
1. Target temp 85.0°F was interpreted as 85.0°C → displayed as **183.2°F**
2. Setting a target of 72°F from HA would send the wrong value to the device

## Root Cause

`climate.py` derives a single `temperature_unit` for the entire entity from the target temperature DPS. All temperature values (including `current_temperature`) are assumed to be in this unit. When the device uses mixed units, `current_temperature` is displayed as a raw value without conversion.

## Fix

### climate.py
Added unit conversion in the `current_temperature` property. When the `current_temperature` DPS has an explicit `unit` that differs from the entity's native `temperature_unit`, the value is converted (C→F or F→C).

This only triggers when:
1. The `current_temperature` DPS explicitly declares a `unit`
2. That unit differs from the entity's native temperature unit

Existing device configs without explicit `unit` on `current_temperature` are **completely unaffected** since the conversion is gated on `self._current_temperature_dps.unit` being non-None.

### starlight_heatpump.yaml
- DPS 2: Changed `unit: C` → `unit: F`, range `160-310` → `600-860` (60.0-86.0°F)
- DPS 3: Added explicit `unit: C`

## Testing

Tested on a StarLight mini split (device ID format `75767832c45bbeda0e85`):
- Target temp now displays correctly (72°F shows as 72°F, not 161.6°F)
- Current temp properly converts from °C to °F (22°C → 71.6°F)
- Setting target temperature from HA sends correct values to device
- Min/max range correctly shows 60-86°F