### PR TITLE
Add Mowe MW368F Atlas 36 smart ceiling fan

### DIFF
--- a/custom_components/tuya_local/devices/mowe_mw368f_ceiling_fan.yaml
+++ b/custom_components/tuya_local/devices/mowe_mw368f_ceiling_fan.yaml
@@ -1,0 +1,105 @@
+# https://mowesmarthome.com/product/smart-ceiling-fan/
+name: Ceiling fan
+products:
+  - id: 12giv5ur6oye6kbo
+    manufacturer: Mowe
+    model: Atlas 36 Smart Ceiling Fan
+    model_id: MW368F
+entities:
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: nature
+            value: nature
+          - dps_val: sleep
+            value: sleep
+          - dps_val: normal
+            value: normal
+      - id: 3
+        type: integer
+        name: speed
+        optional: true
+        range:
+          min: 1
+          max: 6
+      - id: 8
+        type: string
+        name: direction
+        optional: true
+        mapping:
+          - dps_val: null
+            value: forward
+            hidden: true
+  - entity: light
+    dps:
+      - id: 15
+        type: boolean
+        name: switch
+      - id: 16
+        type: integer
+        name: brightness
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - step: 2
+  - entity: select
+    translation_key: timer
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+            available: std
+          - dps_val: "1h"
+            value: "1h"
+            available: std
+          - dps_val: "2h"
+            value: "2h"
+            available: std
+          - dps_val: "4h"
+            value: "4h"
+            available: std
+          - dps_val: "8h"
+            value: "8h"
+            available: std
+          - dps_val: "off"
+            value: cancel
+            available: hour
+          - dps_val: "1hour"
+            value: "1h"
+            available: hour
+          - dps_val: "2hour"
+            value: "2h"
+            available: hour
+          - dps_val: "4hour"
+            value: "4h"
+            available: hour
+          - dps_val: "8hour"
+            value: "8h"
+            available: hour
+      - id: 22
+        type: string
+        name: hour
+        mapping:
+          - value: false
+            conditions:
+              - dps_val: ["off", "1hour", "2hour", "4hour", "8hour"]
+                value: true
+      - id: 22
+        type: string
+        name: std
+        mapping:
+          - value: true
+            conditions:
+              - dps_val: ["off", "1hour", "2hour", "4hour", "8hour"]
+                value: false


### PR DESCRIPTION
## New device: Mowe Atlas 36" Smart Ceiling Fan (MW368F)

**Product page:** https://mowesmarthome.com/product/smart-ceiling-fan/
**Tuya product id:** `12giv5ur6oye6kbo`
**Manufacturer:** Mowe
**Model:** Atlas 36 Smart Ceiling Fan
**Model ID:** MW368F

### Entities

| Entity | Description |
|--------|-------------|
| `fan` | Main fan — on/off, preset modes (nature/sleep/normal), speed (1–6), direction |
| `light` | Integrated ceiling light — on/off, brightness (0–100, step 2) |
| `select` (timer) | Countdown timer — cancel, 1h, 2h, 4h, 8h (supports two DP value formats: std and hour) |

### DPs

| DP | Type | Name | Notes |
|----|------|------|-------|
| 1 | boolean | switch | Fan on/off |
| 2 | string | preset_mode | nature / sleep / normal |
| 3 | integer | speed | 1–6, optional |
| 8 | string | direction | optional |
| 15 | boolean | switch | Light on/off |
| 16 | integer | brightness | 0–100, step 2 |
| 22 | string | timer | Two value sets: std (cancel/1h/2h/4h/8h) and hour (off/1hour/2hour/4hour/8hour) |

### Tested on
- Home Assistant OS 17.1 / Core 2026.4.1
- tuya-local (HACS custom integration)
- Device confirmed online and controllable via HA