### PR TITLE
Create ecs_974t_thermostat.yaml

### DIFF
--- a/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
+++ b/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
@@ -1,4 +1,4 @@
-name: ECS-974T
+name: Refrigeration thermostat
 products:
   - id: hcsrgtxqugqadvms
     name: Elitech ECS-974T

--- a/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
+++ b/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
@@ -1,4 +1,4 @@
-name: Refrigeration thermostat
+name: ECS-974T
 products:
   - id: hcsrgtxqugqadvms
     name: Elitech ECS-974T
@@ -83,6 +83,10 @@ entities:
           - dps_val: 0
             value: false
           - value: true
+      - id: 45
+        type: bitfield
+        name: fault_code
+        optional: true
 
   # ------------------------------------------------
   # Core Operations

--- a/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
+++ b/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
@@ -1,0 +1,553 @@
+name: ECS-974T Temperature Controller
+products:
+  - id: hcsrgtxqugqadvms
+    name: ECS-974T
+entities:
+  - entity: climate
+    dps:
+      - id: 106
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: true
+            value: cool
+          - dps_val: false
+            value: "off"
+      - id: 103
+        type: boolean
+        name: hvac_action
+        optional: true
+        readonly: true
+        mapping:
+          - dps_val: true
+            value: cooling
+          - dps_val: false
+            value: idle
+      - id: 101
+        type: integer
+        name: current_temperature
+        readonly: true
+        mapping:
+          - scale: 10
+      - id: 107
+        type: integer
+        name: temperature
+        optional: true
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+
+  # ------------------------------------------------
+  # Diagnostic Sensors & Binary States
+  # ------------------------------------------------
+  - entity: sensor
+    name: Evaporator temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        mapping:
+          - scale: 10
+  - entity: binary_sensor
+    name: Defrost state
+    class: cold
+    category: diagnostic
+    dps:
+      - id: 104
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: binary_sensor
+    name: Fan state
+    class: running
+    category: diagnostic
+    dps:
+      - id: 105
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: sensor
+    name: Fault code
+    icon: mdi:alert
+    category: diagnostic
+    dps:
+      - id: 45
+        type: integer
+        name: sensor
+        optional: true
+
+  # ------------------------------------------------
+  # Core Operations
+  # ------------------------------------------------
+  - entity: switch
+    name: Manual defrost
+    icon: mdi:snowflake-melt
+    dps:
+      - id: 138
+        type: boolean
+        name: switch
+        optional: true
+
+  # ------------------------------------------------
+  # Configuration: Timers & Delays
+  # ------------------------------------------------
+  - entity: number
+    name: Compressor on time fault limit
+    category: config
+    icon: mdi:timer-alert
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: number
+    name: Compressor off time fault limit
+    category: config
+    icon: mdi:timer-alert
+    dps:
+      - id: 112
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: number
+    name: Compressor restart delay
+    category: config
+    icon: mdi:timer-sync
+    dps:
+      - id: 113
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: number
+    name: Power on delay
+    category: config
+    icon: mdi:power-plug-outline
+    dps:
+      - id: 114
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: number
+    name: Drainage time
+    category: config
+    icon: mdi:water-pump
+    dps:
+      - id: 126
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+
+  # ------------------------------------------------
+  # Configuration: Defrost Settings
+  # ------------------------------------------------
+  - entity: number
+    name: Defrost interval
+    category: config
+    icon: mdi:clock-outline
+    dps:
+      - id: 116
+        type: integer
+        name: value
+        optional: true
+        unit: h
+        mapping:
+          - min: 1
+            max: 250
+            step: 1
+  - entity: select
+    name: Defrost counter type
+    category: config
+    icon: mdi:counter
+    dps:
+      - id: 117
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: compressor_run_time
+          - dps_val: "1"
+            value: real_time
+          - dps_val: "2"
+            value: compressor_stop_time
+  - entity: number
+    name: Defrost offset
+    category: config
+    icon: mdi:timer-sand
+    dps:
+      - id: 118
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 59
+            step: 1
+  - entity: number
+    name: Defrost endurance time
+    category: config
+    icon: mdi:timer-stop
+    dps:
+      - id: 119
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: number
+    name: Defrost stop temperature
+    class: temperature
+    category: config
+    dps:
+      - id: 121
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+  - entity: switch
+    name: Defrost at power on
+    category: config
+    icon: mdi:power-settings
+    dps:
+      - id: 122
+        type: string
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: false
+          - dps_val: "1"
+            value: true
+  - entity: select
+    name: Defrost display lock
+    category: config
+    icon: mdi:monitor-lock
+    dps:
+      - id: 137
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: current_temperature
+          - dps_val: "1"
+            value: lock_at_temperature
+          - dps_val: "2"
+            value: display_def
+
+  # ------------------------------------------------
+  # Configuration: Fan Settings
+  # ------------------------------------------------
+  - entity: number
+    name: Fan stop temperature
+    class: temperature
+    category: config
+    dps:
+      - id: 123
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+  - entity: number
+    name: Fan activation differential
+    category: config
+    icon: mdi:thermometer-lines
+    dps:
+      - id: 124
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: 10
+            max: 500
+            step: 1
+            scale: 10
+  - entity: number
+    name: Fan delay time
+    category: config
+    icon: mdi:fan-clock
+    dps:
+      - id: 125
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: switch
+    name: Defrost fan disable
+    category: config
+    icon: mdi:fan-off
+    dps:
+      - id: 127
+        type: string
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: false
+          - dps_val: "1"
+            value: true
+
+  # ------------------------------------------------
+  # Configuration: Alarms & Overrides
+  # ------------------------------------------------
+  - entity: number
+    name: Power alarm override
+    category: config
+    icon: mdi:alarm-light-off
+    dps:
+      - id: 131
+        type: integer
+        name: value
+        optional: true
+        unit: h
+        mapping:
+          - min: 0
+            max: 15
+            step: 1
+  - entity: number
+    name: Defrost alarm override
+    category: config
+    icon: mdi:alarm-light-off
+    dps:
+      - id: 132
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+  - entity: number
+    name: Temperature alarm override
+    category: config
+    icon: mdi:alarm-light-off
+    dps:
+      - id: 133
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        mapping:
+          - min: 0
+            max: 250
+            step: 1
+
+  # ------------------------------------------------
+  # Configuration: System & Display Parameters
+  # ------------------------------------------------
+  - entity: switch
+    name: Enable evaporator sensor
+    category: config
+    icon: mdi:thermometer
+    dps:
+      - id: 120
+        type: string
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: false
+          - dps_val: "1"
+            value: true
+  - entity: switch
+    name: Decimal point display
+    category: config
+    icon: mdi:decimal-comma
+    dps:
+      - id: 134
+        type: string
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: false
+          - dps_val: "1"
+            value: true
+
+  # ------------------------------------------------
+  # Supplemental Undocumented DPs (Inferred)
+  # ------------------------------------------------
+  - entity: number
+    name: Temperature differential
+    category: config
+    icon: mdi:thermometer-lines
+    dps:
+      - id: 108
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: 10
+            max: 500
+            step: 1
+            scale: 10
+  - entity: number
+    name: Panel high temperature limit
+    class: temperature
+    category: config
+    dps:
+      - id: 109
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+  - entity: number
+    name: Panel low temperature limit
+    class: temperature
+    category: config
+    dps:
+      - id: 110
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+  - entity: select
+    name: Defrost type
+    category: config
+    icon: mdi:heating-coil
+    dps:
+      - id: 115
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: electric
+          - dps_val: "1"
+            value: hot_gas
+  - entity: switch
+    name: Fan continuous operation
+    category: config
+    icon: mdi:fan-sync
+    dps:
+      - id: 128
+        type: string
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: false
+          - dps_val: "1"
+            value: true
+  - entity: number
+    name: High alarm limit
+    class: temperature
+    category: config
+    dps:
+      - id: 129
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+  - entity: number
+    name: Low alarm limit
+    class: temperature
+    category: config
+    dps:
+      - id: 130
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -500
+            max: 990
+            step: 1
+            scale: 10
+  - entity: number
+    name: Main sensor calibration
+    category: config
+    icon: mdi:tune-vertical
+    dps:
+      - id: 135
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -100
+            max: 100
+            step: 1
+            scale: 10
+  - entity: number
+    name: Evaporator sensor calibration
+    category: config
+    icon: mdi:tune-vertical
+    dps:
+      - id: 136
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - min: -100
+            max: 100
+            step: 1
+            scale: 10

