### PR TITLE
Remove useless 'available' property from LDH7700 dehumidifier config

### DIFF
--- a/custom_components/tuya_local/devices/ldh7700_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/ldh7700_dehumidifier.yaml
@@ -36,13 +36,6 @@ entities:
       - id: 1
         type: boolean
         name: switch
-      - id: 5
-        type: string
-        name: available
-        mapping:
-          - dps_val: Continuities
-            value: true
-          - value: false
       - id: 4
         type: string
         name: speed


### PR DESCRIPTION
Removed 'available' property from device configuration.

- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Please describe in simple terms what you are submitting. Do not paste a multi-page AI generated rambling story here, as the maintainers do not have time to read that.
