### PR TITLE
feat(devices): Add Avatto WT20R WiFi Knob Thermostat

### DIFF
--- a/custom_components/tuya_local/devices/avatto_wt20r_thermostat.yaml
+++ b/custom_components/tuya_local/devices/avatto_wt20r_thermostat.yaml
@@ -3,6 +3,9 @@ products:
   - id: axhyyv6w36e5oagp
     manufacturer: Avatto
     model: WS20R smart knob
+  - id: t94pit6zjbask9qo
+    manufacturer: Avatto
+    model: WT20R WiFi Knob Thermostat
 entities:
   - entity: climate
     translation_key: thermostat


### PR DESCRIPTION
Adds the Avatto WT20R WiFi Knob Thermostat (Product ID  t94pit6zjbask9qo ).

This device matches the existing DP schema of the Avatto WS20R - which interestingly is in a file named ...wt20r... 

As an aside - if you web search for "Avatto WS20R", the only real hits are this project. Perhaps 'WS20R' was somehow a typo for 'WT20R'? The original bug https://github.com/make-all/tuya-local/issues/2938 doesn't include the 'model' from the schema, so it's hard to be sure. 

Here is the schema from the Tuya API about my devices - it does report the model as 'WT20R':

    {
      "name": "WiFi Knob Thermostat",
      "model": "WT20R",
      "product_id": "t94pit6zjbask9qo",
      "category": "wk",
      "mapping": {
        "1": {"code": "switch", "type": "Boolean"},
        "2": {"code": "mode", "type": "Enum", "values": {"range": ["auto", "manual"]}},
        "3": {"code": "temp_set", "type": "Integer", "values": {"unit": "°C", "min": 5, "max": 45, "scale": 0, "step": 1}},
        "17": {"code": "temp_set_f", "type": "Integer", "values": {"unit": "°F", "min": 41, "max": 113, "scale": 0, "step": 1}},
        "23": {"code": "temp_unit_convert", "type": "Enum", "values": {"range": ["c", "f"]}},
        "24": {"code": "temp_current", "type": "Integer", "values": {"unit": "°C", "min": 0, "max": 50, "scale": 0, "step": 1}},
        "25": {"code": "humidity", "type": "Integer", "values": {"unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1}},
        "29": {"code": "temp_current_f", "type": "Integer", "values": {"unit": "°F", "min": -4, "max": 122, "scale": 0, "step": 1}},
        "31": {"code": "work_days", "type": "Enum", "values": {"range": ["5_2", "6_1", "7"]}},
        "32": {"code": "work_state", "type": "Enum", "values": {"range": ["auto", "manual"]}},
        "39": {"code": "factory_reset", "type": "Boolean"},
        "44": {"code": "backlight", "type": "Integer", "values": {"unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1}},
        "45": {"code": "fault", "type": "Bitmap", "values": {"label": ["e1", "e2", "e3"]}},
        "101": {"code": "sensor_choose", "type": "Enum", "values": {"range": ["in", "out"]}}
      }
    }
