### PR TITLE
feat(devices): update royal clima fresh AC entities

### DIFF
--- a/custom_components/tuya_local/devices/royalclima_fresh_climate.yaml
+++ b/custom_components/tuya_local/devices/royalclima_fresh_climate.yaml
@@ -2,7 +2,7 @@ name: Air conditioner
 products:
   - id: mcnywzjlugvvvnjj
     manufacturer: Royal Clima
-    model: ROYAL FRESH FULL DC EU Inverter
+    model: Royal Fresh Full DC EU Inverter
 entities:
   - entity: climate
     translation_key: aircon_extra
@@ -139,7 +139,7 @@ entities:
             value: High
           - dps_val: auto
             value: Auto
-    hidden: true
+    deprecated: fan.fan_with_presets # 2026-05-05
   - entity: fan
     translation_key: fan_with_presets
     dps:

--- a/custom_components/tuya_local/devices/royalclima_fresh_climate.yaml
+++ b/custom_components/tuya_local/devices/royalclima_fresh_climate.yaml
@@ -2,7 +2,7 @@ name: Air conditioner
 products:
   - id: mcnywzjlugvvvnjj
     manufacturer: Royal Clima
-    model: Fresh full inverter
+    model: ROYAL FRESH FULL DC EU Inverter
 entities:
   - entity: climate
     translation_key: aircon_extra
@@ -139,6 +139,31 @@ entities:
             value: High
           - dps_val: auto
             value: Auto
+    hidden: true
+  - entity: fan
+    translation_key: fan_with_presets
+    dps:
+      - id: 102
+        type: string
+        name: switch
+        mapping:
+          - dps_val: "off"
+            value: false
+          - dps_val: auto
+            value: true
+      - id: 102
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: low
+            value: low
+          - dps_val: mid
+            value: medium
+          - dps_val: strong
+            value: high
+          - value: auto
   - entity: select
     name: Vertical swing
     category: config

--- a/custom_components/tuya_local/devices/royalclima_fresh_climate.yaml
+++ b/custom_components/tuya_local/devices/royalclima_fresh_climate.yaml
@@ -139,7 +139,7 @@ entities:
             value: High
           - dps_val: auto
             value: Auto
-    deprecated: fan.fan_with_presets # 2026-05-05
+    deprecated: fan.fan_with_presets  # 2026-05-05
   - entity: fan
     translation_key: fan_with_presets
     dps:


### PR DESCRIPTION
Hi!
I made an update for existing device configuration.
Device itself has built-in fresh air intake fan (dp 102).
Current device config describes this fan as _select_ entity with 5 modes (options): "off", "auto", "low", "medium", "high".
I decided to convert it to the _fan_ entity, so it can be used more comfortable in automations, scripts, dashboard cards, etc.
Also I changed device model name as on the vendor's official site and in user manual. 

To be honest, I don't know what to do with old one _select_ entity, so I decided to mark it hidden (disabled by default for new users) for a backward compability to other users already using this integration with this device. If you already have some practices that solves that kind of...questions I will update branch accordingly.