### PR TITLE
Update feit_dimmer.yaml

### DIFF
--- a/custom_components/tuya_local/devices/feit_dimmer.yaml
+++ b/custom_components/tuya_local/devices/feit_dimmer.yaml
@@ -45,3 +45,19 @@ entities:
             value: Incandescent
           - dps_val: halogen
             value: LED
+  - entity: select
+    name: Indicator
+    icon: mdi:lightbulb-variant
+    category: config
+    dps:			
+      - id: 101
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: off
+            value: None
+          - dps_val: low
+            value: Low
+          - dps_val: high
+            value: High		

--- a/custom_components/tuya_local/devices/feit_dimmer.yaml
+++ b/custom_components/tuya_local/devices/feit_dimmer.yaml
@@ -60,4 +60,4 @@ entities:
           - dps_val: low
             value: Low
           - dps_val: high
-            value: High		
+            value: High

--- a/custom_components/tuya_local/devices/feit_dimmer.yaml
+++ b/custom_components/tuya_local/devices/feit_dimmer.yaml
@@ -49,7 +49,7 @@ entities:
     name: Indicator
     icon: mdi:lightbulb-variant
     category: config
-    dps:			
+    dps:
       - id: 101
         type: string
         name: option

--- a/custom_components/tuya_local/devices/feit_dimmer.yaml
+++ b/custom_components/tuya_local/devices/feit_dimmer.yaml
@@ -45,19 +45,27 @@ entities:
             value: Incandescent
           - dps_val: halogen
             value: LED
-  - entity: select
-    name: Indicator
-    icon: mdi:lightbulb-variant
+  - entity: light
+    translation_key: indicator
     category: config
+    hidden: unavailable
     dps:
       - id: 101
         type: string
-        name: option
+        name: brightness
         optional: true
         mapping:
-          - dps_val: off
-            value: None
+          - dps_val: "off"
+            value: 0
           - dps_val: low
-            value: Low
+            value: 128
           - dps_val: high
-            value: High
+            value: 255
+      - id: 101
+        type: string
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true


### PR DESCRIPTION
Added additional dps entries for feit_dimmer to control nightlight

Hi! This is my first ever git contribution, so sorry if I'm missing any steps! I have a Fiet Smart Dimmer, and noticed that on the OEM application there is a feature to control the nightlight on the switch itself. This is missing from tuya-local, so I looked into the raw dps values and found which ones correspond to this feature. I tested the change locally and it fully works on all my devices. I've added a few lines to the device file to allow controlling it. Thanks so much! 
