### PR TITLE
Add Honiture G20 and Q6 Pro Robot Vacuum and Mop device profiles 

### DIFF
--- a/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
@@ -97,7 +97,6 @@ entities:
   - entity: sensor
     name: Edge brush life
     category: diagnostic
-    icon: "mdi:brush"
     dps:
       - id: 7
         type: integer
@@ -108,7 +107,6 @@ entities:
   - entity: sensor
     name: Roll brush life
     category: diagnostic
-    icon: "mdi:brush"
     dps:
       - id: 8
         type: integer
@@ -119,7 +117,6 @@ entities:
   - entity: sensor
     translation_key: filter_life
     category: diagnostic
-    icon: "mdi:air-filter"
     dps:
       - id: 9
         type: integer
@@ -130,7 +127,6 @@ entities:
   - entity: button
     name: Reset edge brush
     category: config
-    icon: "mdi:brush"
     dps:
       - id: 10
         type: boolean
@@ -139,7 +135,6 @@ entities:
   - entity: button
     name: Reset roll brush
     category: config
-    icon: "mdi:brush"
     dps:
       - id: 11
         type: boolean
@@ -148,7 +143,6 @@ entities:
   - entity: button
     name: Reset filter
     category: config
-    icon: "mdi:air-filter"
     dps:
       - id: 12
         type: boolean
@@ -166,19 +160,17 @@ entities:
   - entity: sensor
     name: Cleaning area
     category: diagnostic
-    icon: "mdi:floor-plan"
+    class: area
     dps:
       - id: 16
         type: integer
         name: sensor
         unit: "m²"
-        class: measurement
 
   - entity: sensor
     name: Cleaning time
     category: diagnostic
     class: duration
-    icon: "mdi:clock-outline"
     dps:
       - id: 17
         type: integer
@@ -246,16 +238,15 @@ entities:
         type: string
         mapping:
           - dps_val: only_sweep
-            value: sweep only
+            value: Sweep only
           - dps_val: only_mop
-            value: mop only
+            value: Mop only
           - dps_val: both_work
-            value: sweep and mop
+            value: Sweep and mop
 
   - entity: switch
     name: Carpet boost
     category: config
-    icon: "mdi:rug"
     dps:
       - id: 101
         type: boolean
@@ -264,16 +255,14 @@ entities:
   - entity: switch
     name: Carpet detection
     category: config
-    icon: "mdi:rug"
     dps:
       - id: 102
         type: boolean
         name: switch
 
   - entity: select
-    name: Volume
+    translation_key: volume
     category: config
-    icon: "mdi:volume-high"
     dps:
       - id: 104
         name: option
@@ -289,7 +278,6 @@ entities:
   - entity: select
     translation_key: language
     category: config
-    icon: "mdi:translate"
     dps:
       - id: 105
         name: option

