### PR TITLE
Touchstone Sideline electric fireplace Red Blue variant

### DIFF
--- a/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
@@ -15,6 +15,28 @@ entities:
   - entity: climate
     name: Heater
     dps:
+      - id: 2
+        name: temperature
+        type: integer
+        range:
+          min: 16
+          max: 31
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: "f"
+                range:
+                  min: 60
+                  max: 88
+                value_redirect: temp_set_f
+      - id: 3
+        name: current_temperature
+        type: integer
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: "f"
+                value_redirect: temp_current_f
       - id: 5
         type: string
         name: hvac_mode
@@ -22,9 +44,26 @@ entities:
           - dps_val: "0"
             value: "off"
           - dps_val: "1"
-            value: "heat"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: "heat"
+              - dps_val: true
+                value: "fan_only"
           - dps_val: "2"
-            value: "heat"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: "heat"
+              - dps_val: true
+                value: "fan_only"
+          - dps_val: "3"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: "heat"
+              - dps_val: true
+                value: "fan_only"
       - id: 5
         type: string
         name: preset_mode
@@ -35,15 +74,8 @@ entities:
             value: "low"
           - dps_val: "2"
             value: "high"
-      - id: 14
-        type: integer
-        name: temperature
-        range:
-          min: 60
-          max: 88
-      - id: 15
-        type: integer
-        name: current_temperature
+          - dps_val: "3"
+            value: "auto"
       - id: 13
         type: string
         name: temperature_unit
@@ -52,6 +84,21 @@ entities:
             value: F
           - dps_val: "c"
             value: C
+      - id: 14
+        type: integer
+        name: temp_set_f
+        range:
+          min: 60
+          max: 88
+        hidden: true
+      - id: 15
+        name: temp_current_f
+        type: integer
+        hidden: true
+      - id: 107
+        type: boolean
+        name: heat_disable
+        hidden: true
 
   - entity: select
     name: Flame color
@@ -80,15 +127,15 @@ entities:
           - dps_val: "0"
             value: "Off"
           - dps_val: "1"
-            value: "1"
+            value: "20%"
           - dps_val: "2"
-            value: "2"
+            value: "40%"
           - dps_val: "3"
-            value: "3"
+            value: "60%"
           - dps_val: "4"
-            value: "4"
+            value: "80%"
           - dps_val: "5"
-            value: "5"
+            value: "100%"
 
   - entity: select
     name: Flame speed
@@ -155,15 +202,15 @@ entities:
           - dps_val: "L5"
             value: "Off"
           - dps_val: "L0"
-            value: "1"
+            value: "25%"
           - dps_val: "L1"
-            value: "2"
+            value: "50%"
           - dps_val: "L2"
-            value: "3"
+            value: "75%"
           - dps_val: "L3"
-            value: "4"
+            value: "100%"
           - dps_val: "L4"
-            value: "5"
+            value: "Pulsating"
 
   - entity: select
     name: Timer

--- a/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
@@ -1,8 +1,4 @@
-name: Touchstone Sideline electric fireplace
-products:
-  - id: pkgk72uonlqlzcil
-    manufacturer: Touchstone
-    model: Sideline (red/blue flame variant)
+name: Touchstone Sideline electric fireplace (red/blue version)
 entities:
   - entity: switch
     icon: "mdi:fireplace"
@@ -12,7 +8,7 @@ entities:
         name: switch
 
   - entity: climate
-    translation_key: heater
+    translation_key: Heater
     dps:
       - id: 2
         name: temperature
@@ -212,7 +208,7 @@ entities:
             value: "Pulsating"
 
   - entity: select
-    translation_key: timer
+    translation_key: Timer
     icon: "mdi:timer"
     category: config
     dps:

--- a/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
@@ -1,0 +1,198 @@
+name: Touchstone Sideline electric fireplace
+products:
+  - id: pkgk72uonlqlzcil
+    manufacturer: Touchstone
+    model: Sideline (red/blue flame variant)
+entities:
+  - entity: switch
+    translation_key: power
+    icon: "mdi:fireplace"
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+
+  - entity: climate
+    name: Heater
+    dps:
+      - id: 5
+        type: string
+        name: hvac_mode
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "heat"
+          - dps_val: "2"
+            value: "heat"
+      - id: 5
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: "0"
+            value: "none"
+          - dps_val: "1"
+            value: "low"
+          - dps_val: "2"
+            value: "high"
+      - id: 14
+        type: integer
+        name: temperature
+        range:
+          min: 60
+          max: 88
+      - id: 15
+        type: integer
+        name: current_temperature
+      - id: 13
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: "f"
+            value: F
+          - dps_val: "c"
+            value: C
+
+  - entity: select
+    name: Flame color
+    icon: "mdi:fire"
+    dps:
+      - id: 101
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "Red + Blue"
+          - dps_val: "2"
+            value: "Red"
+          - dps_val: "3"
+            value: "Blue"
+
+  - entity: select
+    name: Flame brightness
+    icon: "mdi:brightness-6"
+    category: config
+    dps:
+      - id: 102
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: "Off"
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+
+  - entity: select
+    name: Flame speed
+    icon: "mdi:speedometer"
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+
+  - entity: select
+    name: Ember color
+    icon: "mdi:campfire"
+    dps:
+      - id: 104
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+          - dps_val: "6"
+            value: "6"
+          - dps_val: "7"
+            value: "7"
+          - dps_val: "8"
+            value: "8"
+          - dps_val: "9"
+            value: "9"
+          - dps_val: "10"
+            value: "10"
+          - dps_val: "11"
+            value: "11"
+          - dps_val: "12"
+            value: "12"
+
+  - entity: select
+    name: Ember brightness
+    icon: "mdi:brightness-7"
+    category: config
+    dps:
+      - id: 109
+        type: string
+        name: option
+        mapping:
+          - dps_val: "L5"
+            value: "Off"
+          - dps_val: "L0"
+            value: "1"
+          - dps_val: "L1"
+            value: "2"
+          - dps_val: "L2"
+            value: "3"
+          - dps_val: "L3"
+            value: "4"
+          - dps_val: "L4"
+            value: "5"
+
+  - entity: select
+    name: Timer
+    icon: "mdi:timer"
+    category: config
+    dps:
+      - id: 106
+        type: string
+        name: option
+        mapping:
+          - dps_val: "cancel"
+            value: "Cancel"
+          - dps_val: "0"
+            value: "Cancel"
+          - dps_val: "30"
+            value: "30m"
+          - dps_val: "1H"
+            value: "1h"
+          - dps_val: "2H"
+            value: "2h"
+          - dps_val: "3H"
+            value: "3h"
+          - dps_val: "4H"
+            value: "4h"
+          - dps_val: "5H"
+            value: "5h"
+          - dps_val: "6H"
+            value: "6h"
+          - dps_val: "7H"
+            value: "7h"
+          - dps_val: "8H"
+            value: "8h"

--- a/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sideline_v2_fireplace.yaml
@@ -5,7 +5,6 @@ products:
     model: Sideline (red/blue flame variant)
 entities:
   - entity: switch
-    translation_key: power
     icon: "mdi:fireplace"
     dps:
       - id: 1
@@ -13,7 +12,7 @@ entities:
         name: switch
 
   - entity: climate
-    name: Heater
+    translation_key: heater
     dps:
       - id: 2
         name: temperature
@@ -213,7 +212,7 @@ entities:
             value: "Pulsating"
 
   - entity: select
-    name: Timer
+    translation_key: timer
     icon: "mdi:timer"
     category: config
     dps:

--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -1,6 +1,7 @@
 name: Electric fireplace
 entities:
   - entity: climate
+    translation_key: heater
     dps:
       - id: 1
         type: boolean

--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -1,17 +1,23 @@
-name: Touchstone Sideline electric fireplace (red/blue version)
+name: Electric fireplace
 entities:
-  - entity: switch
-    icon: "mdi:fireplace"
+  - entity: climate
     dps:
       - id: 1
         type: boolean
-        name: switch
-
-  - entity: climate
-    translation_key: Heater
-    dps:
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: heat
+              - dps_val: true
+                value: fan_only
       - id: 2
         name: temperature
+        optional: true
         type: integer
         range:
           min: 16
@@ -19,7 +25,7 @@ entities:
         mapping:
           - constraint: temperature_unit
             conditions:
-              - dps_val: "f"
+              - dps_val: f
                 range:
                   min: 60
                   max: 88
@@ -30,78 +36,80 @@ entities:
         mapping:
           - constraint: temperature_unit
             conditions:
-              - dps_val: "f"
+              - dps_val: f
                 value_redirect: temp_current_f
       - id: 5
-        type: string
-        name: hvac_mode
-        mapping:
-          - dps_val: "0"
-            value: "off"
-          - dps_val: "1"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: "heat"
-              - dps_val: true
-                value: "fan_only"
-          - dps_val: "2"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: "heat"
-              - dps_val: true
-                value: "fan_only"
-          - dps_val: "3"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: "heat"
-              - dps_val: true
-                value: "fan_only"
-      - id: 5
-        type: string
         name: preset_mode
+        type: string
         mapping:
           - dps_val: "0"
-            value: "none"
+            value: none
           - dps_val: "1"
-            value: "low"
+            value: low
           - dps_val: "2"
-            value: "high"
+            value: high
           - dps_val: "3"
-            value: "auto"
+            value: auto
       - id: 13
-        type: string
         name: temperature_unit
+        type: string
         mapping:
-          - dps_val: "f"
-            value: F
-          - dps_val: "c"
+          - dps_val: c
             value: C
+          - dps_val: f
+            value: F
       - id: 14
-        type: integer
         name: temp_set_f
+        type: integer
+        optional: true
+        hidden: true
         range:
           min: 60
           max: 88
-        hidden: true
       - id: 15
         name: temp_current_f
         type: integer
+        optional: true
         hidden: true
       - id: 107
         type: boolean
         name: heat_disable
         hidden: true
-
   - entity: select
