### PR TITLE
Add SNRE battery and Rinnai heat pump water heater profiles

### DIFF
--- a/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
@@ -40,32 +40,22 @@ entities:
         type: boolean
         name: switch
   - entity: lock
-    name: Child lock
+    translation_key: child_lock
     dps:
       - id: 12
         type: boolean
         name: lock
   - entity: sensor
     name: Operating state
+    category: diagnostic
     dps:
       - id: 8
         type: string
         name: sensor
   - entity: sensor
-    name: Unknown 1 DP18
-    dps:
-      - id: 18
-        type: integer
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 2 DP106
-    dps:
-      - id: 106
-        type: boolean
-        name: sensor
-  - entity: sensor
-    name: Ambient temperature DP101
+    name: Ambient temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 101
         type: integer
@@ -73,8 +63,9 @@ entities:
         unit: C
         class: measurement
   - entity: sensor
-    name: Tank temperature DP102
+    name: Tank temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 102
         type: integer
@@ -82,8 +73,9 @@ entities:
         unit: C
         class: measurement
   - entity: sensor
-    name: Temperature DP103
+    name: Discharge temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 103
         type: integer
@@ -91,8 +83,9 @@ entities:
         unit: C
         class: measurement
   - entity: sensor
-    name: Evaporator temperature DP104
+    name: Evaporator temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 104
         type: integer
@@ -100,8 +93,9 @@ entities:
         unit: C
         class: measurement
   - entity: sensor
-    name: Suction temperature DP105
+    name: Suction temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 105
         type: integer
@@ -110,6 +104,7 @@ entities:
         class: measurement
   - entity: sensor
     name: EEV opening
+    category: diagnostic
     dps:
       - id: 107
         type: integer
@@ -118,70 +113,25 @@ entities:
         class: measurement
   - entity: binary_sensor
     name: Fan
+    category: diagnostic
     dps:
       - id: 108
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 3 DP109
-    dps:
-      - id: 109
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 4 DP110
-    dps:
-      - id: 110
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 5 DP111
-    dps:
-      - id: 111
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 6 DP112
-    dps:
-      - id: 112
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 7 DP113
-    dps:
-      - id: 113
         type: boolean
         name: sensor
   - entity: sensor
     name: Mains voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 114
         type: integer
         name: sensor
         unit: V
         class: measurement
-  - entity: binary_sensor
-    name: Unknown 8 DP115
-    dps:
-      - id: 115
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 9 DP116
-    dps:
-      - id: 116
-        type: boolean
-        name: sensor
-  - entity: binary_sensor
-    name: Unknown 10 DP117
-    dps:
-      - id: 117
-        type: boolean
-        name: sensor
   - entity: sensor
     name: Compressor operation hours
     class: duration
+    category: diagnostic
     dps:
       - id: 118
         type: integer
@@ -191,15 +141,10 @@ entities:
   - entity: sensor
     name: Unit on hours
     class: duration
+    category: diagnostic
     dps:
       - id: 119
         type: integer
         name: sensor
         unit: h
         class: total_increasing
-  - entity: sensor
-    name: Firmware version
-    dps:
-      - id: 120
-        type: string
-        name: sensor

--- a/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
@@ -5,23 +5,22 @@ products:
     model: Heat pump hot water system
 entities:
   - entity: water_heater
-    name: Rinnai heat pump
     dps:
       - id: 2
         type: string
         name: operation_mode
         mapping:
           - dps_val: STANDARD
-            value: Standard
+            value: heat_pump
             default: true
           - dps_val: ECO
-            value: Eco
+            value: eco
           - dps_val: HYBRID
-            value: Hybrid
+            value: performance
           - dps_val: ELECTRIC
-            value: Electric
+            value: electric
           - dps_val: VACATION
-            value: Vacation
+            value: away
       - id: 3
         type: integer
         name: current_temperature
@@ -113,13 +112,13 @@ entities:
         class: measurement
   - entity: binary_sensor
     name: Fan
+    class: running
     category: diagnostic
     dps:
       - id: 108
         type: boolean
         name: sensor
   - entity: sensor
-    name: Mains voltage
     class: voltage
     category: diagnostic
     dps:
@@ -129,7 +128,7 @@ entities:
         unit: V
         class: measurement
   - entity: sensor
-    name: Compressor operation hours
+    name: Compressor runtime
     class: duration
     category: diagnostic
     dps:
@@ -139,7 +138,7 @@ entities:
         unit: h
         class: total_increasing
   - entity: sensor
-    name: Unit on hours
+    name: Unit runtime
     class: duration
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
@@ -1,0 +1,205 @@
+name: Heat pump water heater
+products:
+  - id: svhcpdyj8gvgagyg
+    manufacturer: Rinnai
+    model: Heat pump hot water system
+entities:
+  - entity: water_heater
+    name: Rinnai heat pump
+    dps:
+      - id: 2
+        type: string
+        name: operation_mode
+        mapping:
+          - dps_val: STANDARD
+            value: Standard
+            default: true
+          - dps_val: ECO
+            value: Eco
+          - dps_val: HYBRID
+            value: Hybrid
+          - dps_val: ELECTRIC
+            value: Electric
+          - dps_val: VACATION
+            value: Vacation
+      - id: 3
+        type: integer
+        name: current_temperature
+        unit: C
+      - id: 5
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 25
+          max: 75
+  - entity: switch
+    name: Power
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+  - entity: lock
+    name: Child lock
+    dps:
+      - id: 12
+        type: boolean
+        name: lock
+  - entity: sensor
+    name: Operating state
+    dps:
+      - id: 8
+        type: string
+        name: sensor
+  - entity: sensor
+    name: Unknown 1 DP18
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 2 DP106
+    dps:
+      - id: 106
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Ambient temperature DP101
+    class: temperature
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Tank temperature DP102
+    class: temperature
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Temperature DP103
+    class: temperature
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Evaporator temperature DP104
+    class: temperature
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Suction temperature DP105
+    class: temperature
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: EEV opening
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        unit: steps
+        class: measurement
+  - entity: binary_sensor
+    name: Fan
+    dps:
+      - id: 108
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 3 DP109
+    dps:
+      - id: 109
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 4 DP110
+    dps:
+      - id: 110
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 5 DP111
+    dps:
+      - id: 111
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 6 DP112
+    dps:
+      - id: 112
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 7 DP113
+    dps:
+      - id: 113
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Mains voltage
+    class: voltage
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        unit: V
+        class: measurement
+  - entity: binary_sensor
+    name: Unknown 8 DP115
+    dps:
+      - id: 115
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 9 DP116
+    dps:
+      - id: 116
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Unknown 10 DP117
+    dps:
+      - id: 117
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Compressor operation hours
+    class: duration
+    dps:
+      - id: 118
+        type: integer
+        name: sensor
+        unit: h
+        class: total_increasing
+  - entity: sensor
+    name: Unit on hours
+    class: duration
+    dps:
+      - id: 119
+        type: integer
+        name: sensor
+        unit: h
+        class: total_increasing
+  - entity: sensor
+    name: Firmware version
+    dps:
+      - id: 120
+        type: string
+        name: sensor

--- a/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
+++ b/custom_components/tuya_local/devices/rinnai_heat_pump_water_heater.yaml
@@ -53,7 +53,7 @@ entities:
         type: string
         name: sensor
   - entity: sensor
-    name: Ambient temperature
+    translation_key: ambient_temperature
     class: temperature
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/snre_battery.yaml
+++ b/custom_components/tuya_local/devices/snre_battery.yaml
@@ -25,7 +25,6 @@ entities:
           - scale: 100
         class: measurement
   - entity: sensor
-    name: State of charge
     class: battery
     dps:
       - id: 103

--- a/custom_components/tuya_local/devices/snre_battery.yaml
+++ b/custom_components/tuya_local/devices/snre_battery.yaml
@@ -1,4 +1,4 @@
-name: SNRE battery
+name: Battery
 products:
   - id: l2ak4zqufuarm0j3
     manufacturer: SNRE

