### PR TITLE
Add cado device configurations

### DIFF
--- a/custom_components/tuya_local/devices/cado_ap_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/cado_ap_airpurifier.yaml
@@ -1,0 +1,113 @@
+name: Air purifier
+products:
+  - id: 9SMTMalYiMNQItYo
+    manufacturer: cado
+    model: AP-C120
+  - id: x5gUduZ8QeP8hap6
+    manufacturer: cado
+    model: AP-C220
+  - id: OIFEubH3So07A35c
+    manufacturer: cado
+    model: AP-C320i
+entities:
+  - entity: fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 3
+        type: string
+        name: preset_mode
+        optional: true
+      - id: 4
+        type: string
+        name: speed
+        optional: true
+  - entity: sensor
+    class: pm25
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: "\u00B5g/m\u00B3"
+        class: measurement
+        readonly: true
+  - entity: sensor
+    name: Filter life
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        readonly: true
+  - entity: light
+    category: config
+    dps:
+      - id: 8
+        type: boolean
+        name: switch
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 12
+        type: integer
+        name: sensor
+        unit: "\u00B0C"
+        class: measurement
+        readonly: true
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        readonly: true
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        optional: true
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+  - entity: binary_sensor
+    name: Air quality
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        readonly: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+        optional: true
+  - entity: binary_sensor
+    name: Filter cover
+    class: opening
+    category: diagnostic
+    dps:
+      - id: 102
+        type: boolean
+        name: sensor
+        optional: true

--- a/custom_components/tuya_local/devices/cado_hm_humidifier.yaml
+++ b/custom_components/tuya_local/devices/cado_hm_humidifier.yaml
@@ -1,0 +1,76 @@
+name: Humidifier
+products:
+  - id: 7owpshi3cabjwphk
+    manufacturer: cado
+    model: HM-C630i
+  - id: aghute7o9fv4xdpo
+    manufacturer: cado
+    model: HM-C700i
+entities:
+  - entity: humidifier
+    dps:
+      - id: 10
+        type: boolean
+        name: switch
+      - id: 2
+        type: string
+        name: mode
+        mapping:
+          - dps_val: "0"
+            value: auto
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+  - entity: light
+    category: config
+    dps:
+      - id: 5
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 9
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 9
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: "\u00B0C"
+        class: measurement
+        readonly: true
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        readonly: true
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 107
+        name: option
+        type: string
+        optional: true

--- a/custom_components/tuya_local/devices/cado_smt_double_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smt_double_heater.yaml
@@ -2,7 +2,7 @@ name: Fan heater
 products:
   - id: q97exjuyhtw8zp1q
     manufacturer: cado
-    model: SMT Series (double)
+    model: SMT-140/SMT-160
 entities:
   - entity: climate
     translation_only_key: heater

--- a/custom_components/tuya_local/devices/cado_smt_double_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smt_double_heater.yaml
@@ -1,0 +1,128 @@
+name: Fan heater
+products:
+  - id: q97exjuyhtw8zp1q
+    manufacturer: cado
+    model: SMT Series (double)
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: sleep
+            value: sleep
+          - dps_val: wind
+            value: wind
+          - dps_val: mite
+            value: mite
+      - id: 104
+        name: temperature
+        type: integer
+        range:
+          min: 25
+          max: 40
+        unit: C
+  - entity: switch
+    name: Left side
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Right side
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+        optional: true
+  - entity: switch
+    name: Both sides
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+        optional: true
+  - entity: sensor
+    name: Right side temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        readonly: true
+        optional: true
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: lock
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: 1H
+            value: 1H
+          - dps_val: 2H
+            value: 2H
+          - dps_val: 3H
+            value: 3H
+          - dps_val: 4H
+            value: 4H
+          - dps_val: 5H
+            value: 5H
+          - dps_val: 6H
+            value: 6H
+          - dps_val: 7H
+            value: 7H
+          - dps_val: 8H
+            value: 8H
+          - dps_val: 9H
+            value: 9H
+          - dps_val: 10H
+            value: 10H
+          - dps_val: 11H
+            value: 11H
+          - dps_val: 12H
+            value: 12H
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+  - entity: lock
+    name: Remote child lock
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: lock
+        optional: true

--- a/custom_components/tuya_local/devices/cado_smt_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smt_heater.yaml
@@ -2,7 +2,7 @@ name: Fan heater
 products:
   - id: ffypxhkzmww2kigw
     manufacturer: cado
-    model: SMT Series (single)
+    model: SMT-100/SMT-120
 entities:
   - entity: climate
     translation_only_key: heater

--- a/custom_components/tuya_local/devices/cado_smt_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smt_heater.yaml
@@ -1,0 +1,96 @@
+name: Fan heater
+products:
+  - id: ffypxhkzmww2kigw
+    manufacturer: cado
+    model: SMT Series (single)
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: sleep
+            value: sleep
+          - dps_val: wind
+            value: wind
+          - dps_val: mite
+            value: mite
+      - id: 104
+        name: temperature
+        type: integer
+        range:
+          min: 25
+          max: 40
+        unit: C
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: lock
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: 1H
+            value: 1H
+          - dps_val: 2H
+            value: 2H
+          - dps_val: 3H
+            value: 3H
+          - dps_val: 4H
+            value: 4H
+          - dps_val: 5H
+            value: 5H
+          - dps_val: 6H
+            value: 6H
+          - dps_val: 7H
+            value: 7H
+          - dps_val: 8H
+            value: 8H
+          - dps_val: 9H
+            value: 9H
+          - dps_val: 10H
+            value: 10H
+          - dps_val: 11H
+            value: 11H
+          - dps_val: 12H
+            value: 12H
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+  - entity: lock
+    name: Remote child lock
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: lock
+        optional: true

