### PR TITLE
ble_water_valve use number instead of time for irrigation time/duration

### DIFF
--- a/custom_components/tuya_local/devices/ble_water_valve.yaml
+++ b/custom_components/tuya_local/devices/ble_water_valve.yaml
@@ -101,17 +101,23 @@ entities:
             value: "48h"
           - dps_val: "72h"
             value: "72h"
-  - entity: time
-    name: Irrigation time
+  - entity: number
+    class: duration
+    name: Irrigation duration
     category: config
     dps:
       - id: 11
         type: integer
-        name: second
+        name: value
+        unit: min
         optional: true
+        precision: 0
         range:
           min: 0
           max: 86400
+        mapping:
+          - scale: 60
+            step: 60
   - entity: switch
     name: Smart weather switch
     icon: "mdi:sun-wireless"


### PR DESCRIPTION
Irrigation time was set as a `time` (timestamp) instead of a duration. When not using a 24-hour clock, it becomes clear the [time entity](https://www.home-assistant.io/integrations/time/) represents a time of day, not a time span. This PR changes the entity to a `number` with scaling/steps to convert seconds to minutes, matching the Tuya app interface. The entity name has also been updated to clarify intent. Several other devices also use `number` rather than `time` to represent duration.

If `time` is the intended behavior for DP11, some products using this device would likely need a separate configuration.

Resolves issue from #3718