--- a/custom_components/tuya_local/devices/snre_battery.yaml
+++ b/custom_components/tuya_local/devices/snre_battery.yaml
@@ -1,0 +1,331 @@
+name: SNRE battery
+products:
+  - id: l2ak4zqufuarm0j3
+    manufacturer: SNRE
+    model: Battery module
+entities:
+  - entity: sensor
+    name: Current
+    class: current
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: A
+        mapping:
+          - scale: 100
+        class: measurement
+  - entity: sensor
+    name: Voltage
+    class: voltage
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: V
+        mapping:
+          - scale: 100
+        class: measurement
+  - entity: sensor
+    name: State of charge
+    class: battery
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    name: Unknown 1 DP104
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        class: measurement
+  - entity: sensor
+    name: Remaining capacity
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: Ah
+        mapping:
+          - scale: 10
+        class: measurement
+  - entity: sensor
+    name: Capacity
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        unit: Ah
+        mapping:
+          - scale: 10
+        class: measurement
+  - entity: sensor
+    name: Unknown 2 DP107
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        class: measurement
+  - entity: sensor
+    name: Cycle count
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        class: total_increasing
+  - entity: sensor
+    name: Unknown 3 DP110
+    dps:
+      - id: 110
+        type: integer
+        name: sensor
+        class: measurement
+  - entity: sensor
+    name: Unknown 4 DP111
+    dps:
+      - id: 111
+        type: integer
+        name: sensor
+        class: measurement
+  - entity: sensor
+    name: Unknown 5 DP112
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+        class: measurement
+  - entity: sensor
+    name: Unknown 6 DP113
+    dps:
+      - id: 113
+        type: integer
+        name: sensor
+        class: measurement
+  - entity: sensor
+    name: Temperature 1 candidate
+    class: temperature
+    dps:
+      - id: 115
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+  - entity: sensor
+    name: Temperature 2 candidate
+    class: temperature
+    dps:
+      - id: 116
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+  - entity: sensor
+    name: Environment temperature
+    class: temperature
+    dps:
+      - id: 119
+        type: integer
+        name: sensor
+        unit: C
+        mapping:
+          - scale: 10
+        class: measurement
+  - entity: sensor
+    name: Cell 01 voltage
+    class: voltage
+    dps:
+      - id: 120
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 02 voltage
+    class: voltage
+    dps:
+      - id: 121
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 03 voltage
+    class: voltage
+    dps:
+      - id: 122
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 04 voltage
+    class: voltage
+    dps:
+      - id: 123
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 05 voltage
+    class: voltage
+    dps:
+      - id: 124
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 06 voltage
+    class: voltage
+    dps:
+      - id: 125
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 07 voltage
+    class: voltage
+    dps:
+      - id: 126
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 08 voltage
+    class: voltage
+    dps:
+      - id: 127
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 09 voltage
+    class: voltage
+    dps:
+      - id: 128
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 10 voltage
+    class: voltage
+    dps:
+      - id: 129
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 11 voltage
+    class: voltage
+    dps:
+      - id: 130
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 12 voltage
+    class: voltage
+    dps:
+      - id: 131
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 13 voltage
+    class: voltage
+    dps:
+      - id: 132
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 14 voltage
+    class: voltage
+    dps:
+      - id: 133
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 15 voltage
+    class: voltage
+    dps:
+      - id: 134
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement
+  - entity: sensor
+    name: Cell 16 voltage
+    class: voltage
+    dps:
+      - id: 135
+        type: integer
+        name: sensor
+        unit: V
+        precision: 2
+        mapping:
+          - scale: 1000
+        class: measurement

--- a/custom_components/tuya_local/devices/snre_battery.yaml
+++ b/custom_components/tuya_local/devices/snre_battery.yaml
@@ -36,14 +36,8 @@ entities:
         unit: "%"
         class: measurement
   - entity: sensor
-    name: Unknown 1 DP104
-    dps:
-      - id: 104
-        type: integer
-        name: sensor
-        class: measurement
-  - entity: sensor
     name: Remaining capacity
+    category: diagnostic
     dps:
       - id: 105
         type: integer
@@ -54,6 +48,7 @@ entities:
         class: measurement
   - entity: sensor
     name: Capacity
+    category: diagnostic
     dps:
       - id: 106
         type: integer
@@ -63,50 +58,17 @@ entities:
           - scale: 10
         class: measurement
   - entity: sensor
-    name: Unknown 2 DP107
-    dps:
-      - id: 107
-        type: integer
-        name: sensor
-        class: measurement
-  - entity: sensor
     name: Cycle count
