### PR TITLE
Add Atorch real-time refresh switch

### DIFF
--- a/custom_components/tuya_local/devices/atorch_at4pw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/atorch_at4pw_energymeter.yaml
@@ -230,13 +230,14 @@ entities:
         type: boolean
         name: switch
   - entity: switch
-    name: Real-time refresh (1s/60s)
+    name: Real time data refresh
     category: config
     icon: "mdi:refresh"
     dps:
       - id: 126
         type: boolean
         name: switch
+        optional: true
   - entity: sensor
     class: energy
     dps:

--- a/custom_components/tuya_local/devices/atorch_at4pw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/atorch_at4pw_energymeter.yaml
@@ -229,6 +229,14 @@ entities:
       - id: 120
         type: boolean
         name: switch
+  - entity: switch
+    name: Real-time refresh (1s/60s)
+    category: config
+    icon: "mdi:refresh"
+    dps:
+      - id: 126
+        type: boolean
+        name: switch
   - entity: sensor
     class: energy
     dps:


### PR DESCRIPTION
## Summary
- Add optional DPS 126 as a config switch for the Atorch AT4PBWP energy meter.
- Expose the firmware-dependent real time data refresh setting as `Real time data refresh` with the refresh icon.

## Validation
- Parsed custom_components/tuya_local/devices/atorch_at4pw_energymeter.yaml with PyYAML.
- Ran yamllint on custom_components/tuya_local/devices.
- Validated the modified config against custom_components/tuya_local/devices/device_config_schema.json.
- Ran git diff --check.

Note: uv is not available in my local shell, so the exact uv run commands from AGENTS.md were not run locally.
