### PR TITLE
Add Krisbow Sync Dehumidifier 36W

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -419,7 +419,8 @@
 - Skyfan DC fan with light
 - Smart Mist3 TX-1602MF (ZJ-1522A-WiFi)
 - Smartmi Air Circulating fan
-- Stirling FS1-40DC pedestal fan
+- Stirling FS1-40DC pedestal fan
+
 - Sulion Crixus L ceiling fan with light
 - Temple and Webster Alina ceiling fan
 - TMWF02 fan controller
@@ -522,6 +523,7 @@
 - Vivosun DE0003 dehumidifier
 - Wellio D008A 20L dehumidifier
 - Woods MRD25GW and WDD90 dehumidifiers
+- Krisbow Sync Dehumidifier 36W
 
 ### Humidifiers
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -504,6 +504,7 @@
 - Juro-Pro 2006 dehumidifier
 - Klarstein DryFy Pro Connect dehumidifier
 - Kogan SmarterHome 7L desiccant dehumidifier
+- Krisbow Sync Dehumidifier 36W
 - Luko dehumidifier
 - Meaco DD8L Pro dehumidifier
 - MeacoDry Arete Two 10L dehumidifier
@@ -523,7 +524,6 @@
 - Vivosun DE0003 dehumidifier
 - Wellio D008A 20L dehumidifier
 - Woods MRD25GW and WDD90 dehumidifiers
-- Krisbow Sync Dehumidifier 36W
 
 ### Humidifiers
 

--- a/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
@@ -48,16 +48,16 @@ entities:
         name: switch
       - id: 31
         type: string
-        name: effect
+        name: named_color
         mapping:
           - dps_val: "light_red"
             value: red
           - dps_val: "light_green"
-            value: green
+            value: lime
           - dps_val: "light_blue"
             value: blue
           - dps_val: "light_pink"
-            value: pink
+            value: magenta
           - dps_val: "light_white"
             value: white
           - dps_val: "light_yellow"
@@ -65,14 +65,24 @@ entities:
           - dps_val: "light_purple"
             value: purple
           - dps_val: "light_warm_yellow"
-            value: warm_white
+            value: lemonchiffon
           - dps_val: "light_orange"
             value: orange
           - dps_val: "colorful"
-            value: colorful
-
+            value: black
+            hidden: true
+      - id: 31
+        type: string
+        name: effect
+        mapping:
+          - dps_val: colorful
+            value: Colorful
+          - dps_val: light_white
+            value: "off"
+          - value: "off"
+            hidden: true
   - entity: switch
-    name: Water Tank Reminder
+    name: Water tank reminder
     category: config
     dps:
       - id: 25

--- a/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
@@ -1,4 +1,4 @@
-name: Krisbow Sync Dehumidifier 36W
+name: Dehumidifier
 products:
   - id: ymfznwejbhviuhjk
     manufacturer: Krisbow
@@ -32,14 +32,6 @@ entities:
         name: sensor
         unit: "°C"
 
-  - entity: sensor
-    class: humidity
-    dps:
-      - id: 6
-        type: integer
-        name: sensor
-        unit: "%"
-
   - entity: switch
     translation_key: sleep
     dps:
@@ -47,21 +39,9 @@ entities:
         type: boolean
         name: switch
 
-  - entity: select
-    name: Water Tank Reminder
-    category: config
-    dps:
-      - id: 25
-        type: string
-        name: option
-        mapping:
-          - dps_val: "on"
-            value: "on"
-          - dps_val: "off"
-            value: "off"
-
   - entity: light
-    name: Indicator Light
+    translation_key: indicator
+    category: config
     dps:
       - id: 29
         type: boolean
@@ -71,39 +51,52 @@ entities:
         name: effect
         mapping:
           - dps_val: "light_red"
-            value: Red
+            value: red
           - dps_val: "light_green"
-            value: Green
+            value: green
           - dps_val: "light_blue"
-            value: Blue
+            value: blue
           - dps_val: "light_pink"
-            value: Pink
+            value: pink
           - dps_val: "light_white"
-            value: White
+            value: white
           - dps_val: "light_yellow"
-            value: Yellow
+            value: yellow
           - dps_val: "light_purple"
-            value: Purple
+            value: purple
           - dps_val: "light_warm_yellow"
-            value: Warm Yellow
+            value: warm_white
           - dps_val: "light_orange"
-            value: Orange
+            value: orange
           - dps_val: "colorful"
