### PR TITLE
Update touchstone_sidelineredblue_fireplace.yaml

### DIFF
--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -1,4 +1,4 @@
-name: Touchstone Sideline electric fireplace
+name: Electric fireplace
 products:
   - id: pkgk72uonlqlzcil
     manufacturer: Touchstone
@@ -46,13 +46,15 @@ entities:
         name: preset_mode
         mapping:
           - dps_val: "0"
-            value: "none"
+            value: none
           - dps_val: "1"
-            value: "low"
+            value: low
+            hidden: true
           - dps_val: "2"
-            value: "high"
+            value: high
+            hidden: true
           - dps_val: "3"
-            value: "auto"
+            value: auto
       - id: 2
         name: temperature
         type: integer
@@ -63,7 +65,7 @@ entities:
         mapping:
           - constraint: temperature_unit
             conditions:
-              - dps_val: "f"
+              - dps_val: f
                 range:
                   min: 60
                   max: 88
@@ -74,15 +76,15 @@ entities:
         mapping:
           - constraint: temperature_unit
             conditions:
-              - dps_val: "f"
+              - dps_val: f
                 value_redirect: temp_current_f
       - id: 13
         name: temperature_unit
         type: string
         mapping:
-          - dps_val: "c"
+          - dps_val: c
             value: C
-          - dps_val: "f"
+          - dps_val: f
             value: F
       - id: 14
         name: temp_set_f
@@ -110,18 +112,32 @@ entities:
         type: string
         name: option
         mapping:
-          - dps_val: "c"
+          - dps_val: c
             value: celsius
-          - dps_val: "f"
+          - dps_val: f
             value: fahrenheit
-
-  - entity: select
-    name: Flame color
-    icon: "mdi:fire"
+            
+  - entity: light
+    translation_key: flame
+    category: config
     dps:
-      - id: 101
+      - id: 102
+        name: brightness
         type: string
-        name: option
+        mapping:
+          - dps_val: "1"
+            value: 51
+          - dps_val: "2"
+            value: 102
+          - dps_val: "3"
+            value: 153
+          - dps_val: "4"
+            value: 204
+          - dps_val: "5"
+            value: 255
+      - id: 101
+        name: effect
+        type: string
         mapping:
           - dps_val: "1"
             value: "Red + Blue"
@@ -129,26 +145,6 @@ entities:
             value: "Red"
           - dps_val: "3"
             value: "Blue"
-
-  - entity: select
-    name: Flame brightness
-    icon: "mdi:brightness-6"
-    category: config
-    dps:
-      - id: 102
-        type: string
-        name: option
-        mapping:
-          - dps_val: "1"
-            value: "20%"
-          - dps_val: "2"
-            value: "40%"
-          - dps_val: "3"
-            value: "60%"
-          - dps_val: "4"
-            value: "80%"
-          - dps_val: "5"
-            value: "100%"
 
   - entity: select
     name: Flame speed
@@ -169,61 +165,61 @@ entities:
             value: "4"
           - dps_val: "5"
             value: "5"
-
-  - entity: select
-    name: Ember color
-    icon: "mdi:campfire"
-    dps:
-      - id: 104
-        type: string
-        name: option
-        mapping:
-          - dps_val: "1"
-            value: "1"
-          - dps_val: "2"
-            value: "2"
-          - dps_val: "3"
-            value: "3"
-          - dps_val: "4"
-            value: "4"
-          - dps_val: "5"
-            value: "5"
-          - dps_val: "6"
-            value: "6"
-          - dps_val: "7"
-            value: "7"
-          - dps_val: "8"
-            value: "8"
-          - dps_val: "9"
-            value: "9"
-          - dps_val: "10"
-            value: "10"
-          - dps_val: "11"
-            value: "11"
-          - dps_val: "12"
-            value: "12"
-
-  - entity: select
-    name: Ember brightness
-    icon: "mdi:brightness-7"
+            
+  - entity: light
+    translation_key: embers
     category: config
     dps:
       - id: 109
+        name: brightness
         type: string
-        name: option
+        optional: true
         mapping:
-          - dps_val: "L5"
-            value: "Off"
-          - dps_val: "L0"
-            value: "25%"
-          - dps_val: "L1"
-            value: "50%"
-          - dps_val: "L2"
-            value: "75%"
-          - dps_val: "L3"
-            value: "100%"
-          - dps_val: "L4"
-            value: "Pulsating"
+          - dps_val: L5
+            value: 0
+          - dps_val: L0
+            value: 51
+          - dps_val: L1
+            value: 102
+          - dps_val: L2
+            value: 153
+          - dps_val: L3
+            value: 204
+          - dps_val: L4
+            value: 255
+          - dps_val: null
+            value: 0
+            hidden: true
+      - id: 104
+        name: effect
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: "Orange"
+          - dps_val: "2"
+            value: "Red"
+          - dps_val: "3"
+            value: "Blue"
+          - dps_val: "4"
+            value: "Yellow"
+          - dps_val: "5"
+            value: "Green"
+          - dps_val: "6"
+            value: "Purple"
+          - dps_val: "7"
+            value: "Teal"
+          - dps_val: "8"
+            value: "Pink"
+          - dps_val: "9"
+            value: "White"
+          - dps_val: "10"
+            value: "PeachPuff"
+          - dps_val: "11"
+            value: "Color 11"
+            hidden: true
+          - dps_val: "12"
+            value: "Color 12"
+            hidden: true
 
   - entity: select
     translation_key: timer
@@ -257,3 +253,12 @@ entities:
             value: "7h"
           - dps_val: "8H"
             value: "8h"
+
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    hidden: true
+    dps:
+      - id: 108
+        type: boolean
+        name: lock

--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -14,51 +14,10 @@ entities:
   - entity: climate
     translation_key: heater
     dps:
-      - id: 5
-        type: string
-        name: hvac_mode
-        mapping:
-          - dps_val: "0"
-            value: "off"
-          - dps_val: "1"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: "heat"
-              - dps_val: true
-                value: "fan_only"
-          - dps_val: "2"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: "heat"
-              - dps_val: true
-                value: "fan_only"
-          - dps_val: "3"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: "heat"
-              - dps_val: true
-                value: "fan_only"
-      - id: 5
-        type: string
-        name: preset_mode
-        mapping:
-          - dps_val: "0"
-            value: none
-          - dps_val: "1"
-            value: low
-            hidden: true
-          - dps_val: "2"
-            value: high
-            hidden: true
-          - dps_val: "3"
-            value: auto
       - id: 2
         name: temperature
-        type: integer
         optional: true
+        type: integer
         range:
           min: 16
           max: 31
@@ -78,6 +37,47 @@ entities:
             conditions:
               - dps_val: f
                 value_redirect: temp_current_f
+      - id: 5
+        type: string
+        name: hvac_mode
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: heat
+              - dps_val: true
+                value: fan_only
+          - dps_val: "2"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: heat
+              - dps_val: true
+                value: fan_only
+          - dps_val: "3"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: heat
+              - dps_val: true
+                value: fan_only
+      - id: 5
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: none
+          - dps_val: "1"
+            value: low
+            hidden: true
+          - dps_val: "2"
+            value: high
+            hidden: true
+          - dps_val: "3"
+            value: auto
       - id: 13
         name: temperature_unit
         type: string
@@ -103,7 +103,6 @@ entities:
         type: boolean
         name: heat_disable
         hidden: true
-
   - entity: select
     translation_key: temperature_unit
     category: config
@@ -116,7 +115,6 @@ entities:
             value: celsius
           - dps_val: f
             value: fahrenheit
-            
   - entity: light
     translation_key: flame
     category: config
@@ -125,6 +123,8 @@ entities:
         name: brightness
         type: string
         mapping:
+          - dps_val: "0"
+            value: 0
           - dps_val: "1"
             value: 51
           - dps_val: "2"
@@ -145,7 +145,6 @@ entities:
             value: "Red"
           - dps_val: "3"
             value: "Blue"
-
   - entity: select
     name: Flame speed
     icon: "mdi:speedometer"
@@ -165,7 +164,6 @@ entities:
             value: "4"
           - dps_val: "5"
             value: "5"
-            
   - entity: light
     translation_key: embers
     category: config
