### PR TITLE
Add Gadnic AC800 robot vacuum support

### DIFF
--- a/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
+++ b/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
@@ -1,0 +1,371 @@
+name: Robot vacuum
+products:
+  - id: opn3uutjlhbeojab
+    manufacturer: Gadnic
+    model: AC800
+entities:
+  - entity: vacuum
+    dps:
+      - id: 1
+        type: boolean
+        name: activate
+      - id: 2
+        type: boolean
+        name: pause
+        optional: true
+      - id: 3
+        type: boolean
+        name: switch_charge
+        optional: true
+      - id: 4
+        type: string
+        name: command
+        optional: true
+        mapping:
+          - dps_val: goto_charge
+            value: return_to_base
+      - id: 5
+        type: string
+        name: status
+        mapping:
+          - dps_val: standby
+            value: idle
+          - dps_val: smart
+            value: cleaning
+          - dps_val: zone_clean
+            value: cleaning
+          - dps_val: part_clean
+            value: cleaning
+          - dps_val: cleaning
+            value: cleaning
+          - dps_val: paused
+            value: paused
+          - dps_val: goto_pos
+            value: cleaning
+          - dps_val: pos_arrived
+            value: idle
+          - dps_val: pos_unarrive
+            value: idle
+          - dps_val: goto_charge
+            value: returning
+          - dps_val: charging
+            value: docked
+          - dps_val: charge_done
+            value: docked
+          - dps_val: sleep
+            value: idle
+      - id: 9
+        type: string
+        name: fan_speed
+        mapping:
+          - dps_val: gentle
+            value: "off"
+          - dps_val: normal
+            value: medium
+          - dps_val: strong
+            value: high
+          - dps_val: max
+            value: maximum
+      - id: 12
+        type: string
+        name: direction_control
+        mapping:
+          - dps_val: forward
+            value: forward
+          - dps_val: backward
+            value: backward
+          - dps_val: turn_left
+            value: left
+          - dps_val: turn_right
+            value: right
+          - dps_val: stop
+            value: stop
+  - entity: switch
+    name: locate
+    icon: "mdi:map-marker-alert"
+    category: config
+    dps:
+      - id: 11
+        type: boolean
+        name: switch
+  - entity: select
+    translation_key: cleaning_mode
+    icon: "mdi:vacuum"
+    category: config
+    dps:
+      - id: 41
+        type: string
+        name: option
+        mapping:
+          - dps_val: both_work
+            value: sweep_and_mop
+          - dps_val: only_mop
+            value: mop
+          - dps_val: only_sweep
+            value: sweep
+  - entity: select
+    translation_key: mopping
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        mapping:
+          - dps_val: closed
+            value: "off"
+          - dps_val: low
+            value: low
+          - dps_val: middle
+            value: medium
+          - dps_val: high
+            value: high
+  - entity: number
+    translation_key: volume
+    category: config
+    dps:
+      - id: 26
+        type: integer
+        name: value
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: switch
+    translation_key: do_not_disturb
+    icon: "mdi:bell-cancel"
+    category: config
+    dps:
+      - id: 25
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Auto boost
+    icon: "mdi:car-turbocharger"
+    category: config
+    dps:
+      - id: 45
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Y-shape mop mode
+    category: config
+    dps:
+      - id: 48
+        type: boolean
+        name: switch
+  - entity: button
+    name: Collect dust
+    category: config
+    dps:
+      - id: 38
+        type: boolean
+        optional: true
+        name: button
+  - entity: switch
+    name: Continue cleaning at breakpoint
+    icon: "mdi:clock-star-four-points"
+    category: config
+    dps:
+      - id: 27
+        type: boolean
+        name: switch
+  - entity: select
+    name: Dust collection frequency
+    icon: "mdi:delete"
+    category: config
+    dps:
+      - id: 37
+        type: integer
+        name: option
+        mapping:
+          - dps_val: 0
+            value: "Never"
+          - dps_val: 1
+            value: "Once"
+          - dps_val: 2
+            value: "Twice"
+          - dps_val: 3
+            value: "Three times"
+          - dps_val: 4
+            value: "Four times"
+  - entity: switch
+    name: Custom mode
+    category: config
+    dps:
+      - id: 39
+        type: boolean
+        name: switch
+  # I couldn't find a way to get this mode to work directly from the vacuum card UI so I'm using a switch instead.
+  - entity: switch
+    name: Edge clean mode
+    category: config
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+  # same thing here
+  - entity: switch
+    name: Spiral clean mode
+    category: config
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+  - entity: button
+    name: Reset map
+    icon: "mdi:map-marker-remove"
+    category: config
+    dps:
+      - id: 13
+        type: boolean
+        name: button
+        optional: true
+  - entity: button
+    name: Reset roll brush
+    class: restart
+    category: config
+    dps:
+      - id: 20
+        type: boolean
+        name: button
+  - entity: button
+    translation_key: filter_reset
+    icon: "mdi:air-filter"
+    category: config
+    dps:
+      - id: 22
+        type: boolean
+        name: button
+  - entity: button
+    name: Reset side brush
+    class: restart
+    category: config
+    dps:
+      - id: 18
+        type: boolean
+        name: button
+  - entity: select
+    name: Fetch request
+    icon: "mdi:message-question"
+    category: config
+    dps:
+      - id: 16
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: get_map
+            value: Map
+          - dps_val: get_path
+            value: Path
+          - dps_val: get_both
+            value: Both
+  - entity: sensor
+    name: Cleaning time
+    icon: "mdi:progress-clock"
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: min
+  - entity: sensor
+    name: Cleaning area
+    class: area
+    category: diagnostic
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: m2
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    name: Side brush lifetime
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 17
+        type: integer
+        name: sensor
+        unit: h
+  - entity: sensor
+    name: Rolling brush lifetime
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 19
+        type: integer
+        name: sensor
+        unit: h
+  - entity: sensor
+    translation_key: filter_life
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        unit: h
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 28
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 28
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Total cleaning area
+    class: area
+    category: diagnostic
+    dps:
+      - id: 29
+        type: integer
+        name: sensor
+        unit: m2
+  - entity: sensor
+    name: Total cleaning times
+    icon: "mdi:counter"
+    category: diagnostic
+    dps:
+      - id: 30
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Total cleaning time
+    class: duration
+    icon: "mdi:history"
+    category: diagnostic
+    dps:
+      - id: 31
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    name: Mop installed
+    icon: "mdi:water-plus"
+    category: diagnostic
+    dps:
+      - id: 40
+        type: string
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: installed
+            value: true
+          - value: false

