### PR TITLE
fix (remote): correct broken log call in remote learn command

### DIFF
--- a/custom_components/tuya_local/remote.py
+++ b/custom_components/tuya_local/remote.py
@@ -399,7 +399,7 @@ class TuyaLocalRemote(TuyaLocalEntity, RemoteEntity):
             persistent_notification.async_dismiss(
                 self._device._hass, notification_id="learn_command"
             )
-            _LOGGER("%s ending learning mode", self._config.config_id)
+            _LOGGER.debug("%s ending learning mode", self._config.config_id)
             if self._control_dp:
                 await self._control_dp.async_set_value(
                     self._device,


### PR DESCRIPTION
Pretty self-evident. The existing log call raises a `TypeError` due to the missing method name when trying to learn remote commands.