### PR TITLE
feat(parkside_pmrc250_mower): dedicated config for PMRC 250 Ai

### DIFF
--- a/custom_components/tuya_local/devices/parkside_pmrc250_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_pmrc250_mower.yaml
@@ -1,11 +1,8 @@
 name: Lawnmower
 products:
-  - id: mvt4l2evgq2l3nkn
-    manufacturer: MoeBot
-    model: S20
-  - id: icw5sal7xfcevsve
+  - id: 7yr5iwga
     manufacturer: Parkside
-    model: PMRDA 20-Li A1
+    model: PMRC 250 Ai Bluetooth
 entities:
   - entity: lawn_mower
     dps:
@@ -55,6 +52,9 @@ entities:
           - dps_val: ContinueWork
             value: start_mowing
             hidden: true
+          # PMRC 250 Ai firmware rejects StartReturnStation from MOWING;
+          #  it must be preceded by PauseWork and CancelWork (same flow
+          #  as the Tuya app). The mapping is left here for completeness.
           - dps_val: StartReturnStation
             value: dock
       - id: 101
@@ -163,10 +163,11 @@ entities:
         mapping:
           - dps_val: null
             value: OK
+          # PMRC 250 Ai reports MOWER_LEAN as its default idle code, not an
+          #  actual tilt alarm — the Tuya app and the robot itself show no
+          #  error in this state. Treat it as OK.
           - dps_val: MOWER_LEAN
-            value: Tilted
-            icon: "mdi:angle-acute"
-            icon_priority: 1
+            value: OK
           - dps_val: MOWER_STEEP
             value: Steep
             icon: "mdi:slope-uphill"


### PR DESCRIPTION
Splits the Parkside PMRC 250 Ai Bluetooth (product_id 7yr5iwga)
out of moebot_s_mower.yaml into its own device file.

The PMRC 250 Ai was added to moebot_s_mower.yaml in 50f4961d
(refs #4859) under the assumption that it shares behaviour with
the MoeBot S20. Field testing on my unit, with debug-level logs
from this integration, revealed two firmware divergences:

1. DPS 103 reports MOWER_LEAN as the default idle code on every
   poll, even when the robot is docked, on flat ground, with no
   error shown in the official Tuya app or on the robot's own UI.
   With the shared MoeBot config the Problem sensor in HA is
   therefore stuck permanently on "Tilted". Mapped to OK in the
   new file. All other DPS 103 codes are unchanged.

2. DPS 115 StartReturnStation is silently rejected when the
   mower is in MOWING state. The firmware requires the sequence
   PauseWork -> CancelWork -> StartReturnStation; the same flow
   is enforced by the official Tuya app (you cannot tap "return
   to base" while mowing without first pausing and cancelling).
   The YAML schema cannot express multi-step commands, so the
   mapping is left as-is and a short inline comment documents
   the constraint. End users can chain the commands in an HA
   script when needed.

The product entry has been removed from moebot_s_mower.yaml so
the two files do not both match 7yr5iwga. Existing PMRC 250 Ai
users may need to remove and re-add the device entry to pick up
the new config, since tuya-local caches the matched device type
in the config entry.

yamllint clean. Tested locally on my unit running firmware
V0.1.2 build Mar 11 2025 18:29:07.