--- a/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
+++ b/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
@@ -33,10 +33,11 @@ entities:
         type: integer
         name: temperature
         optional: true
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
 
   # ------------------------------------------------
@@ -107,10 +108,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: number
     name: Compressor off time fault limit
     category: config
@@ -121,10 +123,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: number
     name: Compressor restart delay
     category: config
@@ -135,10 +138,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: number
     name: Power on delay
     category: config
@@ -149,10 +153,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: number
     name: Drainage time
     category: config
@@ -163,10 +168,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
 
   # ------------------------------------------------
   # Configuration: Defrost Settings
@@ -181,10 +187,11 @@ entities:
         name: value
         optional: true
         unit: h
+        range:
+          min: 1
+          max: 250
         mapping:
-          - min: 1
-            max: 250
-            step: 1
+          - step: 1
   - entity: select
     name: Defrost counter type
     category: config
@@ -211,10 +218,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 59
         mapping:
-          - min: 0
-            max: 59
-            step: 1
+          - step: 1
   - entity: number
     name: Defrost endurance time
     category: config
@@ -225,10 +233,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: number
     name: Defrost stop temperature
     class: temperature
@@ -239,10 +248,11 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
   - entity: switch
     name: Defrost at power on
@@ -288,10 +298,11 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
     name: Fan activation differential
