### PR TITLE
add (config): add costway FD10584DE-WH config

### DIFF
--- a/custom_components/tuya_local/devices/costway_fd10584dewh_heatpump.yaml
+++ b/custom_components/tuya_local/devices/costway_fd10584dewh_heatpump.yaml
@@ -1,4 +1,4 @@
-name: Portable air conditioner with heating
+name: Portable air conditioner
 products:
   - id: 4vtaekm8epj9cdlu
     manufacturer: Costway


### PR DESCRIPTION
Following the advice from https://github.com/make-all/tuya-local/pull/4006#issuecomment-3565353273 (plus some time to spare), I've created a dedicated config for the Costway FD10584DE-WH portable air conditioner with heating.

As with https://github.com/make-all/tuya-local/pull/4006 this one is based on the ballu aura AC - but with the necessary tweaks.

I hope this one is more suitable.