### PR TITLE
Add Our Garden Aroma Diffuser GD-30W

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -570,6 +570,7 @@
 - Haoyunma BD100 aroma diffuser
 - InLine ultrasonic aroma diffuser
 - Maxico aroma diffuser with light (cannot be differentiated automatically from Ditua above)
+- Our Garden Smart Diffuser GD-30W
 - Revesien Q-Pro-W aroma diffuser
 - Tesla Smart aroma diffuser with light
 - YX-025 WB aroma diffuser

--- a/custom_components/tuya_local/devices/our_garden_smart_diffuser_gd_30w.yaml
+++ b/custom_components/tuya_local/devices/our_garden_smart_diffuser_gd_30w.yaml
@@ -30,7 +30,7 @@ entities:
         name: brightness
         range:
           min: 0
-          max: 255      
+          max: 255
       - id: 109
         type: string
         name: color_mode

--- a/custom_components/tuya_local/devices/our_garden_smart_diffuser_gd_30w.yaml
+++ b/custom_components/tuya_local/devices/our_garden_smart_diffuser_gd_30w.yaml
@@ -1,0 +1,78 @@
+name: Aroma diffuser
+products:
+  - id: uwP5ueRSh5k5Ccuw
+    manufacturer: Our Garden
+    model: GD-30W
+entities:
+  - entity: fan
+    translation_key: aroma_diffuser
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 103
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: "small"
+            value: small
+          - dps_val: "big"
+            value: large
+
+  - entity: light
+    category: config
+    dps:
+      - id: 11
+        type: boolean
+        name: switch
+      - id: 111
+        type: integer
+        name: brightness
+        range:
+          min: 0
+          max: 255      
+      - id: 109
+        type: string
+        name: color_mode
+        mapping:
+          - dps_val: "white"
+            value: white
+          - dps_val: "colour"
+            value: hs
+          - dps_val: "colourful1"
+            value: effect
+      - id: 108
+        name: rgbhsv
+        type: hex
+        format:
+          - name: r
+            bytes: 1
+          - name: g
+            bytes: 1
+          - name: b
+            bytes: 1
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 1
+            range:
+              min: 0
+              max: 255
+          - name: v
+            bytes: 1
+            range:
+              min: 0
+              max: 255
+      - id: 110
+        type: string
+        name: effect
+        mapping:
+          - dps_val: "2"
+            value: "off"
+          - dps_val: "1"
+            value: Gradient
+          - dps_val: "3"
+            value: Night Light


### PR DESCRIPTION
Add support for OUR GARDEN Smart Diffuser Ultrasonic Aromatherapy WIFI TUYA 300 ml (Tuya product_id: ymfznwejbhviuhjk)

Bought in Indonesia rebranded as Our Garden
https://shopee.co.id/Smart-Diffuser-OUR-GARDEN-Ultrasonic-Aromatherapy-WIFI-TUYA-300-ml-i.88880187.12234843968 . Listed on Aliexpress as Smart Home Decor Tuya WiFi Ultrasonic Essential Oil Diffuser Mist Maker with Colorful Night Light 300ml Google Home Control
https://www.aliexpress.com/item/1005009743295393.html

Data from diagnostics file:
[tuya-Aromatherapy machine.json](https://github.com/user-attachments/files/27563550/tuya-Aromatherapy.machine.json)