### PR TITLE
Add optional temperature and volume unit selections

### DIFF
--- a/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
+++ b/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
@@ -34,7 +34,6 @@ entities:
 
   # Unit selects
   - entity: select
-    name: Temperature unit
     translation_key: temperature_unit
     category: config
     dps:

--- a/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
+++ b/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
@@ -18,6 +18,7 @@ entities:
     dps:
       - id: 12
         type: integer
+        optional: true
         name: sensor
         class: measurement
         mapping:
@@ -31,6 +32,38 @@ entities:
             value: F
           - value: C
 
+  # Unit selects
+  - entity: select
+    name: Temperature unit
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 20
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: f
+            value: Fahrenheit
+          - dps_val: c
+            value: Celsius
+
+  - entity: select
+    name: Volume units
+    icon: "mdi:ruler-square"
+    category: config
+    dps:
+      - id: 102
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: us_units
+            value: Gallon
+          - dps_val: metric_unit
+            value: Liter
+
+  # Optional pressure
   - entity: sensor
     class: pressure
     category: diagnostic
@@ -40,6 +73,13 @@ entities:
         optional: true
         name: sensor
         class: measurement
+        mapping:
+          - constraint: unit
+            conditions:
+              - dps_val: us_units
+                scale: 10
+              - dps_val: metric_unit
+                scale: 100
       - id: 102
         type: string
         optional: true
@@ -47,9 +87,28 @@ entities:
         mapping:
           - dps_val: us_units
             value: psi
-            scale: 10
           - value: bar
-            scale: 100
+
+  - entity: sensor
+    name: System Status
+    class: enum
+    category: diagnostic
+    icon: "mdi:information-outline"
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: "Normal"
+          - dps_val: 1
+            value: "Warning"
+          - dps_val: 2
+            value: "Empty Pipe"
+          - dps_val: 3
+            value: "Fault"
+          - dps_val: 4
+            value: "Tuya Cloud Offline"
 
   # Protection Enabled Switch
   - entity: switch
@@ -324,33 +383,6 @@ entities:
           - dps_val: 0
             value: 50
           - scale: 0.01
-  - entity: select
-    translation_key: temperature_unit
-    category: config
-    dps:
-      - id: 20
-        type: string
-        optional: true
-        name: option
-        mapping:
-          - dps_val: c
-            value: celsius
-          - dps_val: f
-            value: fahrenheit
-  - entity: select
-    name: Measurement units
-    icon: "mdi:ruler-square"
-    category: config
-    dps:
-      - id: 102
-        type: string
-        optional: true
-        name: option
-        mapping:
-          - dps_val: us_units
-            value: US
-          - dps_val: metric_unit
-            value: Metric
 
   # Advanced: Allowed Flow Rate
   - entity: switch


### PR DESCRIPTION
- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Fix pressure scale based on units.  Make temperature a selector like the app.  Make labels/values match the vendor app.

I couldn't figure out a way to hide/disable temperature for devices that always send 25.0 c / 77.0 f.  Since local API doesn't give model and users can't disable in UI due to no unique IDs.  Those devices will just have static values.
