### PR TITLE
Beok TR9HB-AC2 support

### DIFF
--- a/custom_components/tuya_local/devices/beok_tr9hb-ac2_thermostat.yaml
+++ b/custom_components/tuya_local/devices/beok_tr9hb-ac2_thermostat.yaml
@@ -11,16 +11,16 @@ entities:
         type: boolean
         name: hvac_mode
         mapping:
-          - dps_val: False
+          - dps_val: false
             value: "off"
-          - dps_val: True
+          - dps_val: true
             constraint: mode
             conditions:
               - dps_val: cool
                 value: cool
               - dps_val: heat
                 value: heat
-              - dps_val: [ventilation, ventil]
+              - dps_val: ventil
                 value: fan_only
       - id: 2
         type: string
@@ -29,13 +29,24 @@ entities:
       - id: 16
         type: integer
         name: temperature
-        unit: C
         range:
-          min: 100
-          max: 350
+          min: 50
+          max: 400
         mapping:
           - scale: 10
             step: 5
+            constraint: temperature_unit
+            conditions:
+              - dps_val: c
+                range:
+                  min: 50
+                  max: 400
+                step: 5
+              - dps_val: f
+                range:
+                  min: 410
+                  max: 1040
+                step: 10
       - id: 23
         type: string
         name: temperature_unit
@@ -70,9 +81,9 @@ entities:
             value: idle
             constraint: mode
             conditions:
-              - dps_val: [cool]
+              - dps_val: cool
                 value: cooling
-              - dps_val: [heat]
+              - dps_val: heat
                 value: heating
           - dps_val: close
             value: idle


### PR DESCRIPTION
Add suport for Beok TR9HB-AC2 Fan coil thermostat
<img width="672" height="554" alt="image" src="https://github.com/user-attachments/assets/d0f8cc7e-b07c-4591-9a97-90a5086c34b7" />
