### PR TITLE
Add Macro MA-20WODP gas water heater

### DIFF
--- a/custom_components/tuya_local/devices/macro_ma20wodp_water_heater.yaml
+++ b/custom_components/tuya_local/devices/macro_ma20wodp_water_heater.yaml
@@ -1,3 +1,4 @@
+# https://www.cityenergylife.com.sg/products/ma-20wodp
 name: Gas Water Heater
 products:
   - id: yliuzmey7vxflbzr

--- a/custom_components/tuya_local/devices/macro_ma20wodp_water_heater.yaml
+++ b/custom_components/tuya_local/devices/macro_ma20wodp_water_heater.yaml
@@ -1,5 +1,5 @@
 # https://www.cityenergylife.com.sg/products/ma-20wodp
-name: Gas Water Heater
+name: Gas water heater
 products:
   - id: yliuzmey7vxflbzr
     manufacturer: Macro
@@ -7,7 +7,7 @@ products:
     model: MA-20WODP
 entities:
   - entity: water_heater
-    translation_key: water_air
+    translation_only_key: hot_water
     dps:
       - id: 1
         type: boolean
@@ -19,7 +19,7 @@ entities:
             constraint: work_mode
             conditions:
               - dps_val: Manual
-                value: electric
+                value: gas
               - dps_val: Eco
                 value: eco
               - dps_val: Turbo
@@ -33,15 +33,15 @@ entities:
         name: temperature
         unit: C
         range:
-          min: 40
-          max: 75
+          min: 36
+          max: 60
         mapping:
           - step: 5
       - id: 10
         type: integer
         name: current_temperature
   - entity: switch
-    name: Instant Heating
+    name: Instant heating
     icon: mdi:lightning-bolt
     dps:
       - id: 15

--- a/custom_components/tuya_local/devices/macro_ma20wodp_water_heater.yaml
+++ b/custom_components/tuya_local/devices/macro_ma20wodp_water_heater.yaml
@@ -1,0 +1,77 @@
+name: Gas Water Heater
+products:
+  - id: yliuzmey7vxflbzr
+    manufacturer: Macro
+    model_id: MA-20WODP
+    model: MA-20WODP
+entities:
+  - entity: water_heater
+    translation_key: water_air
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: work_mode
+            conditions:
+              - dps_val: Manual
+                value: electric
+              - dps_val: Eco
+                value: eco
+              - dps_val: Turbo
+                value: performance
+      - id: 2
+        type: string
+        name: work_mode
+        hidden: true
+      - id: 9
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 40
+          max: 75
+        mapping:
+          - step: 5
+      - id: 10
+        type: integer
+        name: current_temperature
+  - entity: switch
+    name: Instant Heating
+    icon: mdi:lightning-bolt
+    dps:
+      - id: 15
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    translation_key: status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 13
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: Stop
+            value: idle
+          - dps_val: Heating
+            value: heating
+          - dps_val: Warm
+            value: keeping_warm

--- a/custom_components/tuya_local/devices/macro_ma20wodp_waterheater.yaml
+++ b/custom_components/tuya_local/devices/macro_ma20wodp_waterheater.yaml
@@ -3,7 +3,6 @@ name: Gas water heater
 products:
   - id: yliuzmey7vxflbzr
     manufacturer: Macro
-    model_id: MA-20WODP
     model: MA-20WODP
 entities:
   - entity: water_heater


### PR DESCRIPTION
## New device: Macro MA-20WODP Gas Water Heater

**Tuya product id:** `yliuzmey7vxflbzr`
**Manufacturer:** Macro
**Model:** MA-20WODP
**Product category:** Gas Water Heater (rs)

### Entities

| Entity | Description |
|--------|-------------|
| `water_heater` | Main entity — on/off, mode (electric/eco/performance), set temp (40–75°C, step 5), current temp |
| `switch` (Instant Heating) | DP 15 — toggles instant heating mode |
| `binary_sensor` (problem) | DP 20 — fault detection via bitfield |
| `sensor` (status, enum) | DP 13 — work state: idle / heating / keeping_warm |

### DPs

| DP | Type | Name | Notes |
|----|------|------|-------|
| 1 | boolean | operation_mode | off when false; mode determined by DP 2 when true |
| 2 | string | work_mode | Manual → electric, Eco → eco, Turbo → performance |
| 9 | integer | temperature | Set temp, 40–75°C, step 5 |
| 10 | integer | current_temperature | Read-only |
| 13 | string | work_state | Stop/Heating/Warm |
| 15 | boolean | switch | Instant heating |
| 20 | bitfield | fault | 0 = no fault |

### Tested on
- Home Assistant OS 17.1 / Core 2026.4.1
- tuya-local (HACS custom integration)
- Device confirmed online and controllable via HA