-            value: Colorful
+            value: colorful
+
+  - entity: switch
+    name: Water Tank Reminder
+    category: config
+    dps:
+      - id: 25
+        type: string
+        name: switch
+        mapping:
+          - dps_val: "on"
+            value: true
+          - dps_val: "off"
+            value: false
+
   - entity: select
     translation_key: timer
-    icon: "mdi:timer-outline"
     category: config
     dps:
       - id: 17
         type: string
         name: option
         mapping:
-          - dps_val: "cancel"
-            value: "Off"
+          - dps_val: cancel
+            value: cancel
           - dps_val: "1h"
-            value: "1 Hour"
+            value: "1h"
           - dps_val: "2h"
-            value: "2 Hours"
+            value: "2h"
           - dps_val: "3h"
-            value: "3 Hours"
+            value: "3h"

--- a/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
@@ -1,0 +1,111 @@
+name: Krisbow Sync Dehumidifier 36W
+products:
+  - id: ymfznwejbhviuhjk
+    manufacturer: Krisbow
+    model: Sync Dehumidifier 36W
+entities:
+  - entity: humidifier
+    class: dehumidifier
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 3
+        type: string
+        name: humidity
+        mapping:
+          - dps_val: "30"
+            value: 30
+          - dps_val: "40"
+            value: 40
+          - dps_val: "50"
+            value: 50
+      - id: 6
+        type: integer
+        name: current_humidity
+
+  - entity: sensor
+    name: Temperature
+    class: temperature
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: "°C"
+
+  - entity: sensor
+    name: Humidity
+    class: humidity
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: "%"
+
+  - entity: switch
+    name: Sleep
+    dps:
+      - id: 14
+        type: boolean
+        name: switch
+
+  - entity: select
+    name: Water Tank Reminder
+    category: config
+    dps:
+      - id: 25
+        type: string
+        name: option
+        mapping:
+          - dps_val: "on"
+            value: "on"
+          - dps_val: "off"
+            value: "off"
+
+  - entity: light
+    name: Indicator Light
+    dps:
+      - id: 29
+        type: boolean
+        name: switch
+      - id: 31
+        type: string
+        name: effect
+        mapping:
+          - dps_val: "light_red"
+            value: Red
+          - dps_val: "light_green"
+            value: Green
+          - dps_val: "light_blue"
+            value: Blue
+          - dps_val: "light_pink"
+            value: Pink
+          - dps_val: "light_white"
+            value: White
+          - dps_val: "light_yellow"
+            value: Yellow
+          - dps_val: "light_purple"
+            value: Purple
+          - dps_val: "light_warm_yellow"
+            value: Warm Yellow
+          - dps_val: "light_orange"
+            value: Orange
+          - dps_val: "colorful"
+            value: Colorful
+  - entity: select
+    name: Timer
+    icon: "mdi:timer-outline"
+    category: config
+    dps:
+      - id: 17
+        type: string
+        name: option
+        mapping:
+          - dps_val: "cancel"
+            value: "Off"
+          - dps_val: "1h"
+            value: "1 Hour"
+          - dps_val: "2h"
+            value: "2 Hours"
+          - dps_val: "3h"
+            value: "3 Hours"

--- a/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/krisbow_sync_dehumidifier.yaml
@@ -25,7 +25,6 @@ entities:
         name: current_humidity
 
   - entity: sensor
-    name: Temperature
     class: temperature
     dps:
       - id: 7
@@ -34,7 +33,6 @@ entities:
         unit: "°C"
 
   - entity: sensor
-    name: Humidity
     class: humidity
     dps:
       - id: 6
@@ -43,7 +41,7 @@ entities:
         unit: "%"
 
   - entity: switch
-    name: Sleep
+    translation_key: sleep
     dps:
       - id: 14
         type: boolean
@@ -93,7 +91,7 @@ entities:
           - dps_val: "colorful"
             value: Colorful
   - entity: select
-    name: Timer
+    translation_key: timer
     icon: "mdi:timer-outline"
     category: config
     dps:


### PR DESCRIPTION
Adds support for Krisbow Sync 0.4L Dehumidifier 36W (Tuya product_id: ymfznwejbhviuhjk)
  https://www.ruparupa.com/p/krisbow-sync-0-4-ltr-dehumidifier-36-watt-putih.html
  Sold in Indonesia at Ruparupa. DPS verified from local diagnostics.
  Entities: humidifier (dehumidifier), temperature sensor, humidity sensor,
  sleep switch, water tank reminder, indicator light with colour modes.