### PR TITLE
feat: add support for another Tonepie T1Pro smart cat litter box

### DIFF
--- a/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_v3.yaml
+++ b/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_v3.yaml
@@ -1,0 +1,329 @@
+name: Cat litter box
+products:
+  - id: swrzomblcz1can76
+    manufacturer: Tonepie
+    model: T1Pro
+entities:
+  - entity: sensor
+    name: Cat weight
+    icon: "mdi:cat"
+    class: weight
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: kg
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Daily visits
+    icon: "mdi:emoticon-poop"
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: visits
+        class: measurement
+  - entity: sensor
+    name: Daily visit duration
+    icon: "mdi:emoticon-poop"
+    class: duration
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: s
+        class: measurement
+  # DPS 17 appears writable on other Tonepie variants,
+  # so expose as control here.
+  - entity: switch
+    name: Deodorization
+    icon: "mdi:scent"
+    category: config
+    dps:
+      - id: 17
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+      - id: 22
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: motor_fault
+          - dps_val: 2
+            value: program_fault
+          - dps_val: 4
+            value: weight_sensor_fault
+          - dps_val: 8
+            value: fan_fault
+          - dps_val: 16
+            value: deodorizer_fault
+          - dps_val: 32
+            value: drum_not_installed
+  - entity: sensor
+    name: Fault code
+    class: enum
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: motor_fault
+          - dps_val: 2
+            value: program_fault
+          - dps_val: 4
+            value: weight_sensor_fault
+          - dps_val: 8
+            value: fan_fault
+          - dps_val: 16
+            value: deodorizer_fault
+          - dps_val: 32
+            value: drum_not_installed
+  - entity: button
+    name: Clean now
+    icon: "mdi:shimmer"
+    dps:
+      - id: 101
+        type: boolean
+        name: button
+  - entity: button
+    name: Empty litter
+    icon: "mdi:delete-empty"
+    dps:
+      - id: 102
+        type: boolean
+        name: button
+  - entity: binary_sensor
+    name: Waste bin full
+    category: diagnostic
+    icon: "mdi:trash-can"
+    dps:
+      - id: 103
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: binary_sensor
+    class: occupancy
+    icon: "mdi:motion-sensor"
+    dps:
+      - id: 104
+        type: boolean
+        name: sensor
+  - entity: switch
+    translation_key: auto_clean
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+  # DPS 106 is inferred schedule/blob data, not user-friendly control.
+  - entity: text
+    name: Clean schedule
+    category: diagnostic
+    hidden: true
+    icon: "mdi:calendar-clock"
+    dps:
+      - id: 106
+        type: string
+        optional: true
+        name: value
+  # DPS 107/109 look like internal firmware toggles
+  # for alternate scheduling path.
+  - entity: switch
+    name: Scheduled cleaning
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 107
+        type: boolean
+        optional: true
+        name: switch
+  - entity: text
+    name: Alternate clean schedule
+    category: diagnostic
+    hidden: true
+    icon: "mdi:calendar-sync"
+    dps:
+      - id: 108
+        type: string
+        optional: true
+        name: value
+  - entity: switch
+    name: Alternate clean schedule enabled
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+  - entity: text
+    name: Do not disturb schedule
+    category: diagnostic
+    hidden: true
+    icon: "mdi:calendar-night"
+    dps:
+      - id: 110
+        type: string
+        optional: true
+        name: value
+  - entity: switch
+    name: Infrared detection
+    category: config
+    dps:
+      - id: 111
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Child lock
+    category: config
+    dps:
+      - id: 114
+        type: boolean
+        name: switch
+  - entity: number
+    name: Clean delay
+    category: config
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 117
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 60
+  - entity: number
+    name: Minimum clean interval
+    category: config
+    class: duration
+    icon: "mdi:update"
+    dps:
+      - id: 118
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 120
+  - entity: switch
+    name: Waste bin full notification
+    category: config
+    icon: "mdi:message-alert"
+    dps:
+      - id: 119
+        type: boolean
+        name: switch
+  - entity: button
+    name: Deodorize now
+    category: config
+    icon: "mdi:spray"
+    dps:
+      - id: 120
+        type: boolean
+        name: button
+  - entity: switch
+    name: Smart cleaning
+    icon: "mdi:shimmer"
+    category: config
+    dps:
+      - id: 121
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: do_not_disturb
+    category: config
+    dps:
+      - id: 122
+        type: boolean
+        name: switch
+  - entity: sensor
+    name: Usage count
+    category: diagnostic
+    dps:
+      - id: 123
+        type: integer
+        name: sensor
+        unit: times
+        class: measurement
+  # DPS 124 appears writable calibration on related models.
+  # Keep exposed as config.
+  - entity: number
+    name: Waste bin capacity calibration
+    category: config
+    icon: "mdi:trash-can"
+    dps:
+      - id: 124
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 15
+  # DPS 125 appears writable litter-level calibration on related models.
+  - entity: number
+    name: Litter calibration
+    category: config
+    icon: "mdi:grain"
+    dps:
+      - id: 125
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 6
+  - entity: switch
+    name: Auto deodorize
+    category: config
+    icon: "mdi:flower"
+    dps:
+      - id: 126
+        type: boolean
+        name: switch
+  - entity: number
+    name: Detection sensitivity
+    class: weight
+    category: config
+    icon: "mdi:scale"
+    dps:
+      - id: 127
+        type: integer
+        name: value
+        unit: g
+        range:
+          min: 600
+          max: 1500
+        mapping:
+          - step: 100
+  # DPS 128 looks like firmware/build code
+  # from observed value pattern, not live measurement.
+  - entity: sensor
+    name: Firmware build code
+    icon: "mdi:chip"
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 128
+        type: integer
+        name: sensor


### PR DESCRIPTION
Adds dedicated support for the Tonepie T1Pro smart cat litter box (`swrzomblcz1can76`) with a new device YAML.

Changes include:

* improved entity naming and semantics
* better separation between buttons, switches, sensors and diagnostic entities
* hidden diagnostic entities for uncertain/internal DPS values
* proper units and categories for several entities
* exact product_id matching for the new v3 device definition

All tests and lint checks pass.
