### PR TITLE
Add Ideal Clima fancoil support

### DIFF
--- a/custom_components/tuya_local/devices/ideal_clima_fancoil.yaml
+++ b/custom_components/tuya_local/devices/ideal_clima_fancoil.yaml
@@ -1,0 +1,76 @@
+name: Fancoil
+products:
+  - id: 5dgguakbmhwzwiko
+    manufacturer: Ideal Clima
+    model: Nemo
+entities:
+  - entity: climate
+    translation_key: fancoil
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: cool
+                value: cool
+              - dps_val: heat
+                value: heat
+              - dps_val: dehu
+                value: dry
+              - dps_val: fan
+                value: fan_only
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 0
+          max: 40
+      - id: 3
+        type: integer
+        name: current_temperature
+        unit: C
+        range:
+          min: -20
+          max: 50
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: superlow
+            value: silent
+          - dps_val: low
+            value: low
+          - dps_val: medium
+            value: medium
+          - dps_val: high
+            value: high
+          - dps_val: auto
+            value: auto
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 6
+        type: bitfield
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 6
+        type: bitfield
+        optional: true
+        name: fault_code

--- a/custom_components/tuya_local/devices/ideal_clima_fancoil.yaml
+++ b/custom_components/tuya_local/devices/ideal_clima_fancoil.yaml
@@ -1,11 +1,11 @@
-name: Fancoil
+name: Air conditioner
 products:
   - id: 5dgguakbmhwzwiko
     manufacturer: Ideal Clima
     model: Nemo
 entities:
   - entity: climate
-    translation_key: fancoil
+    translation_key: aircon_extra
     dps:
       - id: 1
         type: boolean
@@ -47,7 +47,7 @@ entities:
         name: fan_mode
         mapping:
           - dps_val: superlow
-            value: silent
+            value: quiet
           - dps_val: low
             value: low
           - dps_val: medium

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -96,7 +96,7 @@
                         }
                     }
                 }
-            },
+            }
         },
         "fan": {
             "aroma_diffuser": {

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -97,23 +97,6 @@
                     }
                 }
             },
-            "fancoil": {
-                "default": "mdi:radiator",
-                "state": {
-                    "off": "mdi:radiator-off"
-                },
-                "state_attributes": {
-                    "fan_mode": {
-                        "state": {
-                            "silent": "mdi:fan",
-                            "low": "mdi:fan-speed-1",
-                            "medium": "mdi:fan-speed-2",
-                            "high": "mdi:fan-speed-3",
-                            "auto": "mdi:fan-auto"
-                        }
-                    }
-                }
-            }
         },
         "fan": {
             "aroma_diffuser": {

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -96,6 +96,23 @@
                         }
                     }
                 }
+            },
+            "fancoil": {
+                "default": "mdi:radiator",
+                "state": {
+                    "off": "mdi:radiator-off"
+                },
+                "state_attributes": {
+                    "fan_mode": {
+                        "state": {
+                            "silent": "mdi:fan",
+                            "low": "mdi:fan-speed-1",
+                            "medium": "mdi:fan-speed-2",
+                            "high": "mdi:fan-speed-3",
+                            "auto": "mdi:fan-auto"
+                        }
+                    }
+                }
             }
         },
         "fan": {


### PR DESCRIPTION
For reference, this configuration targets the device TQCT07. This is used by [Ideal Clima ](https://www.idealclima.eu/it/area-tecnica/wi-fi-e-wi-fi-ready) on various units. I can confirm it works perfectly for my Nemo units.