--- a/custom_components/tuya_local/devices/cado_smts_double_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smts_double_heater.yaml
@@ -2,7 +2,7 @@ name: Fan heater
 products:
   - id: yeon26hix1s2zqhz
     manufacturer: cado
-    model: SMT-S Series (double)
+    model: SMT-S140/SMT-S160
 entities:
   - entity: climate
     translation_only_key: heater

--- a/custom_components/tuya_local/devices/cado_smts_double_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smts_double_heater.yaml
@@ -1,0 +1,128 @@
+name: Fan heater
+products:
+  - id: yeon26hix1s2zqhz
+    manufacturer: cado
+    model: SMT-S Series (double)
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: sleep
+            value: sleep
+          - dps_val: wind
+            value: wind
+          - dps_val: mite
+            value: mite
+      - id: 104
+        name: temperature
+        type: integer
+        range:
+          min: 25
+          max: 40
+        unit: C
+  - entity: switch
+    name: Left side
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Right side
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+        optional: true
+  - entity: switch
+    name: Both sides
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+        optional: true
+  - entity: sensor
+    name: Right side temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        readonly: true
+        optional: true
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: lock
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: 1H
+            value: 1H
+          - dps_val: 2H
+            value: 2H
+          - dps_val: 3H
+            value: 3H
+          - dps_val: 4H
+            value: 4H
+          - dps_val: 5H
+            value: 5H
+          - dps_val: 6H
+            value: 6H
+          - dps_val: 7H
+            value: 7H
+          - dps_val: 8H
+            value: 8H
+          - dps_val: 9H
+            value: 9H
+          - dps_val: 10H
+            value: 10H
+          - dps_val: 11H
+            value: 11H
+          - dps_val: 12H
+            value: 12H
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+  - entity: lock
+    name: Remote child lock
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: lock
+        optional: true

--- a/custom_components/tuya_local/devices/cado_smts_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smts_heater.yaml
@@ -1,0 +1,96 @@
+name: Fan heater
+products:
+  - id: qzy9wa6qafg2fzs5
+    manufacturer: cado
+    model: SMT-S Series (single)
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: sleep
+            value: sleep
+          - dps_val: wind
+            value: wind
+          - dps_val: mite
+            value: mite
+      - id: 104
+        name: temperature
+        type: integer
+        range:
+          min: 25
+          max: 40
+        unit: C
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: lock
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 19
+        name: option
+        type: string
+        mapping:
+          - dps_val: 1H
+            value: 1H
+          - dps_val: 2H
+            value: 2H
+          - dps_val: 3H
+            value: 3H
+          - dps_val: 4H
+            value: 4H
+          - dps_val: 5H
+            value: 5H
+          - dps_val: 6H
+            value: 6H
+          - dps_val: 7H
+            value: 7H
+          - dps_val: 8H
+            value: 8H
+          - dps_val: 9H
+            value: 9H
+          - dps_val: 10H
+            value: 10H
+          - dps_val: 11H
+            value: 11H
+          - dps_val: 12H
+            value: 12H
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+  - entity: lock
+    name: Remote child lock
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: lock
+        optional: true

--- a/custom_components/tuya_local/devices/cado_smts_heater.yaml
+++ b/custom_components/tuya_local/devices/cado_smts_heater.yaml
@@ -2,7 +2,7 @@ name: Fan heater
 products:
   - id: qzy9wa6qafg2fzs5
     manufacturer: cado
-    model: SMT-S Series (single)
+    model: SMT-S100/SMT-S120
 entities:
   - entity: climate
     translation_only_key: heater


### PR DESCRIPTION
## Summary
- Add device configurations for the **cado** product line (Japanese home appliance brand)
- All devices use Tuya protocol 3.4 via the ThingClips SDK

### Fan heaters (温風マットレス)
| Config | Product | Product ID |
|---|---|---|
| `cado_smt_heater` | SMT Series (single) | `ffypxhkzmww2kigw` |
| `cado_smt_double_heater` | SMT Series (double) | `q97exjuyhtw8zp1q` |
| `cado_smts_heater` | SMT-S Series (single) | `qzy9wa6qafg2fzs5` |
| `cado_smts_double_heater` | SMT-S Series (double) | `yeon26hix1s2zqhz` |

**Supported DPs:** switch (1), mode (2: sleep/wind/mite), child lock (17), timer (19: 1H-12H), fault (21), temperature setting (104: 25-40°C), remote child lock (106). Double models add left/right side switches (101/102/103) and right side temperature (105).

### Air purifiers (空気清浄機)
| Config | Products | Product IDs |
|---|---|---|
| `cado_ap_airpurifier` | AP-C120, AP-C220, AP-C320i | `9SMTMalYiMNQItYo`, `x5gUduZ8QeP8hap6`, `OIFEubH3So07A35c` |

**Supported DPs:** switch (1), PM2.5 (2), mode (3), wind speed (4), filter life (5), light (8), temperature (12), humidity (13), timer (19), fault (21), air quality (101), filter cover (102).

### Humidifiers (加湿器)
| Config | Products | Product IDs |
|---|---|---|
| `cado_hm_humidifier` | HM-C630i, HM-C700i | `7owpshi3cabjwphk`, `aghute7o9fv4xdpo` |

**Supported DPs:** mode (2: 0-5), light (5), fault (9), switch (10), temperature (101), humidity (102), timer (107).

## Test plan
- [x] SMT Series (single) tested on real hardware — confirmed working with Home Assistant
- [ ] Other models based on APK reverse engineering (same cado sync app, same ThingClips SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)