### PR TITLE
Adding support for PFC002HA Series 2

### DIFF
--- a/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
+++ b/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
@@ -69,14 +69,19 @@ entities:
   - entity: number
     translation_key: manual_feed
     dps:
-      - id: 203
+      - id: 201
         type: integer
         optional: true
         name: value
+        persist: false
         unit: portions
         range:
           min: 1
           max: 12
+        mapping:
+          - dps_val: null
+            value: 0
+            hidden: true
   - entity: sensor
     name: Feed result
     class: enum

--- a/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
+++ b/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
@@ -98,33 +98,6 @@ entities:
             value: 0
             hidden: true
   - entity: sensor
-    name: Feed result
-    class: enum
-    icon: "mdi:paw"
-    category: diagnostic
-    dps:
-      - id: 201
-        type: integer
-        optional: true
-        name: sensor
-        mapping:
-          - dps_val: -2001
-            value: failed
-          - dps_val: -2000
-            value: feeding
-          - dps_val: 2001
-            value: failed
-          - dps_val: 2000
-            value: feeding
-          - dps_val: 0
-            value: idle
-          - dps_val: null
-            value: idle
-      - id: 201
-        type: integer
-        optional: true
-        name: portions
-  - entity: sensor
     name: Portion size
     class: weight
     category: diagnostic

--- a/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
+++ b/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
@@ -1,0 +1,122 @@
+name: Camera pet feeder
+products:
+  - id: cmubbmrw5ibt5gkl
+    manufacturer: Arlec
+    model: PFC002HA Series 2
+entities:
+  - entity: switch
+    translation_key: flip_image
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: camera
+    dps:
+      - id: 115
+        type: base64
+        optional: true
+        name: snapshot
+        sensitive: true
+      - id: 134
+        type: boolean
+        name: motion_enable
+      - id: 150
+        type: boolean
+        name: record
+  - entity: select
+    translation_key: motion_sensitivity
+    category: config
+    dps:
+      - id: 106
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: low
+          - dps_val: "1"
+            value: medium
+          - dps_val: "2"
+            value: high
+  - entity: select
+    name: Night vision
+    icon: "mdi:weather-night"
+    category: config
+    dps:
+      - id: 108
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Auto
+          - dps_val: "1"
+            value: "Off"
+          - dps_val: "2"
+            value: "On"
+  - entity: select
+    name: Recording mode
+    icon: "mdi:file-video"
+    category: config
+    dps:
+      - id: 151
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: Event
+          - dps_val: "2"
+            value: Continuous
+  - entity: number
+    translation_key: manual_feed
+    dps:
+      - id: 203
+        type: integer
+        optional: true
+        name: value
+        unit: portions
+        range:
+          min: 1
+          max: 12
+  - entity: sensor
+    name: Feed result
+    class: enum
+    icon: "mdi:paw"
+    category: diagnostic
+    dps:
+      - id: 201
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: -2001
+            value: failed
+          - dps_val: -2000
+            value: feeding
+          - dps_val: null
+            value: idle
+          - value: fed
+      - id: 201
+        type: integer
+        name: portions
+  - entity: sensor
+    name: Portion size
+    class: weight
+    category: diagnostic
+    dps:
+      - id: 202
+        type: integer
+        name: sensor
+        unit: g
+        class: measurement
+        range:
+          min: 1
+          max: 100
+        mapping:
+          - scale: 10
+  - entity: text
+    translation_key: schedule
+    category: config
+    hidden: true
+    dps:
+      - id: 207
+        type: string
+        name: value

--- a/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
+++ b/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
@@ -79,6 +79,21 @@ entities:
           min: 1
           max: 12
         mapping:
+          - dps_val: -2001
+            value: 0
+            hidden: true
+          - dps_val: -2000
+            value: 0
+            hidden: true
+          - dps_val: 2001
+            value: 0
+            hidden: true
+          - dps_val: 2000
+            value: 0
+            hidden: true
+          - dps_val: 0
+            value: 0
+            hidden: true
           - dps_val: null
             value: 0
             hidden: true
@@ -90,18 +105,44 @@ entities:
     dps:
       - id: 201
         type: integer
+        optional: true
         name: sensor
         mapping:
           - dps_val: -2001
             value: failed
           - dps_val: -2000
             value: feeding
+          - dps_val: 2001
+            value: failed
+          - dps_val: 2000
+            value: feeding
+          - dps_val: 0
+            value: idle
           - dps_val: null
             value: idle
           - value: fed
       - id: 201
         type: integer
+        optional: true
         name: portions
+  - entity: sensor
+    name: Realtime data
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 204
+        type: integer
+        optional: true
+        name: sensor
+  - entity: sensor
+    name: History data
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 208
+        type: integer
+        optional: true
+        name: sensor
   - entity: sensor
     name: Portion size
     class: weight

--- a/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
+++ b/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
@@ -107,9 +107,6 @@ entities:
         name: sensor
         unit: g
         class: measurement
-        range:
-          min: 1
-          max: 100
         mapping:
           - scale: 10
   - entity: text

--- a/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
+++ b/custom_components/tuya_local/devices/arlec_pfc002ha_petfeeder_camera.yaml
@@ -120,29 +120,10 @@ entities:
             value: idle
           - dps_val: null
             value: idle
-          - value: fed
       - id: 201
         type: integer
         optional: true
         name: portions
-  - entity: sensor
-    name: Realtime data
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 204
-        type: integer
-        optional: true
-        name: sensor
-  - entity: sensor
-    name: History data
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 208
-        type: integer
-        optional: true
-        name: sensor
   - entity: sensor
     name: Portion size
     class: weight


### PR DESCRIPTION
Adding support for PFC002HA Series 2 (Arlec grid connect 5L smart pet feeder with camera)

https://www.bunnings.com.au/arlec-5l-grid-connect-smart-pet-feeder-with-camera_p0397261

Potentially also adds support for Anko / Mirabella Genio 5L smart pet feeder with camera as they appear externally as the same device, however i do not have access to one to test

https://www.target.com.au/p/pet-feeder-with-camera-5l-anko/68955663

Initial support request #4491 ignored without much explanation, so did it myself. Devices builtin scheduler is trash and misses feeds so HA support is needed.