--- a/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
@@ -1,0 +1,159 @@
+name: Honiture G20 Robot Vacuum and Mop
+products:
+  - id: ela0pxryflaldubr
+    manufacturer: Honiture
+    model: G20
+entities:
+  - entity: vacuum
+    dps:
+      - id: 2
+        type: boolean
+        name: activate
+      - id: 3
+        type: string
+        name: command
+        mapping:
+          - dps_val: standby
+            value: stop
+          - dps_val: spiral
+            value: clean_spot
+          - dps_val: wall_follow
+            value: wall_follow
+          - dps_val: chargego
+            value: return_to_base
+          - dps_val: partial_bow
+            value: partial_bow
+          - dps_val: random
+            value: random
+      - id: 4
+        type: string
+        name: direction_control
+        optional: true
+        mapping:
+          - dps_val: forward
+            value: forward
+          - dps_val: backward
+            value: reverse
+          - dps_val: turn_left
+            value: left
+          - dps_val: turnn_right
+            value: right
+          - dps_val: stop
+            value: stop
+      - id: 5
+        type: string
+        name: status
+        mapping:
+          - dps_val: "standby"
+            value: standby
+          - dps_val: "smart_clean"
+            value: cleaning
+          - dps_val: "wall_clean"
+            value: cleaning
+          - dps_val: "spot_clean"
+            value: cleaning
+          - dps_val: "room_clean"
+            value: cleaning
+          - dps_val: "goto_charge"
+            value: returning
+          - dps_val: "charging"
+            value: charging
+          - dps_val: "charge_done"
+            value: charged
+          - dps_val: "cleaning"
+            value: cleaning
+          - dps_val: "sleep"
+            value: sleep
+          - dps_val: "in_trouble"
+            value: error
+      - id: 14
+        type: string
+        name: fan_speed
+        mapping:
+          - dps_val: gentle
+            value: Gentle
+          - dps_val: normal
+            value: Normal
+          - dps_val: strong
+            value: Strong
+  - entity: sensor
+    class: battery
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    name: Cleaning time
+    category: diagnostic
+    class: duration
+    icon: "mdi:clock-outline"
+    dps:
+      - id: 17
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 18
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 18
+        type: bitfield
+        name: fault_code
+      - id: 18
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: wheel_overload
+          - dps_val: 2
+            value: side_brush_entanglement
+          - dps_val: 3
+            value: brush_abnormality
+          - dps_val: 4
+            value: dustbin_not_installed
+          - dps_val: 5
+            value: left_collision_stuck
+          - dps_val: 6
+            value: right_collision_stuck
+          - dps_val: 7
+            value: machine_off_ground
+          - dps_val: 8
+            value: front_drop_trigger
+          - dps_val: 9
+            value: left_drop_trigger
+          - dps_val: 10
+            value: right_drop_trigger
+          - dps_val: 11
+            value: fan_abnormality
+          - dps_val: 12
+            value: water_tank_not_installed
+          - dps_val: 13
+            value: magnetic_field_abnormality
+          - dps_val: 14
+            value: slippage_abnormality
+  - entity: select
+    translation_key: mopping
+    category: config
+    icon: "mdi:cup-water"
+    dps:
+      - id: 20
+        name: option
+        type: string
+        mapping:
+          - dps_val: closed
+            value: "off"
+          - dps_val: low
+            value: low
+          - dps_val: high
+            value: high

--- a/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
@@ -1,4 +1,4 @@
-name: Honiture G20 Robot Vacuum and Mop
+name: Robot vacuum and mop
 products:
   - id: rxmacvgkaz640r4q
     manufacturer: Honiture
@@ -49,15 +49,15 @@ entities:
           - dps_val: standby
             value: standby
           - dps_val: smart_clean
-            value: cleaning
+            value: smart_clean
           - dps_val: wall_clean
-            value: cleaning
+            value: wall_clean
           - dps_val: spot_clean
-            value: cleaning
+            value: spot_clean
           - dps_val: mop_clean
-            value: cleaning
+            value: mop_clean
           - dps_val: random_clean
-            value: cleaning
+            value: random_clean
           - dps_val: cleaning
             value: cleaning
           - dps_val: clean_done
@@ -74,16 +74,19 @@ entities:
             value: error
           - dps_val: sleep
             value: sleep
+      - id: 13
+        type: boolean
+        name: locate
       - id: 14
         type: string
         name: fan_speed
         mapping:
           - dps_val: gentle
-            value: Gentle
+            value: low
           - dps_val: normal
-            value: Normal
+            value: medium
           - dps_val: strong
-            value: Strong
+            value: high
 
   - entity: sensor
     class: battery
@@ -141,19 +144,10 @@ entities:
         name: button
 
   - entity: button
-    name: Reset filter
+    translation_key: filter_reset
     category: config
     dps:
       - id: 12
-        type: boolean
-        name: button
-
-  - entity: button
-    name: Seek robot
-    category: config
-    icon: "mdi:magnify"
-    dps:
-      - id: 13
         type: boolean
         name: button
 
@@ -229,20 +223,19 @@ entities:
             value: high
 
   - entity: select
-    name: Work mode
+    translation_key: cleaning_mode
     category: config
-    icon: "mdi:robot-vacuum"
     dps:
       - id: 24
         name: option
         type: string
         mapping:
           - dps_val: only_sweep
-            value: Sweep only
+            value: sweep
           - dps_val: only_mop
-            value: Mop only
+            value: mop
           - dps_val: both_work
-            value: Sweep and mop
+            value: sweep_and_mop
 
   - entity: switch
     name: Carpet boost
@@ -284,14 +277,14 @@ entities:
         type: string
         mapping:
           - dps_val: english
-            value: English
+            value: english
           - dps_val: german
-            value: German
+            value: german
           - dps_val: french
-            value: French
+            value: french
           - dps_val: italian
-            value: Italian
+            value: italian
           - dps_val: spanish
-            value: Spanish
+            value: spanish
           - dps_val: japanese
-            value: Japanese
+            value: japanese

--- a/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
@@ -117,7 +117,7 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Filter life
+    translation_key: filter_life
     category: diagnostic
     icon: "mdi:air-filter"
     dps:
