### PR TITLE
feat(devices): add heat pump water heater (product id cojwk3pbppwpgofa)

### DIFF
--- a/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
@@ -35,14 +35,14 @@ entities:
         optional: true
 
   - entity: select
-    name: Mode
+    translation_key: mode
     dps:
       - id: 2
         type: string
         name: option
         mapping:
           - dps_val: heating
-            value: Heating
+            value: heating
 
   - entity: sensor
     name: Top tank temperature

--- a/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
@@ -1,8 +1,10 @@
-name: Heat pump water heater
+name: Tauclima DGN-250 Heat pump water heater
 
 products:
   - id: cojwk3pbppwpgofa
-    name: Heat pump water heater
+    name: DGN-250
+    manufacturer: Tauclima
+    model: DGN-250
 
 entities:
   - entity: water_heater
@@ -29,10 +31,13 @@ entities:
         name: current_temperature
         unit: C
 
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
       - id: 7
         type: boolean
-        name: defrosting
-        optional: true
+        name: sensor
 
   - entity: select
     translation_key: mode
@@ -43,6 +48,8 @@ entities:
         mapping:
           - dps_val: heating
             value: heating
+          - dps_val: cold
+            value: cool
 
   - entity: sensor
     name: Top tank temperature
@@ -56,7 +63,6 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Power consumption
     class: energy
     dps:
       - id: 18
@@ -66,7 +72,6 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-            step: 1
 
   - entity: binary_sensor
     name: Circulation pump
@@ -88,3 +93,6 @@ entities:
           - dps_val: 0
             value: false
           - value: true
+      - id: 15
+        type: bitfield
+        name: fault_code

--- a/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
@@ -1,0 +1,88 @@
+name: Heat pump water heater
+
+products:
+  - id: cojwk3pbppwpgofa
+    name: Heat pump water heater
+
+entities:
+  - entity: water_heater
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat_pump
+
+      - id: 4
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 5
+          max: 75
+
+      - id: 16
+        type: integer
+        name: current_temperature
+        unit: C
+
+      - id: 7
+        type: boolean
+        name: defrosting
+        optional: true
+
+  - entity: select
+    name: Mode
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: heating
+            value: Heating
+
+  - entity: sensor
+    name: Top tank temperature
+    category: diagnostic
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        unit: C
+        class: temperature
+
+  - entity: sensor
+    name: Power consumption
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: kWh
+        class: energy
+        mapping:
+          - scale: 100
+            step: 1
+
+  - entity: binary_sensor
+    name: Circulation pump
+    class: running
+    category: diagnostic
+    dps:
+      - id: 30
+        type: boolean
+        name: sensor
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true

--- a/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
@@ -52,7 +52,7 @@ entities:
         type: integer
         name: sensor
         unit: C
-        class: temperature
+        class: measurement
 
   - entity: sensor
     name: Power consumption

--- a/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/heat_pump_water_heater.yaml
@@ -46,6 +46,7 @@ entities:
 
   - entity: sensor
     name: Top tank temperature
+    class: temperature
     category: diagnostic
     dps:
       - id: 21
@@ -56,12 +57,13 @@ entities:
 
   - entity: sensor
     name: Power consumption
+    class: energy
     dps:
       - id: 18
         type: integer
         name: sensor
         unit: kWh
-        class: energy
+        class: total_increasing
         mapping:
           - scale: 100
             step: 1

--- a/custom_components/tuya_local/devices/tauclima_dgn250_waterheater.yaml
+++ b/custom_components/tuya_local/devices/tauclima_dgn250_waterheater.yaml
@@ -1,8 +1,7 @@
-name: Tauclima DGN-250 Heat pump water heater
+name: Heat pump water heater
 
 products:
   - id: cojwk3pbppwpgofa
-    name: DGN-250
     manufacturer: Tauclima
     model: DGN-250
 
@@ -40,14 +39,14 @@ entities:
         name: sensor
 
   - entity: select
-    translation_key: mode
+    translation_key: heat_pump_mode
     dps:
       - id: 2
         type: string
         name: option
         mapping:
           - dps_val: heating
-            value: heating
+            value: heat
           - dps_val: cold
             value: cool
 


### PR DESCRIPTION
Heat pump water heater with product id cojwk3pbppwpgofa.

Tested and working on Home Assistant with tuya-local.

Local DPS:
{"1": true, "2": "heating", "4": 50, "7": false, "10": 0, "15": 0, "16": 50, "18": 89, "21": 50, "22": -50, "30": false, "101": 0, "102": 0, "103": 0, "104": 0}

Cloud spec:
[{"id": 1, "name": "switch", "type": "Boolean"}, {"id": 2, "name": "mode", "type": "Enum", "range": ["cold","heating"]}, {"id": 4, "name": "temp_set", "type": "Integer", "min":5, "max":75, "unit":"℃"}, {"id": 7, "name": "defrost", "type": "Boolean"}, {"id": 16, "name": "temp_current", "type": "Integer"}, {"id": 18, "name": "power_consumption", "type": "Integer", "unit":"kWh", "scale":2}, {"id": 21, "name": "temp_top", "type": "Integer"}, {"id": 22, "name": "temp_bottom", "type": "Integer"}, {"id": 30, "name": "pump_state", "type": "Boolean"}]

Notes: DP22 (bottom tank temp) returns -50 on this unit, sensor may not be present on all models.