### PR TITLE
Add Imaxfire AWA2 water vapor fireplace

### DIFF
--- a/custom_components/tuya_local/devices/imaxfire_awa2_fireplace.yaml
+++ b/custom_components/tuya_local/devices/imaxfire_awa2_fireplace.yaml
@@ -10,25 +10,12 @@ entities:
       - id: 20
         type: boolean
         name: switch
-      # Explicit mapping instead of range: the linear formula
-      # value_to_brightness((1,6), 1) = 0 maps dp=1 to HA brightness
-      # 0, which HA treats as off. The mapping keeps all values valid.
       - id: 105
         type: integer
         name: brightness
-        mapping:
-          - dps_val: 1
-            value: 42
-          - dps_val: 2
-            value: 85
-          - dps_val: 3
-            value: 128
-          - dps_val: 4
-            value: 170
-          - dps_val: 5
-            value: 212
-          - dps_val: 6
-            value: 255
+        range:
+          min: 1
+          max: 6
       - id: 106
         type: string
         name: effect

--- a/custom_components/tuya_local/devices/imaxfire_awa2_fireplace.yaml
+++ b/custom_components/tuya_local/devices/imaxfire_awa2_fireplace.yaml
@@ -1,0 +1,170 @@
+name: Water vapor fireplace
+products:
+  - id: ogoql4oqaedx4mpu
+    manufacturer: Imaxfire
+    model: Water vapor fireplace (AWA2-NN)
+entities:
+  - entity: light
+    translation_key: flame
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      # Explicit mapping instead of range: the linear formula
+      # value_to_brightness((1,6), 1) = 0 maps dp=1 to HA brightness
+      # 0, which HA treats as off. The mapping keeps all values valid.
+      - id: 105
+        type: integer
+        name: brightness
+        mapping:
+          - dps_val: 1
+            value: 42
+          - dps_val: 2
+            value: 85
+          - dps_val: 3
+            value: 128
+          - dps_val: 4
+            value: 170
+          - dps_val: 5
+            value: 212
+          - dps_val: 6
+            value: 255
+      - id: 106
+        type: string
+        name: effect
+        mapping:
+          - dps_val: light_red
+            value: Red
+          - dps_val: light_green
+            value: Green
+          - dps_val: light_blue
+            value: Blue
+          - dps_val: light_orange
+            value: Orange
+          - dps_val: light_yellow
+            value: Yellow
+          - dps_val: light_white
+            value: White
+          - dps_val: light_pink
+            value: Pink
+          - dps_val: light_purple
+            value: Purple
+          - dps_val: light_cyan
+            value: Cyan
+          - dps_val: light_flash
+            value: Flash
+          - dps_val: light_strobe
+            value: Strobe
+          - dps_val: light_fade
+            value: Fade
+      - id: 24
+        name: rgbhsv
+        type: hex
+        format:
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+          # V defaults to 1000. If named "v", HA would route brightness
+          # through this field instead of dp 105. Changing V here does
+          # affect brightness, but once V is no longer 1000, brightness
+          # via dp 24 locks up until a dp 106 color preset is applied.
+          # Renamed to "v_dummy" so HA uses dp 105 for brightness and
+          # SmartLife stays functional.
+          - name: v_dummy
+            bytes: 2
+
+  - entity: sensor
+    translation_key: water_level
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 101
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: high
+            value: high
+          - dps_val: middle
+            value: medium
+          - dps_val: low
+            value: low
+
+  - entity: number
+    translation_key: volume
+    category: config
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 16
+
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 540
+
+  - entity: switch
+    name: Timer
+    category: config
+    dps:
+      - id: 107
+        type: boolean
+        name: switch
+
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 108
+        type: boolean
+        name: switch
+        mapping:
+          - dps_val: false
+            value: true
+          - dps_val: true
+            value: false
+
+  - entity: switch
+    name: Fill tank
+    category: config
+    hidden: true
+    dps:
+      - id: 110
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Empty tank
+    category: config
+    hidden: true
+    dps:
+      - id: 111
+        type: boolean
+        name: switch
+
+  - entity: number
+    name: Flame level
+    dps:
+      - id: 112
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 5


### PR DESCRIPTION
## Summary

Add support for the Imaxfire AWA2 water vapor fireplace.