@@ -287,7 +287,7 @@ entities:
             value: max
 
   - entity: select
-    name: Language
+    translation_key: language
     category: config
     icon: "mdi:translate"
     dps:

--- a/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
@@ -1,6 +1,6 @@
 name: Honiture G20 Robot Vacuum and Mop
 products:
-  - id: ela0pxryflaldubr
+  - id: rxmacvgkaz640r4q
     manufacturer: Honiture
     model: G20
 entities:
@@ -15,16 +15,18 @@ entities:
         mapping:
           - dps_val: standby
             value: stop
+          - dps_val: smart
+            value: clean
           - dps_val: spiral
             value: clean_spot
           - dps_val: wall_follow
             value: wall_follow
           - dps_val: chargego
             value: return_to_base
-          - dps_val: partial_bow
-            value: partial_bow
           - dps_val: random
             value: random
+          - dps_val: partial_bow
+            value: partial_bow
       - id: 4
         type: string
         name: direction_control
@@ -36,7 +38,7 @@ entities:
             value: reverse
           - dps_val: turn_left
             value: left
-          - dps_val: turnn_right
+          - dps_val: turn_right
             value: right
           - dps_val: stop
             value: stop
@@ -44,28 +46,34 @@ entities:
         type: string
         name: status
         mapping:
-          - dps_val: "standby"
+          - dps_val: standby
             value: standby
-          - dps_val: "smart_clean"
+          - dps_val: smart_clean
             value: cleaning
-          - dps_val: "wall_clean"
+          - dps_val: wall_clean
             value: cleaning
-          - dps_val: "spot_clean"
+          - dps_val: spot_clean
             value: cleaning
-          - dps_val: "room_clean"
+          - dps_val: mop_clean
             value: cleaning
-          - dps_val: "goto_charge"
+          - dps_val: random_clean
+            value: cleaning
+          - dps_val: cleaning
+            value: cleaning
+          - dps_val: clean_done
             value: returning
-          - dps_val: "charging"
+          - dps_val: goto_charge
+            value: returning
+          - dps_val: charging
             value: charging
-          - dps_val: "charge_done"
+          - dps_val: charging_dc
+            value: charging
+          - dps_val: charge_done
             value: charged
-          - dps_val: "cleaning"
-            value: cleaning
-          - dps_val: "sleep"
-            value: sleep
-          - dps_val: "in_trouble"
+          - dps_val: fault
             value: error
+          - dps_val: sleep
+            value: sleep
       - id: 14
         type: string
         name: fan_speed
@@ -76,6 +84,7 @@ entities:
             value: Normal
           - dps_val: strong
             value: Strong
+
   - entity: sensor
     class: battery
     dps:
@@ -84,6 +93,87 @@ entities:
         name: sensor
         unit: "%"
         class: measurement
+
+  - entity: sensor
+    name: Edge brush life
+    category: diagnostic
+    icon: "mdi:brush"
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: Roll brush life
+    category: diagnostic
+    icon: "mdi:brush"
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: Filter life
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: button
+    name: Reset edge brush
+    category: config
+    icon: "mdi:brush"
+    dps:
+      - id: 10
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Reset roll brush
+    category: config
+    icon: "mdi:brush"
+    dps:
+      - id: 11
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Reset filter
+    category: config
+    icon: "mdi:air-filter"
+    dps:
+      - id: 12
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Seek robot
+    category: config
+    icon: "mdi:magnify"
+    dps:
+      - id: 13
+        type: boolean
+        name: button
+
+  - entity: sensor
+    name: Cleaning area
+    category: diagnostic
+    icon: "mdi:floor-plan"
+    dps:
+      - id: 16
+        type: integer
+        name: sensor
+        unit: "m²"
+        class: measurement
+
   - entity: sensor
     name: Cleaning time
     category: diagnostic
@@ -94,6 +184,7 @@ entities:
         type: integer
         name: sensor
         unit: min
+
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -115,33 +206,20 @@ entities:
           - dps_val: 0
             value: ok
           - dps_val: 1
-            value: wheel_overload
+            value: edge_sweep
           - dps_val: 2
-            value: side_brush_entanglement
-          - dps_val: 3
-            value: brush_abnormality
+            value: middle_sweep
           - dps_val: 4
-            value: dustbin_not_installed
-          - dps_val: 5
-            value: left_collision_stuck
-          - dps_val: 6
-            value: right_collision_stuck
-          - dps_val: 7
-            value: machine_off_ground
+            value: left_wheel
           - dps_val: 8