-    name: Flame color
-    icon: "mdi:fire"
+    translation_key: temperature_unit
+    category: config
     dps:
-      - id: 101
+      - id: 13
         type: string
         name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+  - entity: light
+    translation_key: flame
+    category: config
+    dps:
+      - id: 102
+        name: brightness
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: 0
+          - dps_val: "1"
+            value: 51
+          - dps_val: "2"
+            value: 102
+          - dps_val: "3"
+            value: 153
+          - dps_val: "4"
+            value: 204
+          - dps_val: "5"
+            value: 255
+      - id: 101
+        name: effect
+        type: string
         mapping:
           - dps_val: "1"
             value: "Red + Blue"
@@ -109,29 +117,6 @@ entities:
             value: "Red"
           - dps_val: "3"
             value: "Blue"
-
-  - entity: select
-    name: Flame brightness
-    icon: "mdi:brightness-6"
-    category: config
-    dps:
-      - id: 102
-        type: string
-        name: option
-        mapping:
-          - dps_val: "0"
-            value: "Off"
-          - dps_val: "1"
-            value: "20%"
-          - dps_val: "2"
-            value: "40%"
-          - dps_val: "3"
-            value: "60%"
-          - dps_val: "4"
-            value: "80%"
-          - dps_val: "5"
-            value: "100%"
-
   - entity: select
     name: Flame speed
     icon: "mdi:speedometer"
@@ -151,65 +136,72 @@ entities:
             value: "4"
           - dps_val: "5"
             value: "5"
-
-  - entity: select
-    name: Ember color
-    icon: "mdi:campfire"
-    dps:
-      - id: 104
-        type: string
-        name: option
-        mapping:
-          - dps_val: "1"
-            value: "1"
-          - dps_val: "2"
-            value: "2"
-          - dps_val: "3"
-            value: "3"
-          - dps_val: "4"
-            value: "4"
-          - dps_val: "5"
-            value: "5"
-          - dps_val: "6"
-            value: "6"
-          - dps_val: "7"
-            value: "7"
-          - dps_val: "8"
-            value: "8"
-          - dps_val: "9"
-            value: "9"
-          - dps_val: "10"
-            value: "10"
-          - dps_val: "11"
-            value: "11"
-          - dps_val: "12"
-            value: "12"
-
-  - entity: select
-    name: Ember brightness
-    icon: "mdi:brightness-7"
+  - entity: light
+    translation_key: embers
     category: config
     dps:
       - id: 109
+        name: brightness
         type: string
-        name: option
+        optional: true
         mapping:
-          - dps_val: "L5"
-            value: "Off"
-          - dps_val: "L0"
-            value: "25%"
-          - dps_val: "L1"
-            value: "50%"
-          - dps_val: "L2"
-            value: "75%"
-          - dps_val: "L3"
-            value: "100%"
-          - dps_val: "L4"
-            value: "Pulsating"
-
+          - dps_val: L5
+            value: 0
+          - dps_val: L0
+            value: 51
+          - dps_val: L1
+            value: 102
+          - dps_val: L2
+            value: 153
+          - dps_val: L3
+            value: 204
+          - dps_val: L4
+            value: 255
+          - dps_val: null
+            value: 0
+            hidden: true
+      - id: 104
+        name: named_color
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: orange
+          - dps_val: "2"
+            value: red
+          - dps_val: "3"
+            value: blue
+          - dps_val: "4"
+            value: yellow
+          - dps_val: "5"
+            value: green
+          - dps_val: "6"
+            value: purple
+          - dps_val: "7"
+            value: teal
+          - dps_val: "8"
+            value: pink
+          - dps_val: "9"
+            value: white
+          - dps_val: "10"
+            value: peachpuff
+          - dps_val: "11"
+            value: black
+          - dps_val: "12"
+            value: grey
+      - id: 104
+        name: effect
+        type: string
+        mapping:
+          - dps_val: "12"
+            value: Mystery
+          - dps_val: "11"
+            value: Cycle
+          - dps_val: "1"
+            value: "off"
+          - value: "off"
+            hidden: true
   - entity: select
-    translation_key: Timer
-    icon: "mdi:timer"
+    translation_key: timer
     category: config
     dps:
       - id: 106
@@ -217,9 +209,10 @@ entities:
         name: option
         mapping:
           - dps_val: "cancel"
-            value: "Cancel"
+            value: "cancel"
           - dps_val: "0"
-            value: "Cancel"
+            value: "cancel"
+            hidden: true
           - dps_val: "30"
             value: "30m"
           - dps_val: "1H"
@@ -238,3 +231,10 @@ entities:
             value: "7h"
           - dps_val: "8H"
             value: "8h"
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 108
+        type: boolean
+        name: lock


### PR DESCRIPTION
Submitting touchstone sideline electric fireplace integration to solve https://github.com/make-all/tuya-local/issues/5071 #5071

The existing integration is for a different model with different features and different firmware. I have tested all of the features here and they work with the Red and blue flame variant.

If anything needs to be changed to be more inline with the repo feel free to!