This is a decorative water vapor fireplace that creates a flame effect using ultrasonic water vapor and multi-color LED lighting. The tested device is from the Imaxfire AWA2 line, which is sold in multiple sizes, including AWA2-20 (~500 mm), AWA2-40 (~1000 mm), and AWA2-60 (~1500 mm / 59 in).

Product page: https://aflyever.com/product/imaxfire-59-multi-color-app-automatic-water-supply-system-water-fireplace/

Product ID: ``ogoql4oqaedx4mpu``

## Supported Features

- Vapor flame light with HSV color control and brightness (dp 105, 6 levels)
- Water level sensor
- Volume control
- Timer duration and timer switch
- Flame brightness and flame level controls
- 12 flame preset effects via dp 106
- Sound control
- Hidden fill tank and empty tank controls

## Design Notes

### Tuya IoT Platform - Official DP definitions

Retrieved via Tuya IoT Platform API. Note: the API returns field names and descriptions in Chinese only - no English option available.

<details>
<summary>DP RAW data</summary>

```json
{
  "modelId": "f57hto",
  "services": [
    {
      "actions": [],
      "code": "",
      "description": "",
      "events": [],
      "name": "默认服务",
      "properties": [
        {
          "abilityId": 20,
          "accessMode": "rw",
          "code": "switch_led",
          "description": "开关机",
          "extensions": {
            "iconName": "icon-dp_power",
            "attribute": "1539"
          },
          "name": "电源",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 21,
          "accessMode": "rw",
          "code": "work_mode",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_mode",
            "attribute": "1536"
          },
          "name": "模式",
          "typeSpec": {
            "type": "enum",
            "range": [
              "colour"
            ]
          }
        },
        {
          "abilityId": 24,
          "accessMode": "rw",
          "code": "colour_data",
          "description": "类型：字符串;Value: 000011112222;0000：H（色度：0-360，0X0000-0X0168）;1111：S (饱和：0-1000, 0X0000-0X03E8);2222：V (明度：0-1000，0X0000-0X03E8)",
          "extensions": {
            "iconName": "icon-yanse",
            "attribute": "1536"
          },
          "name": "彩光",
          "typeSpec": {
            "type": "string",
            "maxlen": 255
          }
        },
        {
          "abilityId": 28,
          "accessMode": "wr",
          "code": "control_data",
          "description": "类型：字符串;Value: 011112222333344445555;0：变化方式，0表示直接输出，1表示渐变;1111：H（色度：0-360）;2222：S (饱和：0-1000);3333：V (明度：0-1000);4444：白光亮度（0-1000）;5555：色温值（0-1000）",
          "extensions": {
            "iconName": "icon-dp_box2",
            "attribute": "1536"
          },
          "name": "调节",
          "typeSpec": {
            "type": "string",
            "maxlen": 255
          }
        },
        {
          "abilityId": 101,
          "accessMode": "ro",
          "code": "water_level",
          "description": "水位状态",
          "name": "当前水位",
          "typeSpec": {
            "type": "enum",
            "range": [
              "high",
              "middle",
              "low"
            ]
          }
        },
        {
          "abilityId": 102,
          "accessMode": "rw",
          "code": "volume_set",
          "description": "音量调节",
          "extensions": {
            "iconName": "icon-dp_voice",
            "attribute": "4096"
          },
          "name": "音量大小",
          "typeSpec": {
            "type": "value",
            "max": 16,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": ""
          }
        },
        {
          "abilityId": 103,
          "accessMode": "rw",
          "code": "remain_time",
          "description": "",
          "name": "剩余时间",
          "typeSpec": {
            "type": "value",
            "max": 540,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "min"
          }
        },
        {
          "abilityId": 105,
          "accessMode": "rw",
          "code": "screen_bright_value",
          "description": "亮度调节",
          "extensions": {
            "iconName": "icon-deng",
            "attribute": "4096"
          },
          "name": "灯光亮度",
          "typeSpec": {
            "type": "value",
            "max": 6,
            "min": 1,
            "scale": 0,
            "step": 1,
            "unit": ""
          }
        },
        {
          "abilityId": 106,
          "accessMode": "rw",
          "code": "light_mode",
          "description": "红、绿、蓝、橙、黄、白、粉、紫、青、闪烁、爆闪、渐变",
          "extensions": {
            "iconName": "tcl_function_light",
            "attribute": "4096"
          },
          "name": "灯光模式",
          "typeSpec": {
            "type": "enum",
            "range": [
              "light_red",
              "light_green",
              "light_blue",
              "light_orange",
              "light_yellow",
              "light_white",
              "light_pink",
              "light_purple",
              "light_cyan",
              "light_flash",
              "light_strobe",
              "light_fade"
            ]
          }
        },
        {
          "abilityId": 107,
          "accessMode": "rw",
          "code": "switch_time",
          "description": "定时开关",
          "name": "定时",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 108,
          "accessMode": "rw",
          "code": "sound_off",
          "description": "静音开关",
          "name": "静音",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 110,
          "accessMode": "rw",
          "code": "add_water",
          "description": "加水开关",
          "name": "加水",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 111,
          "accessMode": "rw",
          "code": "outlet_water",
          "description": "排水开关",
          "name": "排水",
          "typeSpec": {
            "type": "bool"
          }
        },
        {
          "abilityId": 112,
          "accessMode": "rw",
          "code": "flame_level",
          "description": "",
          "name": "火焰",
          "typeSpec": {
            "type": "value",
            "max": 5,
            "min": 1,
            "scale": 0,
            "step": 1,
            "unit": ""
          }
        }
      ]
    }
  ]
}
```