--- a/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
+++ b/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
@@ -195,7 +195,6 @@ entities:
       - id: 39
         type: boolean
         name: switch
-  # I couldn't find a way to get this mode to work directly from the vacuum card UI so I'm using a switch instead.
   - entity: switch
     name: Edge clean mode
     category: config
@@ -203,7 +202,6 @@ entities:
       - id: 101
         type: boolean
         name: switch
-  # same thing here
   - entity: switch
     name: Spiral clean mode
     category: config

--- a/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
+++ b/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
@@ -105,11 +105,11 @@ entities:
           - dps_val: stop
             value: stop
   - entity: switch
-    name: Locate
-    icon: "mdi:map-marker"
+    name: Charge control
+    icon: mdi:battery-charging
     category: config
     dps:
-      - id: 11
+      - id: 3
         type: boolean
         name: switch
   - entity: select

--- a/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
+++ b/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
@@ -13,17 +13,23 @@ entities:
         type: boolean
         name: pause
         optional: true
-      - id: 3
-        type: boolean
-        name: switch_charge
-        optional: true
       - id: 4
         type: string
         name: command
         optional: true
         mapping:
+          - dps_val: smart
+            value: smart
           - dps_val: goto_charge
             value: return_to_base
+          - dps_val: zone
+            value: zone
+          - dps_val: pose
+            value: clean_spot
+          - dps_val: part
+            value: partial
+          - dps_val: select_room
+            value: select_room
       - id: 5
         type: string
         name: status
