### PR TITLE
Add Tadiran Mini Central Inverter air conditioner

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -153,6 +153,7 @@
 - Sonnenkönig Fresco 140/180 air conditioner
 - Star-Light air conditioner (also confirmed to work with Polar branded devices)
 - Suntec Wellness Coolfixx portable air conditioner
+- Tadiran Mini Central Inverter air conditioner
 - Teknopoint Idra Skiv air conditioner
 - Tesla Smart TAF and AUX series air conditioners
 - TroniTechnik Hellnar Klimagerät

--- a/custom_components/tuya_local/devices/tadiran_minicentral_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/tadiran_minicentral_airconditioner.yaml
@@ -1,0 +1,71 @@
+name: Air conditioner
+products:
+  - id: bf5bade910b5f06210fntj
+    manufacturer: Tadiran
+    model: Mini Central Inverter
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: cooling
+                value: cool
+              - dps_val: heating
+                value: heat
+              - dps_val: auto
+                value: heat_cool
+              - dps_val: drying
+                value: dry
+              - dps_val: fan
+                value: fan_only
+              - dps_val: fan_only
+                value: fan_only
+      - id: 2
+        name: temperature
+        type: integer
+        unit: C
+        range:
+          min: 16
+          max: 32
+      - id: 3
+        name: current_temperature
+        type: integer
+        mapping:
+          - scale: 10
+      - id: 4
+        name: mode
+        type: string
+        hidden: true
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: low
+            value: low
+          - dps_val: middle
+            value: medium
+          - dps_val: mid
+            value: medium
+          - dps_val: high
+            value: high
+          - dps_val: auto
+            value: auto
+  - entity: sensor
+    name: Outdoor temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 118
+        name: sensor
+        type: integer
+        unit: C
+        optional: true
+        mapping:
+          - scale: 10


### PR DESCRIPTION
## Summary

Adds local Tuya support for the **Tadiran Mini Central Inverter** air conditioner, an inverter-driven mini-central HVAC unit popular in the Israeli market.

This device uses standard Tuya AC DPs 1-5 but with Tadiran-specific values that no existing profile handled — debugging an AC that showed up as `state: unknown` led me to create a new config.

## DP differences from common Tuya AC profiles

| DP | Common values | Tadiran values |
|----|---------------|----------------|
| 4 (mode) | `cold`/`hot`/`wet`/`wind` | `cooling`/`heating`/`drying`/`fan` |
| 5 (fan_mode) | `mid` | `middle` |
| 3 (current_temperature) | int (raw °C) | int × 10 (235 = 23.5°C) |

## Diagnostics

Raw DP dump from a working device (tinytuya-style `cached_state`):

```json
{
  "1": true,
  "2": 22,
  "3": 235,
  "4": "cooling",
  "5": "middle",
  "101": 235, "102": 235, "103": 235,
  "104": 6, "105": "Middle", "106": true,
  "107": "Cool", "108": "Off", "109": 0,
  "110": 370, "111": 275, "112": 270, "113": 275,
  "114": 380, "115": 260, "116": 0, "117": 0,
  "118": 228, "119": 350,
  "122": 0, "123": 0, "124": 0
}
```

Notes on the 100-series DPs:
- 101-103 mirror DP3 (likely secondary current_temperature readings)
- 105 / 107 / 108 appear to be capitalized duplicates of 5 / 4 / 9 — perhaps the Tadiran/manufacturer app reads from these
- 110-119 look like assorted temperature/sensor readings (zone temps? coil temps? compressor frequency?) — values consistent with `÷10` scale
- 118 reads 22.8°C consistently with outdoor temperature, exposed as a diagnostic sensor in this PR
- 122-124 are always 0 in observation

I haven't decoded the rest with confidence and didn't want to guess. If you'd like me to dig into specific DPs (or expose 101-103 as additional temperature sensors), happy to iterate.

## Test plan

- [x] Loaded YAML, integration sets up cleanly
- [x] `state` correctly reflects HVAC mode (`cool` while running)
- [x] `current_temperature` displays correctly scaled (was showing 235, now 23.5)
- [x] `fan_mode` mapping works (was raw `middle`, now `medium` per HA convention)
- [x] Target temperature setting via HA changes DP2 and the unit responds
- [x] Power on/off via DP1 works
- [x] Outdoor temperature sensor (DP118) reads sensibly

## Notes for reviewer

- File named `tadiran_minicentral_airconditioner.yaml` to match `<manufacturer>_<model>_airconditioner.yaml` convention
- DEVICES.md entry inserted alphabetically in the air conditioner section
- Product ID is from a single physical unit; happy to add more IDs if other Tadiran owners chime in