### PR TITLE
Add Holman WX4 4-zone irrigation controller

### DIFF
--- a/custom_components/tuya_local/devices/holman_wx4_irrigation_controller.yaml
+++ b/custom_components/tuya_local/devices/holman_wx4_irrigation_controller.yaml
@@ -71,11 +71,12 @@ entities:
     name: Last water flow 1
     class: water
     category: diagnostic
-    icon: "mdi:water"
+    icon: mdi:water
     dps:
       - id: 103
         name: sensor
         type: integer
+        readonly: true
         unit: L
         range:
           min: 0
@@ -87,11 +88,12 @@ entities:
     name: Last water flow 2
     class: water
     category: diagnostic
-    icon: "mdi:water"
+    icon: mdi:water
     dps:
       - id: 152
         name: sensor
         type: integer
+        readonly: true
         unit: L
         range:
           min: 0
@@ -103,11 +105,12 @@ entities:
     name: Last water flow 3
     class: water
     category: diagnostic
-    icon: "mdi:water"
+    icon: mdi:water
     dps:
       - id: 183
         name: sensor
         type: integer
+        readonly: true
         unit: L
         range:
           min: 0
@@ -119,11 +122,12 @@ entities:
     name: Last water flow 4
     class: water
     category: diagnostic
-    icon: "mdi:water"
+    icon: mdi:water
     dps:
       - id: 184
         name: sensor
         type: integer
+        readonly: true
         unit: L
         range:
           min: 0
@@ -137,11 +141,12 @@ entities:
     name: Last runtime 1
     class: duration
     category: diagnostic
-    icon: "mdi:timer"
+    icon: mdi:timer
     dps:
       - id: 193
         type: integer
         name: sensor
+        readonly: true
         optional: true
         unit: s
 
@@ -149,11 +154,12 @@ entities:
     name: Last runtime 2
     class: duration
     category: diagnostic
-    icon: "mdi:timer"
+    icon: mdi:timer
     dps:
       - id: 194
         type: integer
         name: sensor
+        readonly: true
         optional: true
         unit: s
 
@@ -165,67 +171,24 @@ entities:
       - id: 7
         type: integer
         name: sensor
+        readonly: true
         unit: "%"
 
   - entity: sensor
     name: Alarm status
     category: diagnostic
-    icon: "mdi:alert-circle"
+    icon: mdi:alert-circle
     dps:
       - id: 120
         name: sensor
         type: integer
+        readonly: true
 
-  # Physical add-on sensor presence (hidden when not fitted)
-  - entity: binary_sensor
-    name: T&H soil sensor present 1
-    category: diagnostic
-    hidden: unavailable
-    dps:
-      - id: 115
-        name: sensor
-        type: boolean
-        optional: true
-
-  - entity: binary_sensor
-    name: Rain sensor present 1
-    category: diagnostic
-    hidden: unavailable
-    dps:
-      - id: 117
-        name: sensor
-        type: boolean
-        optional: true
-
-  - entity: binary_sensor
-    name: T&H soil sensor power OK 1
-    category: diagnostic
-    hidden: unavailable
-    dps:
-      - id: 125
-        name: sensor
-        type: boolean
-        optional: true
-
-  - entity: binary_sensor
-    name: T&H soil sensor present 2
-    category: diagnostic
-    hidden: unavailable
-    dps:
-      - id: 161
-        name: sensor
-        type: boolean
-        optional: true
-
-  - entity: binary_sensor
-    name: Soil sensor power OK 2
-    category: diagnostic
-    hidden: unavailable
-    dps:
-      - id: 162
-        name: sensor
-        type: boolean
-        optional: true
+  # Note: physical add-on sensors (T&H soil sensor DPs 115, 125, 161, 162
+  # and rain sensor DP 117) are not yet included. When the corresponding
+  # measurement DPs (temperature, humidity, rain data) are confirmed, those
+  # sensors should be added with the presence/power DPs attached as
+  # `available` attributes on each measurement entity.
 
   # Units and time format (optional - not confirmed on all firmware)
   - entity: select
@@ -238,9 +201,9 @@ entities:
         optional: true
         mapping:
           - dps_val: "1"
-            value: Metric
+            value: l/C
           - dps_val: "2"
-            value: Imperial
+            value: gal/F
 
   - entity: select
     name: Time format
@@ -266,10 +229,9 @@ entities:
   # DP 176: master scheduling blob - not decoded; device scheduling
   #         is replaced by HA automations for greater flexibility.
   - entity: text
-    name: Zone Timers Raw Data
-    icon: "mdi:code-brackets"
+    name: Zone timers
+    icon: mdi:code-brackets
     category: config
-    hidden: true
     dps:
       - id: 172
         type: string
@@ -277,20 +239,19 @@ entities:
         optional: true
 
   - entity: sensor
-    name: Timer setting 1 encoded
+    name: Zone countdown
     category: diagnostic
-    hidden: true
     dps:
       - id: 173
         name: sensor
         type: base64
+        readonly: true
         optional: true
 
   - entity: text
-    name: Rain Delay Raw Data
-    icon: "mdi:weather-pouring"
+    name: Rain delay
+    icon: mdi:weather-pouring
     category: config
-    hidden: true
     dps:
       - id: 175
         type: string
@@ -298,11 +259,11 @@ entities:
         optional: true
 
   - entity: sensor
-    name: Timestamp or schedule encoded
+    name: Schedule
     category: diagnostic
-    hidden: true
     dps:
       - id: 176
         name: sensor
         type: base64
+        readonly: true
         optional: true


### PR DESCRIPTION
## Device
- **Manufacturer:** Holman
- **Model:** WX4 4-Zone Wi-Fi Irrigation Controller
- **Tuya Product ID:** `5jotr6jtclzapmik`
- **Reference:** https://www.holmanindustries.com.au/products/wx4-wi-fi-4-zone-irrigation-controller/

## What's implemented
- Zone valve control (on/off) for all 4 zones — DPs 108, 155, 181, 182
- Manual run timer (0–60 min) for Zones 1 & 2 — DPs 107, 154 (Zones 3 & 4 DPs not yet confirmed)
- Last water flow sensors for all 4 zones — DPs 103, 152, 183, 184 (raw value ÷ 10 = litres)
- Last runtime sensors for Zones 1 & 2 — DPs 193, 194 (Zones 3 & 4 DPs not yet confirmed)
- Battery percentage — DP 7
- Alarm status — DP 120
- Physical soil/rain sensor presence diagnostics — DPs 115, 117, 125, 161, 162
- Units select (DP 119) and Time Format select (DP 114) — borrowed from WX1 pattern, marked `optional: true`, not personally confirmed on WX4
- Raw data DPs 172, 173, 175, 176 exposed as text/base64 sensors for advanced HA template use (live countdowns, rain delay selector, timer sync)

## Known limitations / not implemented
- Manual timer and runtime DPs for Zones 3 & 4 not yet identified — contributions welcome
- DP 176 scheduling blob not decoded — device scheduling is complex; recommend using HA automations instead
- Tested in metric mode only (Australia)

## Testing
Tested on HA 2026.4.x with tuya_local 2026.3.0. All 4 zones open/close correctly. Water flow, runtime, and battery sensors confirmed working.