### PR TITLE
docs(smart_light_rgb48): document DP56/DP59 protocol behavior

### DIFF
--- a/custom_components/tuya_local/devices/rgb48_lightstring.yaml
+++ b/custom_components/tuya_local/devices/rgb48_lightstring.yaml
@@ -3,22 +3,24 @@
 # Protocol: 3.4
 #
 # Notes:
-# - DP 56 (rgbic_linerlight_scene): base64 scene payload for animated multicolor scenes
-#   saved via Smart Life DIY scene editor. Write-only — device never reports this DP in
-#   status polls. All DP 56 scenes animate; static per-bulb color is NOT possible via
-#   this DP. Use text.set_value to apply saved scenes.
+# - DP 56 (rgbic_linerlight_scene): base64 scene payload for animated
+#   multicolor scenes saved via Smart Life DIY scene editor. Write-only
+#   device never reports this DP in status polls. All DP 56 scenes animate;
+#   static per-bulb color is NOT possible via this DP.
+#   Use text.set_value to apply saved scenes.
 # - DP 58 (led_number_set): configures string length/segment count.
-# - DP 59 (draw_tool): base64 per-bulb paint protocol. Mirrors the Smart Life draw tool.
-#   Supports static (effect=0) and gradient (effect=1) multicolor.
+# - DP 59 (draw_tool): base64 per-bulb paint protocol. Mirrors the Smart
+#   Life draw tool. Supports static (effect=0) and gradient (effect=1).
 #   Payload format per bulb (12 bytes):
-#     [0x01, 0x02, effect, hue_hi, hue_lo, sat, 0x64, 0x00, 0x00, 0x81, 0x00, bulb_index]
+#     [0x01, 0x02, effect, hue_hi, hue_lo, sat, 0x64, 0x00, 0x00, 0x81,
+#      0x00, bulb_index]
 #   - effect: 0 = static, 1 = gradient
 #   - hue: 0-360 as 2-byte big-endian integer
 #   - sat: 0-100
 #   - bulb_index: 0-47 for a 48-bulb string
-#   Send init frame first (9 bytes): [0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00]
-#   Then send one payload per bulb with ~50ms delay between each.
-#   Write-only — device never reports this DP in status polls.
+#   Init frame first (9 bytes):
+#     [0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00]
+#   Then one payload per bulb with ~50ms delay. Write-only.
 name: RGBIC string light
 products:
   - id: 2znvfkx64d4fkzxp


### PR DESCRIPTION
Adding protocol documentation discovered through reverse engineering. 

After extensive testing with this device in Home Assistant via local Tuya, I've documented the behavior of DP 56 and DP 59 in the file header comments:

-DP 56 accepts animated DIY scene payloads from Smart Life but does not support static per-bulb color — all scenes animate regardless of mode bytes -DP 59 implements the full per-bulb paint protocol used by Smart Life's draw tool, supporting static multicolor via effect=0 in the payload header -The per-bulb payload format is fully documented in the header comments including the init frame requirement and 50ms delay between bulb writes -Confirmed hidden: true on colour mode is correct behavior — selecting it directly causes repeated hs color errors in HA logs