@@ -191,39 +189,37 @@ entities:
             value: 0
             hidden: true
       - id: 104
-        name: effect
+        name: named_color
         type: string
         mapping:
           - dps_val: "1"
-            value: "Orange"
+            value: orange
           - dps_val: "2"
-            value: "Red"
+            value: red
           - dps_val: "3"
-            value: "Blue"
+            value: blue
           - dps_val: "4"
-            value: "Yellow"
+            value: yellow
           - dps_val: "5"
-            value: "Green"
+            value: green
           - dps_val: "6"
-            value: "Purple"
+            value: purple
           - dps_val: "7"
-            value: "Teal"
+            value: teal
           - dps_val: "8"
-            value: "Pink"
+            value: pink
           - dps_val: "9"
-            value: "White"
+            value: white
           - dps_val: "10"
-            value: "PeachPuff"
+            value: peachpuff
           - dps_val: "11"
-            value: "Color 11"
+            value: peachpuff
             hidden: true
           - dps_val: "12"
-            value: "Color 12"
+            value: peachpuff
             hidden: true
-
   - entity: select
     translation_key: timer
-    icon: "mdi:timer"
     category: config
     dps:
       - id: 106
@@ -231,9 +227,9 @@ entities:
         name: option
         mapping:
           - dps_val: "cancel"
-            value: "Cancel"
+            value: "cancel"
           - dps_val: "0"
-            value: "Cancel"
+            value: "cancel"
             hidden: true
           - dps_val: "30"
             value: "30m"
@@ -253,7 +249,6 @@ entities:
             value: "7h"
           - dps_val: "8H"
             value: "8h"
-
   - entity: lock
     translation_key: child_lock
     category: config

--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -48,15 +48,19 @@ entities:
             conditions:
               - dps_val: false
                 value: heat
+                hidden: true
               - dps_val: true
                 value: fan_only
+                hidden: true
           - dps_val: "2"
             constraint: heat_disable
             conditions:
               - dps_val: false
                 value: heat
+                hidden: true
               - dps_val: true
                 value: fan_only
+                hidden: true
           - dps_val: "3"
             constraint: heat_disable
             conditions:
@@ -72,10 +76,8 @@ entities:
             value: none
           - dps_val: "1"
             value: low
-            hidden: true
           - dps_val: "2"
             value: high
-            hidden: true
           - dps_val: "3"
             value: auto
       - id: 13

--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -1,32 +1,69 @@
-name: Electric fireplace
+name: Touchstone Sideline electric fireplace
+products:
+  - id: pkgk72uonlqlzcil
+    manufacturer: Touchstone
+    model: Sideline (red/blue flame variant)
 entities:
-  - entity: climate
-    translation_key: heater
+  - entity: switch
+    icon: "mdi:fireplace"
     dps:
       - id: 1
         type: boolean
+        name: switch
+
+  - entity: climate
+    translation_key: heater
+    dps:
+      - id: 5
+        type: string
         name: hvac_mode
         mapping:
-          - dps_val: false
+          - dps_val: "0"
             value: "off"
-          - dps_val: true
+          - dps_val: "1"
             constraint: heat_disable
             conditions:
               - dps_val: false
-                value: heat
+                value: "heat"
               - dps_val: true
-                value: fan_only
+                value: "fan_only"
+          - dps_val: "2"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: "heat"
+              - dps_val: true
+                value: "fan_only"
+          - dps_val: "3"
+            constraint: heat_disable
+            conditions:
+              - dps_val: false
+                value: "heat"
+              - dps_val: true
+                value: "fan_only"
+      - id: 5
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: "0"
+            value: "none"
+          - dps_val: "1"
+            value: "low"
+          - dps_val: "2"
+            value: "high"
+          - dps_val: "3"
+            value: "auto"
       - id: 2
         name: temperature
-        optional: true
         type: integer
+        optional: true
         range:
           min: 16
           max: 31
         mapping:
           - constraint: temperature_unit
             conditions:
-              - dps_val: f
+              - dps_val: "f"
                 range:
                   min: 60
                   max: 88
@@ -37,27 +74,15 @@ entities:
         mapping:
           - constraint: temperature_unit
             conditions:
-              - dps_val: f
+              - dps_val: "f"
                 value_redirect: temp_current_f
-      - id: 5
-        name: preset_mode
-        type: string
-        mapping:
-          - dps_val: "0"
-            value: none
-          - dps_val: "1"
-            value: low
-          - dps_val: "2"
-            value: high
-          - dps_val: "3"
-            value: auto
       - id: 13
         name: temperature_unit
         type: string
         mapping:
-          - dps_val: c
+          - dps_val: "c"
             value: C
-          - dps_val: f
+          - dps_val: "f"
             value: F
       - id: 14
         name: temp_set_f
@@ -76,6 +101,7 @@ entities:
         type: boolean
         name: heat_disable
         hidden: true
+
   - entity: select
     translation_key: temperature_unit
     category: config
@@ -84,33 +110,18 @@ entities:
         type: string
         name: option
         mapping:
-          - dps_val: c
+          - dps_val: "c"
             value: celsius
-          - dps_val: f
+          - dps_val: "f"
             value: fahrenheit
-  - entity: light
-    translation_key: flame
-    category: config
+
+  - entity: select
+    name: Flame color
+    icon: "mdi:fire"
     dps:
-      - id: 102
-        name: brightness
-        type: string
-        mapping:
-          - dps_val: "0"
-            value: 0
-          - dps_val: "1"
-            value: 51
-          - dps_val: "2"
-            value: 102
-          - dps_val: "3"
-            value: 153
-          - dps_val: "4"
-            value: 204
-          - dps_val: "5"
-            value: 255
       - id: 101
-        name: effect
         type: string
+        name: option
         mapping:
           - dps_val: "1"
             value: "Red + Blue"
@@ -118,6 +129,27 @@ entities:
             value: "Red"
           - dps_val: "3"
             value: "Blue"
+
+  - entity: select
+    name: Flame brightness
+    icon: "mdi:brightness-6"
+    category: config
+    dps:
+      - id: 102
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "20%"
+          - dps_val: "2"
+            value: "40%"
+          - dps_val: "3"
+            value: "60%"
+          - dps_val: "4"
+            value: "80%"
+          - dps_val: "5"
+            value: "100%"
+
   - entity: select
     name: Flame speed
     icon: "mdi:speedometer"
@@ -137,72 +169,65 @@ entities:
             value: "4"
           - dps_val: "5"
             value: "5"
-  - entity: light
-    translation_key: embers
+
+  - entity: select
+    name: Ember color
+    icon: "mdi:campfire"
+    dps:
+      - id: 104
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+          - dps_val: "5"
+            value: "5"
+          - dps_val: "6"
+            value: "6"
+          - dps_val: "7"
+            value: "7"
+          - dps_val: "8"
+            value: "8"
+          - dps_val: "9"
+            value: "9"
+          - dps_val: "10"
+            value: "10"
+          - dps_val: "11"
+            value: "11"
+          - dps_val: "12"
+            value: "12"
+
+  - entity: select
+    name: Ember brightness
+    icon: "mdi:brightness-7"
     category: config
     dps:
       - id: 109
-        name: brightness
         type: string
-        optional: true
+        name: option
         mapping:
-          - dps_val: L5
-            value: 0
-          - dps_val: L0
-            value: 51
-          - dps_val: L1
-            value: 102
-          - dps_val: L2
-            value: 153
-          - dps_val: L3
-            value: 204
-          - dps_val: L4
-            value: 255
-          - dps_val: null
-            value: 0
-            hidden: true
-      - id: 104
-        name: named_color
-        type: string
-        mapping:
-          - dps_val: "1"
-            value: orange
-          - dps_val: "2"
-            value: red
-          - dps_val: "3"
-            value: blue
-          - dps_val: "4"
-            value: yellow
-          - dps_val: "5"
-            value: green
-          - dps_val: "6"
-            value: purple
-          - dps_val: "7"
-            value: teal
-          - dps_val: "8"
-            value: pink
-          - dps_val: "9"
-            value: white
-          - dps_val: "10"
-            value: peachpuff
-          - dps_val: "11"
-            value: black
-          - dps_val: "12"
-            value: grey
-      - id: 104
-        name: effect
-        type: string
-        mapping:
-          - dps_val: "12"
-            value: Mystery
-          - dps_val: "11"
-            value: Cycle
-          - dps_val: "1"
-            value: "off"
-          - value: "off"
-            hidden: true
+          - dps_val: "L5"
+            value: "Off"
+          - dps_val: "L0"
+            value: "25%"
+          - dps_val: "L1"
+            value: "50%"
+          - dps_val: "L2"
+            value: "75%"
+          - dps_val: "L3"
+            value: "100%"
+          - dps_val: "L4"
+            value: "Pulsating"
+
   - entity: select
     translation_key: timer