-            value: front_drop_trigger
-          - dps_val: 9
-            value: left_drop_trigger
-          - dps_val: 10
-            value: right_drop_trigger
-          - dps_val: 11
-            value: fan_abnormality
-          - dps_val: 12
-            value: water_tank_not_installed
-          - dps_val: 13
-            value: magnetic_field_abnormality
-          - dps_val: 14
-            value: slippage_abnormality
+            value: right_wheel
+          - dps_val: 16
+            value: garbage_box
+          - dps_val: 32
+            value: land_check
+          - dps_val: 64
+            value: collision
+
   - entity: select
     translation_key: mopping
     category: config
@@ -151,9 +229,81 @@ entities:
         name: option
         type: string
         mapping:
-          - dps_val: closed
-            value: "off"
           - dps_val: low
             value: low
+          - dps_val: middle
+            value: medium
           - dps_val: high
             value: high
+
+  - entity: select
+    name: Work mode
+    category: config
+    icon: "mdi:robot-vacuum"
+    dps:
+      - id: 24
+        name: option
+        type: string
+        mapping:
+          - dps_val: only_sweep
+            value: sweep only
+          - dps_val: only_mop
+            value: mop only
+          - dps_val: both_work
+            value: sweep and mop
+
+  - entity: switch
+    name: Carpet boost
+    category: config
+    icon: "mdi:rug"
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Carpet detection
+    category: config
+    icon: "mdi:rug"
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+
+  - entity: select
+    name: Volume
+    category: config
+    icon: "mdi:volume-high"
+    dps:
+      - id: 104
+        name: option
+        type: string
+        mapping:
+          - dps_val: vol_mute
+            value: mute
+          - dps_val: vol_normal
+            value: normal
+          - dps_val: vol_max
+            value: max
+
+  - entity: select
+    name: Language
+    category: config
+    icon: "mdi:translate"
+    dps:
+      - id: 105
+        name: option
+        type: string
+        mapping:
+          - dps_val: english
+            value: English
+          - dps_val: german
+            value: German
+          - dps_val: french
+            value: French
+          - dps_val: italian
+            value: Italian
+          - dps_val: spanish
+            value: Spanish
+          - dps_val: japanese
+            value: Japanese

--- a/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_g20_robot_vacuum_mop.yaml
@@ -261,7 +261,7 @@ entities:
         name: switch
 
   - entity: select
-    translation_key: volume
+    name: Volume
     category: config
     dps:
       - id: 104

--- a/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
@@ -112,7 +112,7 @@ entities:
             value: high
 
   - entity: switch
-    name: Do not disturb
+    translation_key: do_not_disturb
     category: config
     icon: "mdi:bell-off"
     dps:
@@ -121,7 +121,7 @@ entities:
         name: switch
 
   - entity: number
-    name: Volume
+    translation_key: volume
     category: config
     icon: "mdi:volume-high"
     dps:

--- a/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
@@ -1,4 +1,4 @@
-name: Honiture Q6 Pro Robot Vacuum and Mop
+name: Robot vacuum and mop
 products:
   - id: c4ueb7cxlgmfon1t
     manufacturer: Honiture
@@ -24,21 +24,21 @@ entities:
           - dps_val: idle
             value: standby
           - dps_val: sweep
-            value: cleaning
+            value: sweep
           - dps_val: mop
-            value: cleaning
+            value: mop
           - dps_val: areaing
-            value: cleaning
+            value: areaing
           - dps_val: totaling
-            value: cleaning
+            value: totaling
           - dps_val: pointing
-            value: cleaning
+            value: pointing
           - dps_val: curpointing
-            value: cleaning
+            value: curpointing
           - dps_val: selectroom
-            value: cleaning
+            value: selectroom
           - dps_val: remotectl
-            value: cleaning
+            value: remotectl
           - dps_val: pause
             value: paused
           - dps_val: tocharge
@@ -56,11 +56,11 @@ entities:
         name: fan_speed
         mapping:
           - dps_val: quiet
-            value: quiet
+            value: low
           - dps_val: auto
-            value: auto
+            value: medium
           - dps_val: strong
-            value: strong
+            value: high
           - dps_val: max
             value: max
 

