### PR TITLE
Re-added missing sensor_select section

### DIFF
--- a/custom_components/tuya_local/devices/saswell_c16_thermostat.yaml
+++ b/custom_components/tuya_local/devices/saswell_c16_thermostat.yaml
@@ -74,7 +74,7 @@ entities:
       - id: 14
         type: string
         name: sensor_select
-        hidden: true        
+        hidden: true
       - id: 24
         name: hvac_action
         type: string


### PR DESCRIPTION
Seems that this section was accidentality removed a few PRs ago