### PR TITLE
Add Power Limit select to Solar inverter GTB Series (DPS 102)

### DIFF
--- a/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
+++ b/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
@@ -146,7 +146,7 @@ entities:
         name: switch
         optional: true
   - entity: select
-    name: Power Limit
+    name: Power limit
     category: config
     dps:
       - id: 102

--- a/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
+++ b/custom_components/tuya_local/devices/solar_inverter_gtb_series.yaml
@@ -145,3 +145,21 @@ entities:
         type: boolean
         name: switch
         optional: true
+  - entity: select
+    name: Power Limit
+    category: config
+    dps:
+      - id: 102
+        type: string
+        name: option
+        mapping:
+          - dps_val: "5"
+            value: "5%"
+          - dps_val: "25"
+            value: "25%"
+          - dps_val: "50"
+            value: "50%"
+          - dps_val: "75"
+            value: "75%"
+          - dps_val: "100"
+            value: "100%"


### PR DESCRIPTION
## What

Adds a `select` entity named "Power Limit" mapped to DPS 102 on the `solar_inverter_gtb_series.yaml` device.

The DPS accepts 5 discrete string values: `"5"`, `"25"`, `"50"`, `"75"`, `"100"`, mapped to `5%`, `25%`, `50%`, `75%`, `100%`.

## Why

The existing device config exposes sensors and the on/off switch but not the output power cap that the official Tuya app already provides for this microinverter. I have this microinverter (Solar Grid GTB) at home and I want to throttle its output from Home Assistant (e.g. when the battery is full or to avoid feed-in).

## Verification

I have been running this locally for a couple of weeks. Changing the value in HA does change the actual output power of the inverter, matching what the Tuya app shows. The Tuya app only exposes the same 5 discrete steps, so a `select` (not a `number`) is the right entity type.

## Notes

- Only one new `select` entity appended, no other changes to existing entities.
- No translation_key set, so existing translation machinery is unaffected (translations can be added separately if desired).