--- a/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
@@ -1,0 +1,258 @@
+name: Honiture Q6 Pro Robot Vacuum and Mop
+products:
+  - id: c4ueb7cxlgmfon1t
+    manufacturer: Honiture
+    model: Q6 Pro
+entities:
+  - entity: vacuum
+    dps:
+      - id: 101
+        type: boolean
+        name: activate
+      - id: 102
+        type: boolean
+        name: pause
+        optional: true
+      - id: 103
+        type: boolean
+        name: return_to_base
+        optional: true
+      - id: 105
+        type: string
+        name: status
+        mapping:
+          - dps_val: idle
+            value: standby
+          - dps_val: sweep
+            value: cleaning
+          - dps_val: mop
+            value: cleaning
+          - dps_val: areaing
+            value: cleaning
+          - dps_val: totaling
+            value: cleaning
+          - dps_val: pointing
+            value: cleaning
+          - dps_val: curpointing
+            value: cleaning
+          - dps_val: selectroom
+            value: cleaning
+          - dps_val: remotectl
+            value: cleaning
+          - dps_val: pause
+            value: paused
+          - dps_val: tocharge
+            value: returning
+          - dps_val: chargring
+            value: charging
+          - dps_val: fullcharge
+            value: charged
+          - dps_val: fault
+            value: error
+          - dps_val: dormant
+            value: sleep
+      - id: 109
+        type: string
+        name: fan_speed
+        mapping:
+          - dps_val: quiet
+            value: quiet
+          - dps_val: auto
+            value: auto
+          - dps_val: strong
+            value: strong
+          - dps_val: max
+            value: max
+
+  - entity: sensor
+    class: battery
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: Current clean time
+    category: diagnostic
+    class: duration
+    icon: "mdi:clock-outline"
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        unit: s
+
+  - entity: sensor
+    name: Current clean area
+    category: diagnostic
+    icon: "mdi:floor-plan"
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        unit: "m²"
+        class: measurement
+
+  - entity: select
+    translation_key: mopping
+    category: config
+    icon: "mdi:cup-water"
+    dps:
+      - id: 110
+        name: option
+        type: string
+        mapping:
+          - dps_val: low
+            value: low
+          - dps_val: mid
+            value: medium
+          - dps_val: high
+            value: high
+
+  - entity: switch
+    name: Do not disturb
+    category: config
+    icon: "mdi:bell-off"
+    dps:
+      - id: 113
+        type: boolean
+        name: switch
+
+  - entity: number
+    name: Volume
+    category: config
+    icon: "mdi:volume-high"
+    dps:
+      - id: 114
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
+
+  - entity: sensor
+    name: Total clean time
+    category: diagnostic
+    class: duration
+    icon: "mdi:clock-outline"
+    dps:
+      - id: 116
+        type: integer
+        name: sensor
+        unit: s
+
+  - entity: sensor
+    name: Total clean area
+    category: diagnostic
+    icon: "mdi:floor-plan"
+    dps:
+      - id: 117
+        type: integer
+        name: sensor
+        unit: "m²"
+        class: measurement
+
+  - entity: sensor
+    name: Total clean count
+    category: diagnostic
+    icon: "mdi:counter"
+    dps:
+      - id: 118
+        type: integer
+        name: sensor
+        class: measurement
+
+  - entity: sensor
+    name: Side brush time
+    category: diagnostic
+    icon: "mdi:brush"
+    dps:
+      - id: 119
+        type: integer
+        name: sensor
+        unit: s
+        class: measurement
+
+  - entity: sensor
+    name: Main brush life
+    category: diagnostic
+    icon: "mdi:brush"
+    dps:
+      - id: 120
+        type: integer
+        name: sensor
+        unit: s
+        class: measurement
+
+  - entity: sensor
+    translation_key: filter_life
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 121
+        type: integer
+        name: sensor
+        unit: s
+        class: measurement
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 122
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 122
+        type: bitfield
+        name: fault_code
+
+  - entity: switch
+    name: Auto boost
+    category: config
+    icon: "mdi:rug"
+    dps:
+      - id: 137
+        type: boolean
+        name: switch
+
+  - entity: binary_sensor
+    name: Mop attached
+    class: connectivity
+    icon: "mdi:water"
+    dps:
+      - id: 138
+        type: boolean
+        name: sensor
+
+  - entity: switch
+    name: Mop only mode
+    category: config
+    icon: "mdi:water"
+    dps:
+      - id: 141
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Deep clean
+    category: config
+    icon: "mdi:vacuum"
+    dps:
+      - id: 142
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Room mode
+    category: config
+    icon: "mdi:floor-plan"
+    dps:
+      - id: 144
+        type: boolean
+        name: switch

