### PR TITLE
Add support for TyloHelo SaunaLogic2 (Finnleo sauna controller)

### DIFF
--- a/custom_components/tuya_local/devices/tylohelo_sl2_sauna.yaml
+++ b/custom_components/tuya_local/devices/tylohelo_sl2_sauna.yaml
@@ -55,6 +55,7 @@ entities:
             value: "white"
             default: true
             hidden: true
+      - id: 101
         name: named_color
         type: integer
         mapping:


### PR DESCRIPTION
## Summary

Adds a device definition for the **TyloHelo SaunaLogic2**, a Tuya-based sauna controller (product ID `acl5qrawgmjajabn`, protocol 3.3). This controller is sold under the **Finnleo**, **Helo**, and **Sauna360** brands.

## Entities

| Entity | DP | Type | Description |
|--------|-----|------|-------------|
| climate | 1, 2, 3 | boolean, int, int | Heater on/off, target temp (25-194°F), current temp |
| select | 101 | int (0-8) | Light color: Off, White, Red, Green, Blue, Yellow, Aqua, Purple, Rainbow |
| switch | 103 | boolean | Bluetooth audio on/off |
| sensor | 10 | int | Timer countdown (minutes, read-only) |
| sensor | 4 | string | Sauna mode (diagnostic, e.g. "ONLY_TRAD") |
| sensor | 9 | int | Unknown purpose (diagnostic) |
| sensor | 105 | int | Sauna state: 1=idle, 2=running (diagnostic) |

## Testing

All data points verified via local protocol (v3.3) testing with physical confirmation at the sauna:

- Heater on/off: relay click confirmed, warmth felt
- Temperature set: display updated (device has firmware-enforced minimum ~119°F)
- All 9 light modes: visually confirmed
- Bluetooth on/off: confirmed on sauna display
- Timer write: tested and confirmed **read-only** (device silently ignores writes)
- Two-way: physical panel changes reflected in HA in real-time

## Documentation

Full reverse engineering journey and device specification:
https://github.com/bitswype/finnleo_ha

This device was discovered to be a Tuya OEM (appId 15909) through APK decompilation of the SaunaLogic Android app. Local key obtained by re-pairing to Smart Life. Hidden DPs (101, 103, 105, 4, 9) discovered via local probing — they are not registered in the Tuya cloud product definition.