### PR TITLE
Add AQUASTRONG HEX pool heat pump profile

### DIFF
--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -20,11 +20,7 @@ entities:
             conditions:
               - dps_val: make_cold
                 value: cool
-              - dps_val: cold
-                value: cool
               - dps_val: make_hot
-                value: heat
-              - dps_val: heating
                 value: heat
               - dps_val: auto
                 value: auto
@@ -65,10 +61,6 @@ entities:
           - dps_val: make_cold
             value: cool
           - dps_val: make_hot
-            value: heat
-          - dps_val: cold
-            value: cool
-          - dps_val: heating
             value: heat
           - dps_val: auto
             value: auto

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -39,6 +39,17 @@ entities:
         name: current_temperature
         type: integer
         unit: F
+      - id: 20
+        name: hvac_action
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: idle
+          - value: heating
+            constraint: work_mode
+            conditions:
+              - dps_val: make_cold
+                value: cooling
       - id: 5
         name: preset_mode
         type: string
@@ -71,6 +82,25 @@ entities:
       - id: 33
         name: sensor
         type: boolean
+
+  - entity: binary_sensor
+    name: Backflow
+    category: diagnostic
+    dps:
+      - id: 31
+        name: sensor
+        type: boolean
+
+  - entity: sensor
+    name: High pressure
+    category: diagnostic
+    class: pressure
+    dps:
+      - id: 35
+        name: sensor
+        type: integer
+        unit: psi
+        class: measurement
 
   - entity: sensor
     name: Compressor frequency
@@ -128,7 +158,7 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Ambient temperature
+    translation_key: ambient_temperature
     category: diagnostic
     class: temperature
     dps:

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -2,8 +2,8 @@ name: Pool heat pump
 products:
   - id: nxuflhfprft3btpt
     manufacturer: AQUASTRONG
-    model: HEX100
-    model_id: HEX-series
+    model: HEX series
+    model_id: HEX012/HEX016/HEX018/HEX022/HEX035/HEX055/HEX075/HEX100
 # Mapping validated on AQUASTRONG HEX100 over local protocol 3.5.
 entities:
   - entity: climate

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -3,7 +3,7 @@ products:
   - id: nxuflhfprft3btpt
     manufacturer: AQUASTRONG
     model: HEX series
-    model_id: HEX012/HEX016/HEX018/HEX022/HEX035/HEX055/HEX075/HEX100
+    model_id: HEX100
 # Mapping validated on AQUASTRONG HEX100 over local protocol 3.5.
 entities:
   - entity: climate

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -61,21 +61,6 @@ entities:
           - dps_val: Boost
             value: boost
 
