### PR TITLE
feat: fix stale device cache handling and add support for another Tonepie T1Pro smart cat litter box 

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -74,6 +74,20 @@ def get_device_unique_id(entry: ConfigEntry):
     )
 
 
+def cleanup_failed_device(hass: HomeAssistant, device_id: str):
+    """Drop cached device objects left behind by failed setup."""
+    domain_data = hass.data.get(DOMAIN, {})
+    stale = domain_data.pop(device_id, None)
+    if not stale:
+        return
+
+    api = stale.get("tuyadevice")
+    if api:
+        api.set_socketPersistent(False)
+        if api.parent:
+            api.parent.set_socketPersistent(False)
+
+
 async def async_migrate_entry(hass, entry: ConfigEntry):
     """Migrate to latest config format."""
 
@@ -885,9 +899,10 @@ async def async_migrate_entry(hass, entry: ConfigEntry):
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    device_id = get_device_id(entry.data)
     _LOGGER.debug(
         "Setting up entry for device: %s",
-        get_device_id(entry.data),
+        device_id,
     )
     config = {**entry.data, **entry.options, "name": entry.title}
     try:
@@ -895,9 +910,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await device.async_refresh()
 
     except Exception as e:
+        cleanup_failed_device(hass, device_id)
         raise ConfigEntryNotReady("tuya-local device not ready") from e
 
     if not device.has_returned_state:
+        cleanup_failed_device(hass, device_id)
         raise ConfigEntryNotReady("tuya-local device offline")
 
     device_conf = await hass.async_add_executor_job(

--- a/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_v3.yaml
+++ b/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_v3.yaml
@@ -1,0 +1,329 @@
+name: Cat litter box
+products:
+  - id: swrzomblcz1can76
+    manufacturer: Tonepie
+    model: T1Pro
+entities:
+  - entity: sensor
+    name: Cat weight
+    icon: "mdi:cat"
+    class: weight
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: kg
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Daily visits
+    icon: "mdi:emoticon-poop"
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: visits
+        class: measurement
+  - entity: sensor
+    name: Daily visit duration
+    icon: "mdi:emoticon-poop"
+    class: duration
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: s
+        class: measurement
+  # DPS 17 appears writable on other Tonepie variants,
+  # so expose as control here.
+  - entity: switch
+    name: Deodorization
+    icon: "mdi:scent"
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+      - id: 22
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: motor_fault
+          - dps_val: 2
+            value: program_fault
+          - dps_val: 4
+            value: weight_sensor_fault
+          - dps_val: 8
+            value: fan_fault
+          - dps_val: 16
+            value: deodorizer_fault
+          - dps_val: 32
+            value: drum_not_installed
+  - entity: sensor
+    name: Fault code
+    class: enum
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: motor_fault
+          - dps_val: 2
+            value: program_fault
+          - dps_val: 4
+            value: weight_sensor_fault
+          - dps_val: 8
+            value: fan_fault
+          - dps_val: 16
+            value: deodorizer_fault
+          - dps_val: 32
+            value: drum_not_installed
+  - entity: button
+    name: Clean now
+    icon: "mdi:shimmer"
+    dps:
+      - id: 101
+        type: boolean
+        name: button
+  - entity: button
+    name: Empty litter
+    icon: "mdi:delete-empty"
+    dps:
+      - id: 102
+        type: boolean
+        name: button
+  - entity: binary_sensor
+    name: Waste bin full
+    category: diagnostic
+    icon: "mdi:trash-can"
+    dps:
+      - id: 103
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: binary_sensor
+    class: occupancy
+    icon: "mdi:motion-sensor"
+    dps:
+      - id: 104
+        type: boolean
+        name: sensor
+  - entity: switch
+    translation_key: auto_clean
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+  # DPS 106 is inferred schedule/blob data, not user-friendly control.
+  - entity: text
+    name: Clean schedule
+    category: diagnostic
+    hidden: true
+    icon: "mdi:calendar-clock"
+    dps:
+      - id: 106
+        type: string
+        optional: true
+        name: value
+  # DPS 107/109 look like internal firmware toggles
+  # for alternate scheduling path.
+  - entity: switch
+    name: Scheduled cleaning
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 107
+        type: boolean
+        optional: true
+        name: switch
+  - entity: text
+    name: Alternate clean schedule
+    category: diagnostic
+    hidden: true
+    icon: "mdi:calendar-sync"
+    dps:
+      - id: 108
+        type: string
+        optional: true
+        name: value
+  - entity: switch
+    name: Alternate clean schedule enabled
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+  - entity: text
+    name: Do not disturb schedule
+    category: diagnostic
+    hidden: true
+    icon: "mdi:calendar-night"
+    dps:
+      - id: 110
+        type: string
+        optional: true
+        name: value
+  - entity: switch
+    name: Infrared detection
+    category: config
+    dps:
+      - id: 111
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Child lock
+    category: config
+    dps:
+      - id: 114
+        type: boolean
+        name: switch
+  - entity: number
+    name: Clean delay
+    category: config
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 117
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 60
+  - entity: number
+    name: Minimum clean interval
+    category: config
+    class: duration
+    icon: "mdi:update"
+    dps:
+      - id: 118
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 120
+  - entity: switch
+    name: Waste bin full notification
+    category: config
+    icon: "mdi:message-alert"
+    dps:
+      - id: 119
+        type: boolean
+        name: switch
+  - entity: button
+    name: Deodorize now
+    category: config
+    icon: "mdi:spray"
+    dps:
+      - id: 120
+        type: boolean
+        name: button
+  - entity: switch
+    name: Smart cleaning
+    icon: "mdi:shimmer"
+    category: config
+    dps:
+      - id: 121
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: do_not_disturb
+    category: config
+    dps:
+      - id: 122
+        type: boolean
+        name: switch
+  - entity: sensor
+    name: Usage count
+    category: diagnostic
+    dps:
+      - id: 123
+        type: integer
+        name: sensor
+        unit: times
+        class: measurement
+  # DPS 124 appears writable calibration on related models.
+  # Keep exposed as config.
+  - entity: number
+    name: Waste bin capacity calibration
+    category: config
+    icon: "mdi:trash-can"
+    dps:
+      - id: 124
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 15
+  # DPS 125 appears writable litter-level calibration on related models.
+  - entity: number
+    name: Litter calibration
+    category: config
+    icon: "mdi:grain"
+    dps:
+      - id: 125
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 6
+  - entity: switch
+    name: Auto deodorize
+    category: config
+    icon: "mdi:flower"
+    dps:
+      - id: 126
+        type: boolean
+        name: switch
+  - entity: number
+    name: Detection sensitivity
+    class: weight
+    category: config
+    icon: "mdi:scale"
+    dps:
+      - id: 127
+        type: integer
+        name: value
+        unit: g
+        range:
+          min: 600
+          max: 1500
+        mapping:
+          - step: 100
+  # DPS 128 looks like firmware/build code
+  # from observed value pattern, not live measurement.
+  - entity: sensor
+    name: Firmware build code
+    icon: "mdi:chip"
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 128
+        type: integer
+        name: sensor

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,10 +4,12 @@ import pytest
 import voluptuous as vol
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.tuya_local import (
     async_migrate_entry,
+    async_setup_entry,
     config_flow,
     get_device_unique_id,
 )
@@ -73,6 +75,54 @@ async def test_init_entry(hass, bypass_data_fetch):
     await hass.async_block_till_done()
     assert hass.states.get("climate.test")
     assert hass.states.get("lock.test_child_lock")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("refresh_error", [RuntimeError("boom"), None])
+async def test_async_setup_entry_cleans_up_failed_device(hass, mocker, refresh_error):
+    """Failed runtime setup should not leave stale device state cached."""
+
+    mock_device = mocker.MagicMock()
+    if refresh_error is None:
+        mock_device.async_refresh = mocker.AsyncMock()
+        mock_device.has_returned_state = False
+    else:
+        mock_device.async_refresh = mocker.AsyncMock(side_effect=refresh_error)
+
+    def fake_setup_device(hass, config):
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN]["deviceid"] = {
+            "device": mock_device,
+            "tuyadevice": mock_device._api,
+            "tuyadevicelock": mocker.MagicMock(),
+        }
+        return mock_device
+
+    mocker.patch(
+        "custom_components.tuya_local.setup_device", side_effect=fake_setup_device
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=13,
+        minor_version=18,
+        title="test",
+        data={
+            CONF_DEVICE_ID: "deviceid",
+            CONF_HOST: "hostname",
+            CONF_LOCAL_KEY: TESTKEY,
+            CONF_POLL_ONLY: False,
+            CONF_PROTOCOL_VERSION: 3.4,
+            CONF_TYPE: "kogan_kahtp_heater",
+        },
+        options={},
+    )
+
+    with pytest.raises(ConfigEntryNotReady):
+        await async_setup_entry(hass, entry)
+
+    assert "deviceid" not in hass.data.get(DOMAIN, {})
+    mock_device._api.set_socketPersistent.assert_called_with(False)
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -14,6 +14,7 @@ from custom_components.tuya_local.helpers.device_config import (
     _typematch,
     available_configs,
     get_config,
+    possible_matches,
 )
 from custom_components.tuya_local.sensor import TuyaLocalSensor
 
