### PR TITLE
Fix binary_sensor device class for Parkside PPWD 30 A1 vacuum

### DIFF
--- a/custom_components/tuya_local/devices/parkside_ppwd30a1_vacuum.yaml
+++ b/custom_components/tuya_local/devices/parkside_ppwd30a1_vacuum.yaml
@@ -65,7 +65,7 @@ entities:
             value: Crevice tool
   - entity: binary_sensor
     name: Sync
-    class: connection
+    class: connectivity
     category: diagnostic
     dps:
       - id: 101


### PR DESCRIPTION
## Summary

The `Sync` binary_sensor entity in `parkside_ppwd30a1_vacuum.yaml` uses `class: connection`, which is not a valid `BinarySensorDeviceClass` in Home Assistant. This causes a repeated warning on every sync poll:

```
WARNING [custom_components.tuya_local.binary_sensor] parkside_ppwd30a1_vacuum.yaml/Sync: Unrecognised binary_sensor device class of connection ignored
```

The correct device class is `connectivity` (`BinarySensorDeviceClass.CONNECTIVITY`), which has the semantics "On means connected, Off means disconnected" — matching the intended behaviour of this sensor.

## Change

- `class: connection` → `class: connectivity` in the `Sync` binary_sensor entity (DPS 101)