@@ -303,10 +314,11 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: 10
+          max: 500
         mapping:
-          - min: 10
-            max: 500
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
     name: Fan delay time
@@ -318,10 +330,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: switch
     name: Defrost fan disable
     category: config
@@ -350,10 +363,11 @@ entities:
         name: value
         optional: true
         unit: h
+        range:
+          min: 0
+          max: 15
         mapping:
-          - min: 0
-            max: 15
-            step: 1
+          - step: 1
   - entity: number
     name: Defrost alarm override
     category: config
@@ -364,10 +378,11 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
   - entity: number
     name: Temperature alarm override
     category: config
@@ -378,16 +393,17 @@ entities:
         name: value
         optional: true
         unit: min
+        range:
+          min: 0
+          max: 250
         mapping:
-          - min: 0
-            max: 250
-            step: 1
+          - step: 1
 
   # ------------------------------------------------
   # Configuration: System & Display Parameters
   # ------------------------------------------------
   - entity: switch
-    name: Enable evaporator sensor
+    name: Evaporator sensor
     category: config
     icon: mdi:thermometer
     dps:
@@ -428,13 +444,14 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: 10
+          max: 500
         mapping:
-          - min: 10
-            max: 500
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
-    name: Panel high temperature limit
+    name: High temperature limit
     class: temperature
     category: config
     dps:
@@ -443,13 +460,14 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
-    name: Panel low temperature limit
+    name: Low temperature limit
     class: temperature
     category: config
     dps:
@@ -458,10 +476,11 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
   - entity: select
     name: Defrost type
@@ -501,10 +520,11 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
     name: Low alarm limit
@@ -516,13 +536,14 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -500
+          max: 990
         mapping:
-          - min: -500
-            max: 990
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
-    name: Main sensor calibration
+    name: Room sensor calibration
     category: config
     icon: mdi:tune-vertical
     dps:
@@ -531,10 +552,11 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -100
+          max: 100
         mapping:
-          - min: -100
-            max: 100
-            step: 1
+          - step: 1
             scale: 10
   - entity: number
     name: Evaporator sensor calibration
@@ -546,8 +568,9 @@ entities:
         name: value
         optional: true
         unit: C
+        range:
+          min: -100
+          max: 100
         mapping:
-          - min: -100
-            max: 100
-            step: 1
+          - step: 1
             scale: 10

--- a/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
+++ b/custom_components/tuya_local/devices/ecs_974t_thermostat.yaml
@@ -1,7 +1,7 @@
-name: ECS-974T Temperature Controller
+name: ECS-974T
 products:
   - id: hcsrgtxqugqadvms
-    name: ECS-974T
+    name: Elitech ECS-974T
 entities:
   - entity: climate
     dps:
@@ -37,8 +37,7 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
 
   # ------------------------------------------------
   # Diagnostic Sensors & Binary States
@@ -56,8 +55,7 @@ entities:
         mapping:
           - scale: 10
   - entity: binary_sensor
-    name: Defrost state
-    class: cold
+    translation_key: defrost
     category: diagnostic
     dps:
       - id: 104
@@ -65,7 +63,7 @@ entities:
         name: sensor
         optional: true
   - entity: binary_sensor
-    name: Fan state
+    name: Fan
     class: running
     category: diagnostic
     dps:
@@ -73,15 +71,18 @@ entities:
         type: boolean
         name: sensor
         optional: true
-  - entity: sensor
-    name: Fault code
-    icon: mdi:alert
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
     dps:
       - id: 45
-        type: integer
+        type: bitfield
         name: sensor
         optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
 
   # ------------------------------------------------
   # Core Operations
@@ -99,7 +100,8 @@ entities:
   # Configuration: Timers & Delays
   # ------------------------------------------------
   - entity: number
-    name: Compressor on time fault limit
+    name: Compressor max on time
+    class: duration
     category: config
     icon: mdi:timer-alert
     dps:
@@ -111,10 +113,9 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: number
-    name: Compressor off time fault limit
+    name: Compressor max off time
+    class: duration
     category: config
     icon: mdi:timer-alert
     dps:
@@ -126,10 +127,9 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: number
     name: Compressor restart delay
+    class: duration
     category: config
     icon: mdi:timer-sync
     dps:
@@ -141,10 +141,9 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: number
     name: Power on delay
+    class: duration
     category: config
     icon: mdi:power-plug-outline
     dps:
@@ -156,10 +155,9 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: number
-    name: Drainage time
+    name: Drainage duration
+    class: duration
     category: config
     icon: mdi:water-pump
     dps:
@@ -171,14 +169,13 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
 
   # ------------------------------------------------
   # Configuration: Defrost Settings
   # ------------------------------------------------
   - entity: number
     name: Defrost interval
+    class: duration
     category: config
     icon: mdi:clock-outline
     dps:
@@ -190,10 +187,8 @@ entities:
         range:
           min: 1
           max: 250
-        mapping:
-          - step: 1
   - entity: select
-    name: Defrost counter type
+    name: Defrost interval method
     category: config
     icon: mdi:counter
     dps:
@@ -203,13 +198,14 @@ entities:
         optional: true
         mapping:
           - dps_val: "0"
-            value: compressor_run_time
+            value: Compressor run time
           - dps_val: "1"
-            value: real_time
+            value: Real time
           - dps_val: "2"
-            value: compressor_stop_time
+            value: Compressor stop time
   - entity: number
-    name: Defrost offset
+    name: Defrost power on offset
+    class: duration
     category: config
     icon: mdi:timer-sand
     dps:
@@ -221,10 +217,9 @@ entities:
         range:
           min: 0
           max: 59
-        mapping:
-          - step: 1
   - entity: number
-    name: Defrost endurance time
+    name: Defrost duration
+    class: duration
     category: config
     icon: mdi:timer-stop
     dps:
@@ -236,8 +231,6 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: number
     name: Defrost stop temperature
     class: temperature
@@ -252,8 +245,7 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: switch
     name: Defrost at power on
     category: config
@@ -269,7 +261,7 @@ entities:
           - dps_val: "1"
             value: true
   - entity: select
-    name: Defrost display lock
+    name: Defrost display mode
     category: config
     icon: mdi:monitor-lock
     dps:
@@ -279,11 +271,11 @@ entities:
         optional: true
         mapping:
           - dps_val: "0"
-            value: current_temperature
+            value: Current temperature
           - dps_val: "1"
-            value: lock_at_temperature
+            value: Lock at temperature
           - dps_val: "2"
-            value: display_def
+            value: Display DEF
 
   # ------------------------------------------------
   # Configuration: Fan Settings
@@ -302,10 +294,10 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
-    name: Fan activation differential
+    name: Fan hysteresis
+    class: temperature_delta
     category: config
     icon: mdi:thermometer-lines
     dps:
@@ -318,10 +310,10 @@ entities:
           min: 10
           max: 500
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
     name: Fan delay time
+    class: duration
     category: config
     icon: mdi:fan-clock
     dps:
@@ -333,8 +325,6 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: switch
     name: Defrost fan disable
     category: config
@@ -355,6 +345,7 @@ entities:
   # ------------------------------------------------
   - entity: number
     name: Power alarm override
+    class: duration
     category: config
     icon: mdi:alarm-light-off
     dps:
@@ -366,10 +357,9 @@ entities:
         range:
           min: 0
           max: 15
-        mapping:
-          - step: 1
   - entity: number
     name: Defrost alarm override
+    class: duration
     category: config
     icon: mdi:alarm-light-off
     dps:
@@ -381,10 +371,9 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
   - entity: number
     name: Temperature alarm override
+    class: duration
     category: config
     icon: mdi:alarm-light-off
     dps:
@@ -396,8 +385,6 @@ entities:
         range:
           min: 0
           max: 250
-        mapping:
-          - step: 1
 
   # ------------------------------------------------
   # Configuration: System & Display Parameters
@@ -435,7 +422,8 @@ entities:
   # Supplemental Undocumented DPs (Inferred)
   # ------------------------------------------------
   - entity: number
-    name: Temperature differential
+    name: Temperature hysteresis
+    class: temperature_delta
     category: config
     icon: mdi:thermometer-lines
     dps:
@@ -448,10 +436,9 @@ entities:
           min: 10
           max: 500
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
-    name: High temperature limit
+    translation_key: maximum_temperature
     class: temperature
     category: config
     dps:
@@ -464,10 +451,9 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
-    name: Low temperature limit
+    translation_key: minimum_temperature
     class: temperature
     category: config
     dps:
@@ -480,8 +466,7 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: select
     name: Defrost type
     category: config
@@ -493,9 +478,9 @@ entities:
         optional: true
         mapping:
           - dps_val: "0"
-            value: electric
+            value: Electric
           - dps_val: "1"
-            value: hot_gas
+            value: Hot gas
   - entity: switch
     name: Fan continuous operation
     category: config
@@ -524,8 +509,7 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
     name: Low alarm limit
     class: temperature
@@ -540,10 +524,9 @@ entities:
           min: -500
           max: 990
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
-    name: Room sensor calibration
+    translation_key: temperature_calibration
     category: config
     icon: mdi:tune-vertical
     dps:
@@ -556,8 +539,7 @@ entities:
           min: -100
           max: 100
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10
   - entity: number
     name: Evaporator sensor calibration
     category: config
@@ -572,5 +554,4 @@ entities:
           min: -100
           max: 100
         mapping:
-          - step: 1
-            scale: 10
+          - scale: 10

--- a/custom_components/tuya_local/devices/elitech_ecs974t_thermostat.yaml
+++ b/custom_components/tuya_local/devices/elitech_ecs974t_thermostat.yaml
@@ -1,7 +1,8 @@
-name: ECS-974T
+name: Refrigeration thermostat
 products:
   - id: hcsrgtxqugqadvms
-    name: Elitech ECS-974T
+    manufacturer: Elitech
+    model: ECS-974T
 entities:
   - entity: climate
     dps:


### PR DESCRIPTION
Adds complete support for ESC-974T wifi temperature controller / thermostat.
Tried to make this as complete as possible thus the large number of DP's, most non critical ones have to be listed as optional as the unit only advertises a smaller number when adding.