--- a/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
@@ -77,7 +77,6 @@ entities:
     name: Current clean time
     category: diagnostic
     class: duration
-    icon: "mdi:clock-outline"
     dps:
       - id: 107
         type: integer
@@ -87,13 +86,12 @@ entities:
   - entity: sensor
     name: Current clean area
     category: diagnostic
-    icon: "mdi:floor-plan"
+    class: area
     dps:
       - id: 108
         type: integer
         name: sensor
         unit: "m²"
-        class: measurement
 
   - entity: select
     translation_key: mopping
@@ -114,7 +112,6 @@ entities:
   - entity: switch
     translation_key: do_not_disturb
     category: config
-    icon: "mdi:bell-off"
     dps:
       - id: 113
         type: boolean
@@ -123,7 +120,6 @@ entities:
   - entity: number
     translation_key: volume
     category: config
-    icon: "mdi:volume-high"
     dps:
       - id: 114
         type: integer
@@ -136,7 +132,6 @@ entities:
     name: Total clean time
     category: diagnostic
     class: duration
-    icon: "mdi:clock-outline"
     dps:
       - id: 116
         type: integer
@@ -146,13 +141,12 @@ entities:
   - entity: sensor
     name: Total clean area
     category: diagnostic
-    icon: "mdi:floor-plan"
+    class: area
     dps:
       - id: 117
         type: integer
         name: sensor
         unit: "m²"
-        class: measurement
 
   - entity: sensor
     name: Total clean count
@@ -167,7 +161,6 @@ entities:
   - entity: sensor
     name: Side brush time
     category: diagnostic
-    icon: "mdi:brush"
     dps:
       - id: 119
         type: integer
@@ -178,7 +171,6 @@ entities:
   - entity: sensor
     name: Main brush life
     category: diagnostic
-    icon: "mdi:brush"
     dps:
       - id: 120
         type: integer
@@ -189,7 +181,6 @@ entities:
   - entity: sensor
     translation_key: filter_life
     category: diagnostic
-    icon: "mdi:air-filter"
     dps:
       - id: 121
         type: integer
@@ -215,7 +206,6 @@ entities:
   - entity: switch
     name: Auto boost
     category: config
-    icon: "mdi:rug"
     dps:
       - id: 137
         type: boolean
@@ -224,7 +214,6 @@ entities:
   - entity: binary_sensor
     name: Mop attached
     class: connectivity
-    icon: "mdi:water"
     dps:
       - id: 138
         type: boolean
@@ -233,7 +222,6 @@ entities:
   - entity: switch
     name: Mop only mode
     category: config
-    icon: "mdi:water"
     dps:
       - id: 141
         type: boolean
@@ -242,7 +230,6 @@ entities:
   - entity: switch
     name: Deep clean
     category: config
-    icon: "mdi:vacuum"
     dps:
       - id: 142
         type: boolean
@@ -251,7 +238,6 @@ entities:
   - entity: switch
     name: Room mode
     category: config
-    icon: "mdi:floor-plan"
     dps:
       - id: 144
         type: boolean

--- a/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
+++ b/custom_components/tuya_local/devices/honiture_q6_pro_robot_vacuum_mop.yaml
@@ -13,10 +13,19 @@ entities:
         type: boolean
         name: pause
         optional: true
-      - id: 103
+      - id: 3
+        type: string
+        name: command
+        mapping:
+          - dps_val: standby
+            value: stop
+          - dps_val: smart
+            value: clean
+          - dps_val: chargego
+            value: return_to_base
+      - id: 13
         type: boolean
-        name: return_to_base
-        optional: true
+        name: locate
       - id: 105
         type: string
         name: status
@@ -224,6 +233,14 @@ entities:
     category: config
     dps:
       - id: 141
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Charge switch
+    category: config
+    dps:
+      - id: 103
         type: boolean
         name: switch
 


### PR DESCRIPTION
Adds device profiles for two Honiture robot vacuums with mopping capability.

**Honiture G20** (protocol 3.4):
Includes all three fan speeds (gentle, normal, strong), mopping water control, battery, brush/filter life sensors, carpet boost, carpet detection, seek robot, work mode, volume, and language. 

**Honiture Q6 Pro** (protocol 3.3):
Includes full robot_state status mapping, fan speeds (quiet, auto, strong, max), mopping water control, battery, brush life sensors, auto boost, mop detection, deep clean, room mode, do not disturb, and volume control.

Both tested on hardware.