### PR TITLE
Add support for Fanelite Manihi ceiling fan

### DIFF
--- a/custom_components/tuya_local/devices/fanelite_manihi_6speed_fanlight_backlight.yaml
+++ b/custom_components/tuya_local/devices/fanelite_manihi_6speed_fanlight_backlight.yaml
@@ -1,0 +1,69 @@
+name: Ceiling fan with light and backlight
+products:
+  - id: ftqsaibnb3insvp9
+    manufacturer: Fanelite
+    model: "Manihi"
+entities:
+  - entity: fan
+    dps:
+      - id: 60
+        type: boolean
+        name: switch
+      - id: 62
+        type: integer
+        name: speed
+        range:
+          min: 1
+          max: 6
+      - id: 63
+        type: string
+        name: direction
+  - entity: light
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 21
+        name: work_mode
+        type: string
+        optional: true
+      - id: 22
+        name: brightness
+        type: integer
+        range:
+          min: 1
+          max: 7
+      - id: 23
+        name: color_temp
+        type: integer
+        optional: true
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - target_range:
+              min: 2700
+              max: 6500
+            step: 500
+      - id: 25
+        name: scene_data
+        type: string
+        optional: true
+  - entity: light
+    translation_key: backlight
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 64
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 540


### PR DESCRIPTION
New device definition for Fanelite Manihi ceiling fan (https://www.fanelite.fr/brasseur-d-air-dc-noir-et-bois-132-cm-avec-telecommande-led-3-pales-c2x42684852)

Tested locally and all the function are working.