### PR TITLE
C500 improvements

### DIFF
--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -116,6 +116,7 @@ entities:
           - dps_val: medium
             value: unhealthy
   - entity: switch
+    translation_key: timer
     name: Timer
     category: config
     dps:

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -117,7 +117,7 @@ entities:
             value: severe
   - entity: switch
     name: Timer
-    icon: mdi:timer
+    icon: "mdi:timer"
     category: config
     dps:
       - id: 101

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -116,7 +116,6 @@ entities:
           - dps_val: medium
             value: unhealthy
   - entity: switch
-    translation_key: timer
     name: Timer
     category: config
     dps:

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -32,6 +32,26 @@ entities:
             value: 80
           - dps_val: max
             value: 100
+  # The fan speeds are reffered to as sleep,1,2,3,4 in he app but idk how to convert number into string so the code doesnt freak out
+  #I think a translation key is also needed
+  - entity: select
+  name: Fan Speed
+  icon: mdi:fan
+  dps:
+    - id: 4
+      type: string
+      name: option
+      mapping:
+        - dps_val: sleep
+          value: Sleep
+        - dps_val: low
+          value: Low
+        - dps_val: mid
+          value: Medium
+        - dps_val: high
+          value: High
+        - dps_val: max
+          value: Max
   - entity: sensor
     class: pm25
     dps:

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -114,7 +114,7 @@ entities:
           - dps_val: good
             value: poor
           - dps_val: medium
-            value: unhealthy
+            value: severe
   - entity: switch
     name: Timer
     icon: mdi:timer

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -32,26 +32,6 @@ entities:
             value: 80
           - dps_val: max
             value: 100
-  # The fan speeds are reffered to as sleep,1,2,3,4 in he app but idk how to convert number into string so the code doesnt freak out
-  #I think a translation key is also needed
-  - entity: select
-  name: Fan Speed
-  icon: mdi:fan
-  dps:
-    - id: 4
-      type: string
-      name: option
-      mapping:
-        - dps_val: sleep
-          value: Sleep
-        - dps_val: low
-          value: Low
-        - dps_val: mid
-          value: Medium
-        - dps_val: high
-          value: High
-        - dps_val: max
-          value: Max
   - entity: sensor
     class: pm25
     dps:

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -117,6 +117,7 @@ entities:
             value: unhealthy
   - entity: switch
     name: Timer
+    icon: mdi:timer
     category: config
     dps:
       - id: 101

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -59,7 +59,7 @@ entities:
         type: boolean
         name: lock
   - entity: light
-    translation_key: indicator
+    translation_key: display
     category: config
     dps:
       - id: 8

--- a/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/homemedics_c500_airpurifier.yaml
@@ -108,13 +108,13 @@ entities:
         name: sensor
         mapping:
           - dps_val: great
-            value: excellent
+            value: good
           - dps_val: mild
             value: moderate
           - dps_val: good
-            value: good
-          - dps_val: medium
             value: poor
+          - dps_val: medium
+            value: unhealthy
   - entity: switch
     name: Timer
     category: config

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -789,8 +789,8 @@
                     "moderate": "mdi:emoticon-neutral",
                     "poor": "mdi:emoticon-sad",
                     "severe": "mdi:emoticon-sick",
-                    "danger": "mdi:emoticon-dead",
                     "unhealthy": "mdi:emoticon-sick"
+                    "danger": "mdi:emoticon-dead",
                 }
             },
             "cooking_status": {

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -789,7 +789,6 @@
                     "moderate": "mdi:emoticon-neutral",
                     "poor": "mdi:emoticon-sad",
                     "severe": "mdi:emoticon-sick",
-                    "unhealthy": "mdi:emoticon-sick",
                     "danger": "mdi:emoticon-dead"
                 }
             },

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -789,8 +789,8 @@
                     "moderate": "mdi:emoticon-neutral",
                     "poor": "mdi:emoticon-sad",
                     "severe": "mdi:emoticon-sick",
-                    "unhealthy": "mdi:emoticon-sick"
-                    "danger": "mdi:emoticon-dead",
+                    "unhealthy": "mdi:emoticon-sick",
+                    "danger": "mdi:emoticon-dead"
                 }
             },
             "cooking_status": {

--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -789,7 +789,8 @@
                     "moderate": "mdi:emoticon-neutral",
                     "poor": "mdi:emoticon-sad",
                     "severe": "mdi:emoticon-sick",
-                    "danger": "mdi:emoticon-dead"
+                    "danger": "mdi:emoticon-dead",
+                    "unhealthy": "mdi:emoticon-sick"
                 }
             },
             "cooking_status": {


### PR DESCRIPTION
Heres what i did

1. changed mapping for the air quality entity
2. added unhealthy icon for air quality entities
3. added icon for the timer switch entity
4. added select entity for fan speed (was in xtend tuya)(got help from ai adding this)

The mappings i changed better reflect what is being shown in the tuya/smartlife app, and yes the dps val of good is actually "poor" in the app, most of these dps vals are inaccurate to what is actually displayed in the app.