### PR TITLE
Add Olight Ostation 2 charger config

### DIFF
--- a/custom_components/tuya_local/devices/olight_ostation2_charger.yaml
+++ b/custom_components/tuya_local/devices/olight_ostation2_charger.yaml
@@ -70,7 +70,7 @@ entities:
         type: string
         name: sensor
         optional: true
-        
+
   - entity: switch
     name: Pause schedule
     dps:
@@ -86,7 +86,7 @@ entities:
         type: string
         name: sensor
         optional: true
-        
+
   - entity: sensor
     name: DP113
     category: diagnostic
@@ -94,4 +94,3 @@ entities:
       - id: 113
         type: integer
         name: sensor
- 

--- a/custom_components/tuya_local/devices/olight_ostation2_charger.yaml
+++ b/custom_components/tuya_local/devices/olight_ostation2_charger.yaml
@@ -1,0 +1,97 @@
+name: Charger
+products:
+  - id: 1fnensm6
+    manufacturer: Olight
+    model: Ostation2
+  - id: v8znljza
+    manufacturer: Olight
+    model: Ostation2
+
+entities:
+  - entity: switch
+    name: Power
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: Fully charged count
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+
+  - entity: binary_sensor
+    name: DP103
+    category: diagnostic
+    dps:
+      - id: 103
+        type: boolean
+        name: sensor
+
+  - entity: binary_sensor
+    name: DP104
+    category: diagnostic
+    dps:
+      - id: 104
+        type: boolean
+        name: sensor
+
+  - entity: sensor
+    name: DP105
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+
+  - entity: binary_sensor
+    name: DP106
+    category: diagnostic
+    dps:
+      - id: 106
+        type: boolean
+        name: sensor
+
+  - entity: sensor
+    name: Invalid battery count
+    category: diagnostic
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Raw Bay Telemetry
+    category: diagnostic
+    dps:
+      - id: 110
+        type: string
+        name: sensor
+        optional: true
+        
+  - entity: switch
+    name: Pause schedule
+    dps:
+      - id: 111
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: Pause Window Raw
+    category: diagnostic
+    dps:
+      - id: 112
+        type: string
+        name: sensor
+        optional: true
+        
+  - entity: sensor
+    name: DP113
+    category: diagnostic
+    dps:
+      - id: 113
+        type: integer
+        name: sensor
+ 


### PR DESCRIPTION
Adds a device configuration YAML for the Olight Ostation 2 / Ostation 2 Pro battery charger. This is a config-only contribution using known Tuya datapoints DP101, DP102, DP108, DP110, and optional schedule controls DP111/DP112. No Python code changes are included.