</details>

### Brightness (dp 105)

Uses explicit 6-step mapping instead of ``range: min: 1, max: 6``. The linear formula ``value_to_brightness((1,6), 1) = 0`` maps the lowest brightness level to HA brightness 0, which HA interprets as off. The mapping (1->42, 2->85, 3->128, 4->170, 5->212, 6->255) keeps all values in the valid 1-255 range.

### HSV color data (dp 24)

The V field in the rgbhsv format is named ``v_dummy`` instead of ``v``. When named ``v``, HA routes brightness through the HSV V-component instead of the dedicated brightness dp 105. Changing V through HA does temporarily affect brightness, but once V is no longer 1000, brightness via dp 24 locks up until a dp 106 color preset is applied, and it also breaks the SmartLife app brightness slider. The ``v_dummy`` name prevents HA from detecting it as a brightness source, so dp 105 is used correctly. The 6-byte struct layout (HHHHSSSSVVVV) is preserved since pack/unpack operates on field count and byte positions, not names.

### Color mode (dp 21)

The Tuya spec shows ``work_mode`` (dp 21) with a single value ``colour``, meaning the device only supports colored light output via dp 24 -- there is no white or color temperature mode to switch between. Since there is nothing to switch between, it was not added entirely rather than moved to a separate entity, and the light entity only exposes ``supported_color_modes: [hs]``.

### Transition control (dp 28)

The Tuya spec defines ``control_data`` (dp 28) as a write-only string that controls how color transitions happen: instant (``0``) or gradient (``1``), along with H/S/V/white brightness/color temperature values. It is likely used internally by the device's preset effects (dp 106) for animated transitions. Not implemented as other device configs in tuya-local that include this dp only register it as ``optional: true`` without format or mapping, and there is no standard way to expose transition mode selection through HA's light entity.

### Translation keys

Entities without existing translation keys use ``name:`` (timer switch, fill tank, empty tank, flame level). Translations are submitted separately in PR #5174.

### Other notes

- The model is listed as ``Water vapor fireplace (AWA2-NN)`` because the same product ID may cover multiple AWA2 sizes.
- ``fill_tank`` and ``empty_tank`` are hidden by default because they trigger physical water movement.

## Test Plan

Verified in Docker/Linux with Python 3.14.2 using ``ghcr.io/astral-sh/uv:python3.14-bookworm``:

- ``uv run pytest`` - 181 passed
- ``uv run pytest tests/test_device_config.py tests/test_translations.py`` - 33 passed
- ``uv run untranslated_entities`` - clean
- ``uv run ruff check custom_components/`` - passed
- ``uv run ruff check --select I custom_components/`` - passed
- ``uv run ruff format --check custom_components/`` - passed
- ``uv run yamllint custom_components/tuya_local/devices/imaxfire_awa2_fireplace.yaml`` - passed