+    icon: "mdi:timer"
     category: config
     dps:
       - id: 106
@@ -210,9 +235,9 @@ entities:
         name: option
         mapping:
           - dps_val: "cancel"
-            value: "cancel"
+            value: "Cancel"
           - dps_val: "0"
-            value: "cancel"
+            value: "Cancel"
             hidden: true
           - dps_val: "30"
             value: "30m"
@@ -232,10 +257,3 @@ entities:
             value: "7h"
           - dps_val: "8H"
             value: "8h"
-  - entity: lock
-    translation_key: child_lock
-    category: config
-    dps:
-      - id: 108
-        type: boolean
-        name: lock

--- a/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
+++ b/custom_components/tuya_local/devices/touchstone_sidelineredblue_fireplace.yaml
@@ -44,30 +44,13 @@ entities:
           - dps_val: "0"
             value: "off"
           - dps_val: "1"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: heat
-                hidden: true
-              - dps_val: true
-                value: fan_only
-                hidden: true
+            value: heat
+            hidden: true
           - dps_val: "2"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: heat
-                hidden: true
-              - dps_val: true
-                value: fan_only
-                hidden: true
+            value: heat
+            hidden: true
           - dps_val: "3"
-            constraint: heat_disable
-            conditions:
-              - dps_val: false
-                value: heat
-              - dps_val: true
-                value: fan_only
+            value: heat
       - id: 5
         name: preset_mode
         type: string
@@ -100,10 +83,6 @@ entities:
         name: temp_current_f
         type: integer
         optional: true
-        hidden: true
-      - id: 107
-        type: boolean
-        name: heat_disable
         hidden: true
   - entity: select
     translation_key: temperature_unit
@@ -254,8 +233,7 @@ entities:
   - entity: lock
     translation_key: child_lock
     category: config
-    hidden: true
     dps:
-      - id: 108
+      - id: 107
         type: boolean
         name: lock


### PR DESCRIPTION
I previously contributed an electric_fireplace.yaml update that turned out to conflate two distinct product ID variants
After testing, the merged version has these specific issues on my unit: 
1. DP 1 is master power, not HVAC mode -- The toggles for ember and flame do nothing because power is currently tied to HVAC mode in the new device config
2. DP 102 `"0"` mapping causes phantom "off" display
3. Flame color palette differs by product ID
4. Ember color names are invented for my variant
5. Ember brightness states aren't continuous brightness — there's a "Pulsating" effect
6. DP 108 is mapped as child_lock but there does not appear to be a child lock on this model
7. Timer enum values are unique to my variant


I'd like to **revert the merged changes to electric_fireplace.yaml back to its previous state** (matching the original product ID `qhwld7e4eqvu5fbp` Sideline Elite variant), and **add a separate `touchstone_sideline_fireplace.yaml`** profile tied specifically to product ID `pkgk72uonlqlzcil` with the verified mappings for my variant.

This avoids:
- Breaking the existing Sideline Elite profile users already rely on
- Misleading users with invented child_lock and color-name mappings
- Continuous-brightness misrepresentation of the Pulsating effect
- The DP 102 = "0" phantom display issue

And it correctly handles the genuine hardware differences between product IDs that can't be reconciled with conditional mappings (since tuya-local doesn't support per-product DPS conditions).

I have stepped-test diagnostics for every claim above and a fully working profile ready to submit. Happy to break this into smaller PRs if that's easier to review.

This PR adds a separate profile for product ID pkgk72uonlqlzcil while leaving the original Sideline Elite profile (qhwld7e4eqvu5fbp) untouched

Link to issue #5071
PR #5089 