### PR TITLE
fix: remove duplicate displayoff key in icons.json

### DIFF
--- a/custom_components/tuya_local/icons.json
+++ b/custom_components/tuya_local/icons.json
@@ -325,7 +325,6 @@
                             "high": "mdi:fan-speed-3",
                             "medium": "mdi:fan-speed-2",
                             "low": "mdi:fan-speed--1",
-                            "displayoff": "mdi:monitor-off",
                             "off": "mdi:fan-off"
                         }
                     }


### PR DESCRIPTION
Removes a duplicate `"displayoff": "mdi:monitor-off"` entry in the `fan_with_presets` state attributes of `icons.json`. The same key was defined twice in the same object, which is invalid JSON that some parsers silently deduplicate.