### PR TITLE
Add Poolex JetLine Premium FI pool heat pump

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -781,3 +781,4 @@ Further device support has been made with the assistance of users. Please consid
 - [bluefroguk1](https://github.com/bluefroguk1) for contributing support for new variants of Ecostrad iQ ceramic radiator and elements.
 - [lboy](https://github.com/lboy) for contributing support for Krisbow Sync 36W dehumidifier.
 - [uhodav](https://github.com/uhodav) for contributing improvements to Ukrainian translations.
+- [casualg1t](https://github.com/casualg1t) for contributing support for Poolex JetLine Premium FI pool heat pump.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -176,7 +176,7 @@
 - Henden Essential pool heat pump
 - Komeco QC60 pool heat pump
 - Madimack Eco, Elite V2,V3,V4 and other model pool heat pumps
-- Poolex Silverline, Q-7, Q-line, Arctic, Vertigo, Ice Spa, Mag FI heat pumps
+- Poolex Silverline, Q-7, Q-line, Arctic, Vertigo, Ice Spa, Mag FI, JetLine Premium FI heat pumps
 - Poolsana InverPower Next pool heat pump
 - Poolstyle PSL-150-00xx pool heat pump
 - Pool Systems IPS Pro pool heat pump (also Fairland Inver-X)

--- a/custom_components/tuya_local/devices/poolex_jetline_premium_fi_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolex_jetline_premium_fi_heatpump.yaml
@@ -1,0 +1,62 @@
+name: Pool heat pump
+products:
+  - id: gnjlgcrctawnzk2v
+    manufacturer: Poolex
+    model: JetLine Premium FI
+entities:
+  - entity: climate
+    translation_only_key: pool_heatpump
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: preset_mode
+            conditions:
+              - dps_val: hot
+                value: heat
+              - dps_val: eco
+                value: heat
+              - dps_val: cold
+                value: cool
+              - dps_val: auto
+                value: heat_cool
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 8
+          max: 40
+      - id: 3
+        type: integer
+        name: current_temperature
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: hot
+            value: quick_heat
+          - dps_val: eco
+            value: quiet_heat
+          - dps_val: cold
+            value: quiet_cool
+          - dps_val: auto
+            value: auto
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        name: fault_code
+        type: bitfield

--- a/custom_components/tuya_local/devices/poolex_jetlinepremiumfi_poolheatpump.yaml
+++ b/custom_components/tuya_local/devices/poolex_jetlinepremiumfi_poolheatpump.yaml
@@ -20,6 +20,7 @@ entities:
                 value: heat
               - dps_val: eco
                 value: heat
+                hidden: true
               - dps_val: cold
                 value: cool
               - dps_val: auto


### PR DESCRIPTION
Adds support for Poolex JetLine Premium FI pool heat pump
(Tuya product_id: `gnjlgcrctawnzk2v`).

Entities:
- climate (on/off via DP1, target temperature 8–40 °C on DP2,
  current temperature on DP3, preset_mode on DP4 with
  quick_heat / quiet_heat / quiet_cool / auto)
- problem binary_sensor with fault_code attribute (DP21 bitfield)

Distinct from the existing Poolex Mag FI config (also DP21 fault):
- DP4 enum is lowercase `hot` / `eco` / `cold` / `auto`
  (Mag FI uses capitalized `Auto` / `Cold` / `Heating`)
- DP1+DP4 combine to expose 4 presets in HA rather than 3 hvac modes
- separate product_id (`gnjlgcrctawnzk2v`) so no overlap with Mag FI's
  match (`s3aau3iaenjrspin`)

Tested on my own unit, running in Home Assistant 2026.4.4 for the
past month; mode switching, target temp, current temp, and fault
reporting all behave correctly.