@@ -820,6 +821,52 @@ def test_matched_product_id_with_conflict_rejected():
     """Test that matching with product id fails when there is a conflict"""
     cfg = get_config("smartplugv1")
     assert not cfg.matches({"1": "wrong_type"}, ["37mnhia3pojleqfh"])
+
+
+def test_tonepie_t1pro_v3_preferred_for_exact_product_id():
+    """Exact product id should prefer dedicated Tonepie v3 config."""
+
+    dps = {
+        "6": 5538,
+        "7": 1,
+        "8": 44,
+        "17": False,
+        "22": 0,
+        "101": False,
+        "102": False,
+        "104": False,
+        "105": True,
+        "109": True,
+        "111": True,
+        "114": False,
+        "117": 3,
+        "118": 15,
+        "119": False,
+        "120": False,
+        "121": False,
+        "122": False,
+        "123": 1,
+        "124": 5,
+        "125": 0,
+        "126": True,
+        "127": 1500,
+        "128": 240127,
+    }
+    product_ids = ["swrzomblcz1can76"]
+
+    generic = get_config("tonepie_t1pro_catlitterbox")
+    dedicated = get_config("tonepie_t1pro_catlitterbox_v3")
+
+    assert generic.match_quality(dps, product_ids) == 100
+    assert dedicated.match_quality(dps, product_ids) == 101
+
+    matches = list(possible_matches(dps, product_ids))
+    match_types = [cfg.config_type for cfg in matches]
+    assert dedicated.config_type in match_types
+    assert generic.config_type in match_types
+    assert dedicated.match_quality(dps, product_ids) > generic.match_quality(
+        dps, product_ids
+    )
 
 
 def test_multi_stage_redirect(mocker):


### PR DESCRIPTION
Adds dedicated support for the Tonepie T1Pro smart cat litter box (`swrzomblcz1can76`) with a new device YAML.

Changes include:

* improved entity naming and semantics
* better separation between buttons, switches, sensors and diagnostic entities
* hidden diagnostic entities for uncertain/internal DPS values
* proper units and categories for several entities
* exact product_id matching for the new v3 device definition

Also fixes a runtime issue where stale cached `tinytuya` device objects could cause intermittent `914: Check device key or version` errors after failed setup retries, even when the config flow test succeeded.

All tests and lint checks pass.
