### PR TITLE
Add Geeni WW117 Smart Plug to simple_switch_timerv2.yaml

### DIFF
--- a/custom_components/tuya_local/devices/simple_switch_timerv2.yaml
+++ b/custom_components/tuya_local/devices/simple_switch_timerv2.yaml
@@ -3,6 +3,9 @@ products:
   - id: eetmtcempdyxgpx5
     manufacturer: Nexxt
     model: 220v smartplug
+  - id: eoyy79zjaco4j8c8   # https://mygeeni.com/products/geeni-gn-ww117-199-dot-smart-wi-fi-plug-pack-of-1-white
+    manufacturer: Geeni
+    model: WW117 Smart Plug
   - id: 45gg9a0jfyzj1z1d
     name: Mini smart switch
   - id: qlrnevw57ezct7ta

--- a/custom_components/tuya_local/devices/simple_switch_timerv2.yaml
+++ b/custom_components/tuya_local/devices/simple_switch_timerv2.yaml
@@ -3,7 +3,8 @@ products:
   - id: eetmtcempdyxgpx5
     manufacturer: Nexxt
     model: 220v smartplug
-  - id: eoyy79zjaco4j8c8   # https://mygeeni.com/products/geeni-gn-ww117-199-dot-smart-wi-fi-plug-pack-of-1-white
+  - id: eoyy79zjaco4j8c8
+    # https://mygeeni.com/products/geeni-gn-ww117-199-dot-smart-wi-fi-plug-pack-of-1-white
     manufacturer: Geeni
     model: WW117 Smart Plug
   - id: 45gg9a0jfyzj1z1d


### PR DESCRIPTION
Adds product ID `eoyy79zjaco4j8c8` to the existing simple_switch_timerv2.yaml. This device offers 3 DPs, which match the existing schema:

- DP 1 — switch (on/off)
- DP 9 — countdown timer (integer, 0–86400s)
- DP 38 — power-on state (on/off/memory)