### PR TITLE
Add Tuya W-2839 water quality monitor config

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1289,6 +1289,7 @@ port and password.
 - PGST PA-010 indoor temperature and humidity sensor
 - PH-W218 water quality monitor
 - Pinjia PJ3101A presence sensor
+- W-2839 water quality monitor
 - PlantsIO Ivy and Ivy Gen2 smart planters
 - PNI Sofe House Smart Gas 300 alarm
 - Prodotec PT02 air quality monitor

--- a/custom_components/tuya_local/devices/w2839_pool_monitor.yaml
+++ b/custom_components/tuya_local/devices/w2839_pool_monitor.yaml
@@ -1,0 +1,121 @@
+name: Water quality monitor
+products:
+  - id: muwcszgae41ccndk
+    model: W-2839
+entities:
+  - entity: sensor
+    class: temperature
+    icon: "mdi:water-thermometer"
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: ph
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        class: measurement
+        mapping:
+          - scale: 100
+          - dps_val: 1500
+            value: null
+  - entity: sensor
+    name: Oxidation reduction potential
+    icon: "mdi:virus-off"
+    dps:
+      - id: 131
+        type: integer
+        name: sensor
+        unit: mV
+        class: measurement
+        optional: true
+  - entity: number
+    translation_key: maximum_temperature
+    class: temperature
+    category: config
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        unit: C
+        optional: true
+        range:
+          min: -100
+          max: 1100
+        mapping:
+          - scale: 10
+  - entity: number
+    translation_key: minimum_temperature
+    class: temperature
+    category: config
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        unit: C
+        optional: true
+        range:
+          min: -100
+          max: 1100
+        mapping:
+          - scale: 10
+  - entity: number
+    name: Maximum pH
+    class: ph
+    category: config
+    dps:
+      - id: 107
+        type: integer
+        name: value
+        optional: true
+        range:
+          min: 0
+          max: 1500
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Minimum pH
+    class: ph
+    category: config
+    dps:
+      - id: 108
+        type: integer
+        name: value
+        optional: true
+        range:
+          min: 0
+          max: 1500
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Maximum ORP
+    category: config
+    icon: "mdi:virus-off"
+    dps:
+      - id: 132
+        type: integer
+        name: value
+        unit: mV
+        optional: true
+        range:
+          min: -2000
+          max: 2000
+  - entity: number
+    name: Minimum ORP
+    category: config
+    icon: "mdi:virus-off"
+    dps:
+      - id: 133
+        type: integer
+        name: value
+        unit: mV
+        optional: true
+        range:
+          min: -2000
+          max: 2000


### PR DESCRIPTION
## Proposed change

Add device configuration for the Tuya W-2839 water quality monitor / WiFi Online Control Monitor.

This is a 3-in-1 pool/aquarium water quality monitor that reports:

- temperature on DP 8, scaled by 10
- pH on DP 106, scaled by 100
- oxidation reduction potential (ORP/redox) on DP 131 in mV

It also exposes the device warning thresholds as config number entities:

- high/low temperature warnings on DPs 102/103, scaled by 10
- high/low pH warnings on DPs 107/108, scaled by 100
- high/low ORP warnings on DPs 132/133 in mV

Tested with product ID `muwcszgae41ccndk` using protocol version 3.3.

The existing `phw218_waterquality_monitor` config does not match this device because the W-2839 only reports the three measurement datapoints above by default, while the PH-W218 config expects additional required datapoints.

## Device diagnostics

Initial Local Tuya diagnostics showed the following cached state:

```json
{
  "8": 116,
  "106": 704,
  "131": -3
}
```

After setting warning thresholds, the device reported:

```json
{
  "8": 116,
  "102": 350,
  "103": 210,
  "106": 701,
  "107": 1500,
  "108": 0,
  "131": 546,
  "132": 2000,
  "133": -2000
}
```

Home Assistant entities created and tested:

- temperature: `11.6 °C`
- pH: `7.04`
- ORP: `546 mV`
- high/low temperature warning numbers
- high/low pH warning numbers
- high/low ORP warning numbers

The threshold number writes were verified against the Tuya app.

## Type of change

- [x] Add new device configuration
- [x] Update supported devices list

## Checklist

- [x] The device configuration validates with `yamllint`
- [x] `pytest tests/test_device_config.py` passes
