### PR TITLE
fix(light): complete brightness range clamping

### DIFF
--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -37,13 +37,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
 
-def _clamped_brightness_to_dp_value(brightness, brightness_range):
-    """Convert HA brightness to device range and keep the device minimum reachable."""
-    if brightness == 1 and brightness_range[0] != 0:
-        return brightness_range[0]
+def _ha_brightness_to_dp_value(ha_brightness, dp_range):
+    """Convert HA brightness to a clamped device DP value."""
+    if ha_brightness == 1 and dp_range[0] != 0:
+        return dp_range[0]
 
-    value = color_util.brightness_to_value(brightness_range, brightness)
-    return max(brightness_range[0], value)
+    dp_value = color_util.brightness_to_value(dp_range, ha_brightness)
+    return max(dp_range[0], dp_value)
 
 
 class TuyaLocalLight(TuyaLocalEntity, LightEntity):
@@ -304,7 +304,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
                 bright = params.get(ATTR_WHITE)
                 r = self._brightness_dps.range(self._device)
                 if r:
-                    bright = _clamped_brightness_to_dp_value(bright, r)
+                    bright = _ha_brightness_to_dp_value(bright, r)
 
                 _LOGGER.info(
                     "%s setting white brightness to %d", self._config.config_id, bright
@@ -477,7 +477,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
 
             r = self._brightness_dps.range(self._device)
             if r:
-                bright = _clamped_brightness_to_dp_value(bright, r)
+                bright = _ha_brightness_to_dp_value(bright, r)
             _LOGGER.info("%s setting brightness to %d", self._config.config_id, bright)
             settings = {
                 **settings,

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
 
-def _brightness_to_value(brightness, brightness_range):
+def _clamped_brightness_to_dp_value(brightness, brightness_range):
     """Convert HA brightness to device range and keep the device minimum reachable."""
     if brightness == 1 and brightness_range[0] != 0:
         return brightness_range[0]
@@ -304,7 +304,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
                 bright = params.get(ATTR_WHITE)
                 r = self._brightness_dps.range(self._device)
                 if r:
-                    bright = _brightness_to_value(bright, r)
+                    bright = _clamped_brightness_to_dp_value(bright, r)
 
                 _LOGGER.info(
                     "%s setting white brightness to %d", self._config.config_id, bright
@@ -477,7 +477,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
 
             r = self._brightness_dps.range(self._device)
             if r:
-                bright = _brightness_to_value(bright, r)
+                bright = _clamped_brightness_to_dp_value(bright, r)
             _LOGGER.info("%s setting brightness to %d", self._config.config_id, bright)
             settings = {
                 **settings,

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -37,6 +37,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
 
+def _brightness_to_value(brightness, brightness_range):
+    """Convert HA brightness to device range and keep the device minimum reachable."""
+    if brightness == 1 and brightness_range[0] != 0:
+        return brightness_range[0]
+
+    value = color_util.brightness_to_value(brightness_range, brightness)
+    return max(brightness_range[0], value)
+
+
 class TuyaLocalLight(TuyaLocalEntity, LightEntity):
     """Representation of a Tuya WiFi-connected light."""
 
@@ -295,11 +304,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
                 bright = params.get(ATTR_WHITE)
                 r = self._brightness_dps.range(self._device)
                 if r:
-                    # ensure full range is used
-                    if bright == 1 and r[0] != 0:
-                        bright = r[0]
-                    else:
-                        bright = color_util.brightness_to_value(r, bright)
+                    bright = _brightness_to_value(bright, r)
 
                 _LOGGER.info(
                     "%s setting white brightness to %d", self._config.config_id, bright
@@ -472,14 +477,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
 
             r = self._brightness_dps.range(self._device)
             if r:
-                # ensure full range is used
-                if bright == 1 and r[0] != 0:
-                    bright = r[0]
-                else:
-                    bright = color_util.brightness_to_value(r, bright)
-                    # workaround brightness_to_value not respecting the minimum
-                    if bright < r[0]:
-                        bright = r[0]
+                bright = _brightness_to_value(bright, r)
             _LOGGER.info("%s setting brightness to %d", self._config.config_id, bright)
             settings = {
                 **settings,

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -203,6 +203,92 @@ async def test_async_turn_on_with_brightness_on_packed_dp():
     assert sent_value & 0x000100000000 != 0
 
 
+@pytest.mark.parametrize(
+    ("brightness_range", "ha_value", "expected_dps", "path"),
+    [
+        # brightness_to_value() uses scale_to_ranged_value((1,255), target, bright).
+        # For small DP ranges, low HA brightness maps below the configured minimum:
+        #   (1, 6), 20   -> 20 * 6/255       = 0.470   -> below min 1
+        #   (10, 15), 20 -> 20 * 6/255 + 9    = 9.470   -> below min 10
+        #   (1, 6), 1    -> 1  * 6/255        = 0.024   -> below min 1 (HA minimum)
+        # Each case is tested via both code paths: brightness and white.
+        # 1-2. Original bug: low brightness maps below min
+        ({"min": 1, "max": 6}, 20, 1, "brightness"),
+        ({"min": 1, "max": 6}, 20, 1, "white"),
+        # 3-4. Generic min: not just tied to min=1
+        ({"min": 10, "max": 15}, 20, 10, "brightness"),
+        ({"min": 10, "max": 15}, 20, 10, "white"),
+        # 5-6. Wide range snap: ensures bright=1 snaps to physical min, not proportional (3.92 -> 4)
+        ({"min": 1, "max": 1000}, 1, 1, "brightness"),
+        ({"min": 1, "max": 1000}, 1, 1, "white"),
+        # 7-8. Wide offset range snap: proves snap uses actual DP min
+        ({"min": 10, "max": 1000}, 1, 10, "brightness"),
+        ({"min": 10, "max": 1000}, 1, 10, "white"),
+        # 9-10. Normal mid-range value: proves we don't over-clamp
+        ({"min": 1, "max": 6}, 128, 3, "brightness"),
+        ({"min": 1, "max": 6}, 128, 3, "white"),
+        # 11-12. Maximum value: proves upper bound is reachable
+        ({"min": 1, "max": 6}, 255, 6, "brightness"),
+        ({"min": 1, "max": 6}, 255, 6, "white"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_turn_on_clamps_low_brightness_to_range_min(
+    brightness_range, ha_value, expected_dps, path
+):
+    """Low non-zero HA brightness should clamp to the first DP range value.
+
+    Tests both the regular brightness path (ATTR_BRIGHTNESS) and the white
+    brightness path (ATTR_WHITE) in async_turn_on, ensuring brightness_to_value
+    results below the DP minimum are clamped correctly.
+    """
+    mock_device = AsyncMock()
+    mock_device.get_property = Mock()
+
+    if path == "white":
+        dps_config = [
+            {"id": "1", "name": "switch", "type": "boolean"},
+            {
+                "id": "2",
+                "name": "color_mode",
+                "type": "string",
+                "mapping": [
+                    {"dps_val": "white", "value": "white"},
+                    {"dps_val": "colour", "value": "hs"},
+                ],
+            },
+            {
+                "id": "3",
+                "name": "brightness",
+                "type": "integer",
+                "range": brightness_range,
+            },
+        ]
+        device_dps = {"1": True, "2": "white", "3": brightness_range["min"]}
+        call_kwargs = {"white": ha_value}
+        assert_dp = "3"
+    else:
+        dps_config = [
+            {"id": "1", "name": "switch", "type": "boolean"},
+            {
+                "id": "2",
+                "name": "brightness",
+                "type": "integer",
+                "range": brightness_range,
+            },
+        ]
+        device_dps = {"1": True, "2": brightness_range["min"]}
+        call_kwargs = {"brightness": ha_value}
+        assert_dp = "2"
+
+    mock_device.get_property.side_effect = lambda arg: device_dps[arg]
+    mock_config = Mock()
+    config = TuyaEntityConfig(mock_config, {"entity": "light", "dps": dps_config})
+    light = TuyaLocalLight(mock_device, config)
+    await light.async_turn_on(**call_kwargs)
+    mock_device.async_set_properties.assert_called_once_with({assert_dp: expected_dps})
+
+
 @pytest.mark.asyncio
 async def test_is_off_when_off_by_brightness():
     """Test that the light appears off when turned off by brightness."""


### PR DESCRIPTION
## Summary
- Complete the brightness range clamp added in c33c67b2 by applying the same conversion path to ATTR_WHITE brightness.
- Extract the HA-to-DP brightness conversion into one helper so ATTR_BRIGHTNESS and ATTR_WHITE cannot drift apart.
- Add regression coverage for small ranges, offset ranges, wide ranges, midpoint values, and max values through both code paths.

## Problem
Home Assistant's color_util.brightness_to_value() can return a value below the configured device range minimum for low HA brightness values. For example, brightness_to_value((1, 6), 20) returns 0.470588, which later rounds to 0 and fails validation against the 1..6 DP range.

The workaround in c33c67b2 fixes this for regular brightness, but the white brightness path still used the old conversion logic. This PR applies the same behavior to both paths and keeps the existing bright == 1 behavior that makes the physical device minimum reachable on wide ranges.

Related discussion: #5123

## Test Plan
- uv run ruff check custom_components tests
- uv run ruff check --select I custom_components tests
- uv run ruff format --check custom_components tests
- uv run yamllint custom_components/tuya_local/devices
- Docker: tests/test_light.py -v -> 18 passed
- Docker: full pytest -> 193 passed