### PR TITLE
Add mapping for code "0" and re-divine "class" to "state_class" for tonepie_t1pro_catlitterbox_max

### DIFF
--- a/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_max.yaml
+++ b/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_max.yaml
@@ -235,7 +235,7 @@ entities:
   - entity: sensor
     name: Total visits
     icon: "mdi:counter"
-    class: measurement
+    state_class: measurement
     category: diagnostic
     dps:
       - id: 7
@@ -253,7 +253,7 @@ entities:
         type: integer
         name: sensor
         unit: kg
-        class: measurement
+        state_class: measurement
         mapping:
           - scale: 1000
   # Duration of cat's last visit in seconds
@@ -265,7 +265,7 @@ entities:
         type: integer
         name: sensor
         unit: s
-        class: measurement
+        state_class: measurement
   # Current weight reading in kg
   - entity: sensor
     class: weight
@@ -274,7 +274,7 @@ entities:
         type: integer
         name: sensor
         unit: kg
-        class: measurement
+        state_class: measurement
         mapping:
           - scale: 1000
   # Internal temperature of device

--- a/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_max.yaml
+++ b/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_max.yaml
@@ -316,6 +316,8 @@ entities:
         name: event
         persist: false
         mapping:
+          - dps_val: 0
+            value: "Normal"
           - dps_val: 1
             value: "Garbage Box Full"
           - dps_val: 2


### PR DESCRIPTION
The connection to my cats litter-box was unstable because of the missing mapping, after adding the mapping of code "0" the connection was stable again. The "class: measurement"change to "state_class: measurement" is just wanted by Home Assistant.
