### PR TITLE
Add Garden PAC InverTech heat pump profile

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -172,7 +172,7 @@
 - Edge Theory Labs cold plunge heat pump
 - Evotherm ETI series heat pump
 - Fairland IPHCR15, RMIC06, X20 pool heat pumps (also Pool Systems and other brands)
-- Garden PAC pool heat pump (also works with Summerwave Si Series)
+- Garden PAC pool heat pumps, including InverTech GHD-150-0356 (also works with Summerwave Si Series)
 - Henden Essential pool heat pump
 - Komeco QC60 pool heat pump
 - Madimack Eco, Elite V2,V3,V4 and other model pool heat pumps

--- a/custom_components/tuya_local/devices/gardenpac_invertech_ghd_heatpump.yaml
+++ b/custom_components/tuya_local/devices/gardenpac_invertech_ghd_heatpump.yaml
@@ -1,0 +1,125 @@
+name: Pool heat pump
+products:
+  - id: koAASpds906awojG
+    manufacturer: Garden PAC
+    model: InverTech GHD-150-0356
+entities:
+  - entity: climate
+    translation_only_key: pool_heatpump
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+            icon: "mdi:hvac-off"
+            icon_priority: 1
+          - dps_val: true
+            value: "heat"
+            icon: "mdi:hot-tub"
+            icon_priority: 3
+      - id: 102
+        name: current_temperature
+        type: integer
+      - id: 103
+        name: temperature_unit
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: F
+          - dps_val: true
+            value: C
+      - id: 105
+        name: work_mode
+        type: string
+        hidden: true
+        mapping:
+          - dps_val: smart
+            value: heat_cool
+          - dps_val: warm
+            value: heat
+          - dps_val: cool
+            value: cool
+      - id: 106
+        name: temperature
+        type: integer
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: false
+                range:
+                  min: 60
+                  max: 115
+        range:
+          min: 18
+          max: 45
+      - id: 107
+        type: integer
+        name: min_temperature
+      - id: 108
+        type: integer
+        name: max_temperature
+      - id: 117
+        name: preset_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: quiet
+          - dps_val: true
+            value: smart
+  - entity: switch
+    name: Silent mode
+    category: config
+    dps:
+      - id: 117
+        type: boolean
+        name: switch
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true
+  - entity: sensor
+    name: Power level
+    icon: "mdi:signal"
+    category: diagnostic
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    name: Water flow
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 115
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 116
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: true
+            constraint: fault_code
+            conditions:
+              - dps_val: [0, 4]
+                value: false
+          - value: true
+      - id: 115
+        type: bitfield
+        name: fault_code
+      - id: 116
+        type: bitfield
+        name: fault_code_2


### PR DESCRIPTION
## Summary

Add a dedicated profile for a Garden PAC InverTech GHD-150-0356 swimming pool heat pump.

The device is a Tuya v3.3 heat pump controlled by the Smarter Pool mobile app.
Also update the supported devices list to mention this Garden PAC InverTech model.

## Device details

- Product ID: `koAASpds906awojG`
- Manufacturer: Garden PAC
- Model: InverTech GHD-150-0356
- Nameplate: Swimming Pool Heat Pump

## Implemented entities

- Climate control: power, current water temperature, target temperature, heat/cool/smart work mode
- Preset mode: Smart / Quiet
- Silent mode config switch
- Power level diagnostic sensor
- Water flow problem binary sensor
- General fault binary sensor

## Validation

- Tested locally with Home Assistant and tuya-local against the physical device.
- Confirmed bidirectional updates for power, target temperature, and Smart/Silence mode.
- Confirmed water temperature, power level, water-flow problem, and fault DPS are exposed.
- Ran `yamllint` on the new device YAML.
- Validated the new YAML against `custom_components/tuya_local/devices/device_config_schema.json`.

## Notes

The Tuya cloud schema exposes additional diagnostic DPS for compressor/current/fan/coil temperatures, but they are not included here because they remained unavailable over local polling on this device.