### PR TITLE
Add Zencar Wpro 32A 3P EV charger

### DIFF
--- a/custom_components/tuya_local/devices/zencar_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/zencar_ev_charger.yaml
@@ -1,0 +1,116 @@
+name: EV charger
+products:
+  - id: c1twbctmrehgni7a
+    manufacturer: Zencar
+    model: Wpro 32A 3P
+entities:
+  - entity: sensor
+    class: enum
+    translation_key: status
+    icon: "mdi:ev-station"
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: charger_free
+            value: available
+          - dps_val: charger_insert
+            value: plugged_in
+          - dps_val: charger_free_fault
+            value: fault_unplugged
+          - dps_val: charger_charging
+            value: charging
+          - dps_val: charger_fault
+            value: fault
+      - id: 23
+        type: string
+        optional: true
+        name: system_version
+      - id: 101
+        type: string
+        optional: true
+        name: serial_number
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        optional: true
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Set current
+    category: config
+    icon: "mdi:ev-plug-type2"
+    dps:
+      - id: 4
+        type: integer
+        name: value
+        unit: A
+        range:
+          min: 6
+          max: 32
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: select
+    translation_key: charging_mode
+    icon: "mdi:ev-station"
+    dps:
+      - id: 14
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: immediate
+          - dps_val: charge_pct
+            value: charge_to_percent
+          - dps_val: charge_energy
+            value: fixed_charge
+          - dps_val: charge_schedule
+            value: scheduled_charge
+  - entity: switch
+    icon: "mdi:ev-station"
+    dps:
+      - id: 18
+        type: boolean
+        optional: true
+        name: switch
+        mapping:
+          - dps_val: null
+            value: false
+            hidden: true
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        optional: true
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Last charge
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
+        unit: kWh
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 100

--- a/custom_components/tuya_local/devices/zencar_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/zencar_ev_charger.yaml
@@ -22,7 +22,7 @@ entities:
           - dps_val: charger_charging
             value: charging
           - dps_val: charger_stop_wait
-            value: stopping
+            value: waiting
           - dps_val: charger_fault
             value: fault
       - id: 23
@@ -46,6 +46,7 @@ entities:
           - scale: 100
   - entity: number
     name: Set current
+    class: current
     category: config
     icon: "mdi:ev-plug-type2"
     dps:
@@ -107,6 +108,7 @@ entities:
         class: measurement
   - entity: sensor
     name: Last charge
+    class: energy_storage
     dps:
       - id: 25
         type: integer

--- a/custom_components/tuya_local/devices/zencar_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/zencar_ev_charger.yaml
@@ -21,6 +21,8 @@ entities:
             value: fault_unplugged
           - dps_val: charger_charging
             value: charging
+          - dps_val: charger_stop_wait
+            value: stopping
           - dps_val: charger_fault
             value: fault
       - id: 23


### PR DESCRIPTION
New device: Zencar Wpro 32A 3P (3-phase EV charger).

Product ID: c1twbctmrehgni7a, category qccdz.
Tested locally over Tuya protocol 3.5.

Maps DPS 1/3/4/9/14/18/24/25 (energy, status, set current, power, charging mode, switch, temperature, last charge). Reuses existing status and charging_mode translation keys from afyeev_evcharger.

DPS 23 (system_version) and 101 (device code, content unknown) are
exposed as attributes on the status sensor.