### PR TITLE
feat: add mac address to device connections

### DIFF
--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -70,6 +70,7 @@ class TuyaLocalDevice(object):
             model (str | None): The device model, if known.
         """
         self._name = name
+        self._address = address
         self._manufacturer = manufacturer
         self._model = model
         self._children = []
@@ -158,6 +159,31 @@ class TuyaLocalDevice(object):
         self._AUTO_FAILURE_RESET_COUNT = 10
         self._lock = Lock()
 
+        self._mac = None
+        if hasattr(hass, "async_create_background_task"):
+            hass.async_create_background_task(self._resolve_mac(), "tuya_local_resolve_mac")
+        else:
+            hass.async_create_task(self._resolve_mac())
+
+    async def _resolve_mac(self):
+        """Asynchronously resolve MAC address to avoid blocking the event loop."""
+        if not getattr(self, "_address", None):
+            return
+
+        def get_mac():
+            try:
+                from getmac import get_mac_address
+                return get_mac_address(ip=self._address)
+            except Exception as e:
+                _LOGGER.debug("Failed to resolve MAC address for %s: %s", self._address, e)
+                return None
+
+        mac = await self._hass.async_add_executor_job(get_mac)
+        if mac:
+            from homeassistant.helpers import device_registry as dr
+            self._mac = dr.format_mac(mac)
+            _LOGGER.debug("Resolved MAC address for %s: %s", self._address, self._mac)
+
     @property
     def name(self):
         return self._name
@@ -177,6 +203,11 @@ class TuyaLocalDevice(object):
         }
         if self._model:
             info["model"] = self._model
+
+        if getattr(self, "_mac", None):
+            from homeassistant.helpers import device_registry as dr
+            info["connections"] = {(dr.CONNECTION_NETWORK_MAC, self._mac)}
+
         return info
 
     @property


### PR DESCRIPTION
## Description

This PR enhances the device registration process by adding the device's MAC address to the `connections` property in `device_info`. 

Currently, `tuya-local` devices are registered in Home Assistant using only their Tuya identifiers. By associating the MAC address via the device's local IP, Home Assistant's Device Registry can automatically link the Tuya device with the physical network device reported by router integrations (such as OpenWRT, Mikrotik, UniFi, etc.). This prevents duplicate devices in the Home Assistant registry and allows users to track the device's network state alongside its Tuya entities.

## Changes made
* Saved the `address` parameter as `self._address` during the `TuyaLocalDevice` initialization.
* Updated the `device_info` property to dynamically fetch the MAC address using the `getmac` library (already used within the Home Assistant ecosystem).
* Injected the MAC address into the `connections` dictionary using `dr.CONNECTION_NETWORK_MAC` if the lookup is successful.
* Wrapped the MAC lookup in a try-except block to ensure it fails silently and doesn't disrupt the integration if ARP lookup is unavailable.

## Motivation and Context
This provides a smoother experience for users who use presence detection or network tracking in Home Assistant, automatically bridging the logical Tuya device with its physical network presence.

## Testing
- Verified locally that the MAC address is correctly retrieved via ARP.
- Confirmed that the `device_info` now properly reports the MAC connection.
- Verified that Home Assistant automatically merges the Tuya device with the existing network tracker device without generating duplicates.
