### PR TITLE
feat: expose update_dps as a Home Assistant service

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -66,7 +66,9 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
         try:
             async with device._api_lock:
-                await hass.async_add_executor_job(device._api.updatedps, dps)
+                await hass.async_add_executor_job(
+                    device._api.updatedps, dps, True
+                )
         except Exception as e:
             _LOGGER.warning("update_dps failed for %s: %s", dev_id, e)
 

--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -64,7 +64,11 @@ async def async_setup(hass: HomeAssistant, config: dict):
         if dps is None:
             dps = device._force_dps or [18, 19, 20]
 
-        await hass.async_add_executor_job(device._api.updatedps, dps)
+        try:
+            async with device._api_lock:
+                await hass.async_add_executor_job(device._api.updatedps, dps)
+        except Exception as e:
+            _LOGGER.warning("update_dps failed for %s: %s", dev_id, e)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -9,10 +9,13 @@ https://github.com/codetheweb/tuyapi/issues/31.
 
 import logging
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_registry import (
     async_get as async_get_entity_registry,
 )
@@ -33,6 +36,44 @@ from .helpers.device_config import get_config
 
 _LOGGER = logging.getLogger(__name__)
 NOT_FOUND = "Configuration file for %s not found"
+
+SERVICE_UPDATE_DPS = "update_dps"
+SERVICE_UPDATE_DPS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Optional("dps"): list,
+    }
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the tuya_local integration."""
+
+    async def _handle_update_dps(call: ServiceCall):
+        """Handle update_dps service call - sends UPDATEDPS command."""
+        dev_id = call.data[CONF_DEVICE_ID]
+        data = hass.data.get(DOMAIN, {}).get(dev_id)
+        if not data or "device" not in data:
+            raise HomeAssistantError(f"Device {dev_id} not found")
+
+        device = data["device"]
+        if not device.has_returned_state:
+            raise HomeAssistantError(f"Device {dev_id} is not connected")
+
+        dps = call.data.get("dps")
+        if dps is None:
+            dps = device._force_dps or [18, 19, 20]
+
+        await hass.async_add_executor_job(device._api.updatedps, dps)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_DPS,
+        _handle_update_dps,
+        schema=SERVICE_UPDATE_DPS_SCHEMA,
+    )
+
+    return True
 
 
 def replace_unique_ids(entity_entry, device_id, conf_file, replacements):

--- a/custom_components/tuya_local/services.yaml
+++ b/custom_components/tuya_local/services.yaml
@@ -1,0 +1,18 @@
+update_dps:
+  name: "Update DPs"
+  description: "Request the device to report current values for specified datapoints (sends UPDATEDPS 0x12 command)"
+  fields:
+    device_id:
+      name: "Device ID"
+      description: The Tuya device ID to request updated DP values from
+      required: true
+      example: 11100118278aab4de001
+      selector:
+        text:
+    dps:
+      name: "DPs"
+      description: "List of DP indexes to refresh. If omitted, the device's force_dps list will be used, or defaults to [18, 19, 20]."
+      required: false
+      example: "[18, 19, 20]"
+      selector:
+        object:


### PR DESCRIPTION
## Summary

- Adds a new `tuya_local.update_dps` service that sends the Tuya `UPDATEDPS` (`0x12`) protocol command to request fresh datapoint values from a device on demand
- Accepts an optional `dps` parameter to specify which DP indexes to refresh (defaults to the device's `force_dps` list, or `[18, 19, 20]` if none configured)
- Properly acquires `_api_lock` to avoid socket conflicts with the persistent connection loop
- Uses `nowait=True` so the response is processed by `async_receive`'s loop, ensuring entities update immediately

## Motivation

Currently, `updatedps()` is only triggered internally via the 30-second cache timeout cycle (alternating with `status()`), and only for devices with DPs marked `force: true` in their config YAML. There is no way for users to trigger an on-demand DPS refresh from automations or scripts.

This is particularly useful for energy monitoring scenarios where users want to:
- Poll power/current/voltage DPs only when a smart plug is actively in use
- Avoid unnecessary traffic when the device is idle
- Control polling frequency dynamically based on device state

### Example automation

```yaml
automation:
  - alias: "Poll energy only when plug is on"
    trigger:
      - platform: time_pattern
        seconds: "/10"
    condition:
      - condition: state
        entity_id: switch.my_plug
        state: "on"
    action:
      - action: tuya_local.update_dps
        data:
          device_id: "bf3a9c1e4ab012df3c"
          dps:
            - 18
            - 19
            - 20
```

## Implementation details

- `nowait=True` is critical: without it, `updatedps()` consumes the device response directly but discards it. Entities only update when `async_receive`'s loop yields data on its 30s cycle. With `nowait=True`, the command is sent and the response stays in the socket buffer for the loop to pick up on its next iteration (~0.1s), allowing immediate entity updates.
- `_api_lock` must be acquired before calling `updatedps` because the persistent connection loop holds this lock while communicating over the shared socket.

## Changes

- `__init__.py`: Added imports, service schema, `async_setup()` with `_handle_update_dps` handler (with proper locking and nowait)
- `services.yaml`: New file with `update_dps` service definition

## Test plan

- [x] Manually tested on a Tuya smart plug — calling the service updates energy sensor entities immediately
- [x] Verified that without `nowait=True`, updates only happen every 30s
- [x] Verified that without `_api_lock`, calls fail intermittently
- [ ] Verify behavior with sub-devices (CID)
- [ ] Verify error handling when device is offline