### PR TITLE
Add 'Normal' event mapping to tonepie_t1pro_catlitterbox_max

### DIFF
--- a/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_max.yaml
+++ b/custom_components/tuya_local/devices/tonepie_t1pro_catlitterbox_max.yaml
@@ -316,6 +316,8 @@ entities:
         name: event
         persist: false
         mapping:
+          - dps_val: 0
+            value: "Normal"
           - dps_val: 1
             value: "Garbage Box Full"
           - dps_val: 2


### PR DESCRIPTION
This event mapping (dps: 0: "Normal")  was missing witch was making the live connection between the litter-box and HA crash.
adding it resolves the bug.

          - dps_val: 0
            value: "Normal"