### PR TITLE
Update Meegeem Self-Cleaning Cat Litter Box DPS Definition

### DIFF
--- a/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
+++ b/custom_components/tuya_local/devices/meegeem_selfcleaningcatlitterbox.yaml
@@ -8,7 +8,7 @@ entities:
     class: enum
     dps:
       - id: 107
-        type: string
+        type: integer
         name: sensor
         mapping:
           - dps_val: 0
@@ -199,12 +199,12 @@ entities:
     class: problem
     dps:
       - id: 104
-        type: string
+        type: integer
         name: sensor
         mapping:
-          - dps_val: "0"
+          - dps_val: 0
             value: true
-          - dps_val: "1"
+          - dps_val: 1
             value: false
 
   - entity: sensor
@@ -223,10 +223,10 @@ entities:
     class: problem
     dps:
       - id: 106
-        type: string
+        type: integer
         name: sensor
         mapping:
-          - dps_val: "0"
+          - dps_val: 0
             value: true
-          - dps_val: "1"
+          - dps_val: 1
             value: false


### PR DESCRIPTION
Update DPS 104, 106, 107 from type: string to type: integer to enable matching during new device config.

Meegeem Self-Cleaning Cat Litter Box was "matching" to a number of switches with <30% confidence instead of matching to the proper device definition.  Some DPS types were defined as string but provided by the device as integer.  Making this change ensures a direct/high-confidence match during device configuration.