@@ -49,11 +55,25 @@ entities:
           - dps_val: goto_charge
             value: returning
           - dps_val: charging
-            value: docked
+            value: charging
           - dps_val: charge_done
             value: docked
           - dps_val: sleep
-            value: idle
+            value: sleep
+          - dps_val: select_room
+            value: select_room
+          - dps_val: seek_dust_bucket
+            value: seek_dust_bucket
+          - dps_val: collecting_dust
+            value: collecting_dust
+          - dps_val: self_clean
+            value: self_clean
+          - dps_val: mapping
+            value: mapping
+          - dps_val: mapping_done
+            value: mapping_done
+          - dps_val: in_trouble
+            value: error
       - id: 9
         type: string
         name: fan_speed
@@ -66,6 +86,10 @@ entities:
             value: high
           - dps_val: max
             value: maximum
+      - id: 11
+        type: boolean
+        name: locate
+        optional: true
       - id: 12
         type: string
         name: direction_control
@@ -81,8 +105,8 @@ entities:
           - dps_val: stop
             value: stop
   - entity: switch
-    name: locate
-    icon: "mdi:map-marker-alert"
+    name: Locate
+    icon: "mdi:map-marker"
     category: config
     dps:
       - id: 11
@@ -132,7 +156,6 @@ entities:
           max: 100
   - entity: switch
     translation_key: do_not_disturb
-    icon: "mdi:bell-cancel"
     category: config
     dps:
       - id: 25

--- a/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
+++ b/custom_components/tuya_local/devices/gadnic_ac800_vacuum.yaml
@@ -106,7 +106,7 @@ entities:
             value: stop
   - entity: switch
     name: Charge control
-    icon: mdi:battery-charging
+    icon: "mdi:battery-charging"
     category: config
     dps:
       - id: 3
@@ -114,7 +114,6 @@ entities:
         name: switch
   - entity: select
     translation_key: cleaning_mode
-    icon: "mdi:vacuum"
     category: config
     dps:
       - id: 41
@@ -251,7 +250,6 @@ entities:
         name: button
   - entity: button
     translation_key: filter_reset
-    icon: "mdi:air-filter"
     category: config
     dps:
       - id: 22


### PR DESCRIPTION

## Summary

Adds support for the Gadnic AC800 robot vacuum.
The profile was created manually using the tuya developer platform and by configuring the propierties based on examples from other robot vacuums. Tested with the tuya_local integration and real hardware, I can confirm that it works correctly.

## Device details

- Manufacturer / brand: Gadnic
- Model: AC800
- Device type: Vacuum

## Tested features

### Configuration
- Auto-boost mode
- Collect dust button (activates the base dust collection feature)
- Custom mode switch
- Dust collection frequency
- Edge clean mode switch (uses its own dp_id in Tuya)
- Mop water volume adjustment selector
- Setting to resume cleaning from where the robot stopped during the last cleaning job
- Switch to locate the vacuum
- Cleaning mode selector
- Do Not Disturb switch
- Buttons to reset the map, rolling brush, side brush, and filter
- Spiral cleaning mode switch (uses its own dp_id in Tuya)
- Volume settings
- Y-pattern mopping mode

### Diagnostics

Battery, cleaned area, cleaning time, mop installed status, current status (including whether it has an issue), remaining rolling brush lifetime, remaining side brush lifetime, total cleaned area, total cleaning time, total cleaning sessions, and filter lifetime.

## Notes

The device profile was validated with real hardware. Home Assistant logs are clean and the entities are exposed correctly.