### PR TITLE
Added 8ch relay board

### DIFF
--- a/custom_components/tuya_local/remote.py
+++ b/custom_components/tuya_local/remote.py
@@ -399,7 +399,7 @@ class TuyaLocalRemote(TuyaLocalEntity, RemoteEntity):
             persistent_notification.async_dismiss(
                 self._device._hass, notification_id="learn_command"
             )
-            _LOGGER("%s ending learning mode", self._config.config_id)
+            _LOGGER.debug("%s ending learning mode", self._config.config_id)
             if self._control_dp:
                 await self._control_dp.async_set_value(
                     self._device,


### PR DESCRIPTION
## New device: 8ch relay board

**Tuya product id:** aaa2vqyazpodpqhb
**Manufacturer:** 8路开关
**Model:** 8112

### Entities

| Entity | DP | Type | Description |
|--------|-----|------|--------------|
| `switch 1-8` | 1-8 | boolean | relay output — on/off |
| `timer 1-8` | 9-16 | integer | operation timer (in seconds) |
| `relays initial state` | 38 | string | relays state after power-up: Off-all off, On-all on, Memory - last state |
| `light` | 40 | string | mode of state leds: relay-state of the relay, pos-?, none-always off |

### Tested
- Home Assistant 2025.10.1 - 2026.4.1 versions
- tuya-local from HACS
- Device confirmed online and controllable via HA