-  - entity: select
-    translation_key: heat_pump_mode
-    category: config
-    dps:
-      - id: 2
-        name: option
-        type: string
-        mapping:
-          - dps_val: make_cold
-            value: cool
-          - dps_val: make_hot
-            value: heat
-          - dps_val: auto
-            value: auto
-
   - entity: binary_sensor
     translation_key: defrost
     dps:

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -1,0 +1,229 @@
+name: Pool heat pump
+products:
+  - id: nxuflhfprft3btpt
+    manufacturer: AQUASTRONG
+    model: HEX100
+    model_id: HEX-series
+# Mapping validated on AQUASTRONG HEX100 over local protocol 3.5.
+entities:
+  - entity: climate
+    name: Pool heat pump
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+      - id: 4
+        name: temperature
+        type: integer
+        unit: F
+        range:
+          min: 50
+          max: 104
+      - id: 21
+        name: current_temperature
+        type: integer
+        unit: F
+      - id: 5
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: ECO
+            value: eco
+          - dps_val: Normal
+            value: normal
+          - dps_val: Boost
+            value: boost
+
+  - entity: select
+    translation_key: heat_pump_mode
+    category: config
+    dps:
+      - id: 2
+        name: option
+        type: string
+        mapping:
+          - dps_val: cold
+            value: cool
+          - dps_val: heating
+            value: heat
+          - dps_val: floor_heating
+            value: floor_heat
+          - dps_val: hot_water
+            value: hotwater
+          - dps_val: make_hot
+            value: hotwater
+          - dps_val: cold_and_hot_water
+            value: hotwater_cool
+          - dps_val: heating_and_hot_water
+            value: hotwater_heat
+          - dps_val: floor_heating_and_hot_water
+            value: hotwater_floor_heat
+
+  - entity: binary_sensor
+    translation_key: defrost
+    dps:
+      - id: 33
+        name: sensor
+        type: boolean
+
+  - entity: sensor
+    name: Compressor frequency
+    category: diagnostic
+    class: frequency
+    dps:
+      - id: 20
+        name: sensor
+        type: integer
+        unit: Hz
+        class: measurement
+
+  - entity: sensor
+    name: Inlet temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 21
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Outlet temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 22
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Coiler temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 23
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Discharge temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 24
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Ambient temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 26
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Incoiler temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 37
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Fan motor frequency
+    category: diagnostic
+    class: frequency
+    dps:
+      - id: 40
+        name: sensor
+        type: integer
+        unit: Hz
+        class: measurement
+
+  - entity: sensor
+    name: Suction temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 41
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: EEV opening
+    category: diagnostic
+    dps:
+      - id: 16
+        name: sensor
+        type: integer
+        unit: P
+        class: measurement
+
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 102
+        name: sensor
+        type: integer
+        unit: A
+        class: measurement
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 103
+        name: sensor
+        type: integer
+        unit: V
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        unit: W
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 105
+        name: sensor
+        type: integer
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -8,6 +8,7 @@ products:
 entities:
   - entity: climate
     name: Pool heat pump
+    icon: mdi:hot-tub
     dps:
       - id: 1
         name: hvac_mode

--- a/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquastrong_hex_heatpump.yaml
@@ -7,8 +7,7 @@ products:
 # Mapping validated on AQUASTRONG HEX100 over local protocol 3.5.
 entities:
   - entity: climate
-    name: Pool heat pump
-    icon: mdi:hot-tub
+    translation_key: pool_heatpump
     dps:
       - id: 1
         name: hvac_mode
@@ -17,7 +16,22 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            value: heat
+            constraint: work_mode
+            conditions:
+              - dps_val: make_cold
+                value: cool
+              - dps_val: cold
+                value: cool
+              - dps_val: make_hot
+                value: heat
+              - dps_val: heating
+                value: heat
+              - dps_val: auto
+                value: auto
+      - id: 2
+        name: work_mode
+        type: string
+        hidden: true
       - id: 4
         name: temperature
         type: integer
@@ -48,22 +62,16 @@ entities:
         name: option
         type: string
         mapping:
+          - dps_val: make_cold
+            value: cool
+          - dps_val: make_hot
+            value: heat
           - dps_val: cold
             value: cool
           - dps_val: heating
             value: heat
-          - dps_val: floor_heating
-            value: floor_heat
-          - dps_val: hot_water
-            value: hotwater
-          - dps_val: make_hot
-            value: hotwater
-          - dps_val: cold_and_hot_water
-            value: hotwater_cool
-          - dps_val: heating_and_hot_water
-            value: hotwater_heat
-          - dps_val: floor_heating_and_hot_water
-            value: hotwater_floor_heat
+          - dps_val: auto
+            value: auto
 
   - entity: binary_sensor
     translation_key: defrost


### PR DESCRIPTION
This PR adds a new Tuya Local device profile for AQUASTRONG HEX-series pool heat pumps.

Tested on:

AQUASTRONG HEX100
Local protocol: 3.5
Stable local DPS polling and control verified
Compatibility target:

HEX012
HEX016
HEX018
HEX022
HEX035
HEX055
HEX075
HEX100
What is included:

Climate entity (with pool/hot-tub style icon)
Heat pump mode select
Defrost binary sensor
Diagnostic sensors:
Compressor frequency
Fan motor frequency
Inlet/outlet/coiler/discharge/ambient/incoiler/suction temperatures
EEV opening
Electrical telemetry mappings (current/voltage/power/energy)
Notes:

Temperature mapping is in Fahrenheit for this profile variant.
Setpoint range is 50-104 F.
On the tested unit, electrical DPS keys are present but reported zero values during local polling, even under load.