+    category: diagnostic
     dps:
       - id: 109
         type: integer
         name: sensor
         class: total_increasing
   - entity: sensor
-    name: Unknown 3 DP110
-    dps:
-      - id: 110
-        type: integer
-        name: sensor
-        class: measurement
-  - entity: sensor
-    name: Unknown 4 DP111
-    dps:
-      - id: 111
-        type: integer
-        name: sensor
-        class: measurement
-  - entity: sensor
-    name: Unknown 5 DP112
-    dps:
-      - id: 112
-        type: integer
-        name: sensor
-        class: measurement
-  - entity: sensor
-    name: Unknown 6 DP113
-    dps:
-      - id: 113
-        type: integer
-        name: sensor
-        class: measurement
-  - entity: sensor
-    name: Temperature 1 candidate
+    name: Battery temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 115
         type: integer
@@ -116,8 +78,9 @@ entities:
           - scale: 10
         class: measurement
   - entity: sensor
-    name: Temperature 2 candidate
+    name: MOS temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 116
         type: integer
@@ -129,6 +92,7 @@ entities:
   - entity: sensor
     name: Environment temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 119
         type: integer
@@ -140,6 +104,7 @@ entities:
   - entity: sensor
     name: Cell 01 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 120
         type: integer
@@ -152,6 +117,7 @@ entities:
   - entity: sensor
     name: Cell 02 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 121
         type: integer
@@ -164,6 +130,7 @@ entities:
   - entity: sensor
     name: Cell 03 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 122
         type: integer
@@ -176,6 +143,7 @@ entities:
   - entity: sensor
     name: Cell 04 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 123
         type: integer
@@ -188,6 +156,7 @@ entities:
   - entity: sensor
     name: Cell 05 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 124
         type: integer
@@ -200,6 +169,7 @@ entities:
   - entity: sensor
     name: Cell 06 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 125
         type: integer
@@ -212,6 +182,7 @@ entities:
   - entity: sensor
     name: Cell 07 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 126
         type: integer
@@ -224,6 +195,7 @@ entities:
   - entity: sensor
     name: Cell 08 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 127
         type: integer
@@ -236,6 +208,7 @@ entities:
   - entity: sensor
     name: Cell 09 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 128
         type: integer
@@ -248,6 +221,7 @@ entities:
   - entity: sensor
     name: Cell 10 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 129
         type: integer
@@ -260,6 +234,7 @@ entities:
   - entity: sensor
     name: Cell 11 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 130
         type: integer
@@ -272,6 +247,7 @@ entities:
   - entity: sensor
     name: Cell 12 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 131
         type: integer
@@ -284,6 +260,7 @@ entities:
   - entity: sensor
     name: Cell 13 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 132
         type: integer
@@ -296,6 +273,7 @@ entities:
   - entity: sensor
     name: Cell 14 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 133
         type: integer
@@ -308,6 +286,7 @@ entities:
   - entity: sensor
     name: Cell 15 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 134
         type: integer
@@ -320,6 +299,7 @@ entities:
   - entity: sensor
     name: Cell 16 voltage
     class: voltage
+    category: diagnostic
     dps:
       - id: 135
         type: integer

--- a/custom_components/tuya_local/devices/snre_battery.yaml
+++ b/custom_components/tuya_local/devices/snre_battery.yaml
@@ -5,7 +5,6 @@ products:
     model: Battery module
 entities:
   - entity: sensor
-    name: Current
     class: current
     dps:
       - id: 101
@@ -16,7 +15,6 @@ entities:
           - scale: 100
         class: measurement
   - entity: sensor
-    name: Voltage
     class: voltage
     dps:
       - id: 102


### PR DESCRIPTION
## Summary
- Add an SNRE battery module profile with current, voltage, SoC, capacity, temperatures, cycle count, unknown diagnostics, and 16 cell voltage sensors.
- Add a Rinnai heat pump water heater profile with power, operation mode, target/current temperature, child lock, telemetry sensors, and unknown diagnostics.

## Notes
- Profiles were built from live local Tuya DPS dumps from the devices.
- Some diagnostic DPS remain intentionally labelled as unknown until their meaning is confirmed.