### PR TITLE
fix: retry setup when device descriptor missing instead of permanent failure

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -922,8 +922,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.data[CONF_TYPE],
     )
     if device_conf is None:
-        _LOGGER.error(NOT_FOUND, config[CONF_TYPE])
-        return False
+        cleanup_failed_device(hass, device_id)
+        raise ConfigEntryNotReady(NOT_FOUND % config[CONF_TYPE])
 
     entities = set()
     for e in device_conf.all_entities():


### PR DESCRIPTION
### What happens

When the config flow for a `tuya_local` entry references a device descriptor that isn't currently present on disk (i.e. `get_config(entry.data[CONF_TYPE])` returns `None`), `async_setup_entry` at `custom_components/tuya_local/__init__.py:924-926` logs an error and `return False`s. This marks the config entry as permanent `setup_error` with no auto-retry. A manual reload (`homeassistant.reload_config_entry`) is required even after the descriptor file reappears.

The two other early-exit paths immediately above (`Exception` from `setup_device` / `device.async_refresh()`, and `not device.has_returned_state`) both raise `ConfigEntryNotReady` — Home Assistant's standard backoff retry then handles recovery automatically. The "descriptor not found" path is the outlier.

### When this surfaces in practice

After HACS updates the integration to a new version, HACS replaces the entire `custom_components/tuya_local/` tree, including the `devices/` subdir. Any user-maintained descriptors that live in `devices/` (e.g. added via a `cp` from `/config/custom_devices/` in a user automation) are wiped. On the post-update HA restart:

* All built-in descriptor types resume normally
* Any entries whose `type` is a user-supplied descriptor that hasn't yet been re-copied into `devices/` fail with `Configuration file for <type> not found` and end up in permanent `setup_error`

The user's `deploy_custom_devices_on_startup`-style automation typically restores the files 10-30 s after HA start, but by then it's too late — the entries are stuck and stay stuck across subsequent restarts until manually reloaded.

### Why `ConfigEntryNotReady` is the right exception here

Same reasoning as the device-offline path: this is a transient condition. The file may appear later in the same boot (deploy automation, HACS re-install of a separate add-on), the next boot (user manually restores), or on the next reload. There's no reason to require manual operator intervention for a condition that often self-resolves within 30 s.

### Proposed change

```python
if device_conf is None:
    cleanup_failed_device(hass, device_id)
    raise ConfigEntryNotReady(NOT_FOUND % config[CONF_TYPE])
```

(Matches the style + cleanup behavior of the two adjacent error paths. Reuses the existing `NOT_FOUND` format string.)

### Scope

Only `async_setup_entry`. The similar `_LOGGER.error(NOT_FOUND, …) + return False` patterns in `async_migrate_entry` (~line 195) and `async_unload_entry` (~line 950) have different semantics (migration retry / unload blocking) and are intentionally left alone.

### Real-world incident

Observed 2026-05-16 22:08:46 CDT after HACS auto-updated tuya_local to 2026.5.1 on a homelab with 3 custom-descriptor entries (two `greenhouse_mister` switches + one `globe_g1_litterbox`). All three went to `unavailable` and stayed there until each was manually reloaded the next morning. The `deploy_custom_devices_on_startup` automation restored the descriptor files ~30 s after HA start, well within the natural `ConfigEntryNotReady` backoff window — but the entries were already past the no-retry point.

### Will follow up with a PR

Branch ready at `festion/tuya-local:fix/descriptor-not-found-retry`. Will open the PR right after this issue.
