### PR TITLE
fix(cleanair_ca702_dehumidifier): mark DP19 (water-tank fault) as optional

### DIFF
--- a/custom_components/tuya_local/devices/cleanair_ca702_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/cleanair_ca702_dehumidifier.yaml
@@ -58,12 +58,14 @@ entities:
       - id: 19
         type: bitfield
         name: sensor
+        optional: true
         mapping:
           - dps_val: 0
             value: false
           - value: true
       - id: 19
         type: bitfield
+        optional: true
         name: fault_code
   - entity: sensor
     class: temperature


### PR DESCRIPTION
## Summary
Mark DP19 (water-tank fault) as `optional: true` on both DP entries inside the `class: problem` binary_sensor block of `cleanair_ca702_dehumidifier.yaml`.

## Problem
The CA-702 firmware emits DP19 only on a real fault event (water tank full). On a clean device the discovery DPS poll omits DP19 entirely, so the strict-DPS matcher rejects the profile at config-flow time and the device falls back to a generic profile — in my case `desk_lamp` at 44%, despite the unique product_id `bgo09goklrcdwqg7` already being listed.

## Fix
Add `optional: true` to both DP-19 entries (`sensor` and `fault_code`) inside the existing binary_sensor block. When the device does emit DP19 (on a fault) the entity still functions normally; when DP19 is absent, the profile is no longer disqualified from matching.

This follows the upstream convention already used for the same fault-DP shape on `eeese_anna_dehumidifier.yaml` (also DP19), `arida_s7l2_dehumidifier.yaml` and `breville_lad208_dehumidifier.yaml` (DP11).

## Regression risk
Low: the CA-702 has a unique product_id (`bgo09goklrcdwqg7`), so the change only affects the DPS-fallback matching path for devices that don't match by product_id.

## Device info
- Device: Clean Air Optima CA-702 Smart
- Product ID: `bgo09goklrcdwqg7`
- Discovery DPS (DP19 absent): `{"1": false, "2": "auto", "3": 60, "4": 50, "5": false, "10": false, "16": false, "103": 18, "104": false}`

## Testing
- `uv run yamllint custom_components/tuya_local/devices/cleanair_ca702_dehumidifier.yaml` — clean
- `uv run pytest tests/test_device_config.py` — 32/32 pass
- `uv run ruff check .`, `uv run ruff check --select I .`, `uv run ruff format --check .` — clean