### PR TITLE
fix: refine Feyree Lion EV-Ultra DP mappings

### DIFF
--- a/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
+++ b/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
@@ -19,15 +19,6 @@ entities:
           - dps_val: "CloseCharging"
             value: false
 
-  - entity: light
-    translation_key: backlight
-    category: config
-    dps:
-      - id: 18
-        name: switch
-        type: boolean
-        optional: true
-
   - entity: number
     class: current
     category: config
@@ -70,10 +61,32 @@ entities:
         unit: h
 
   - entity: sensor
-    name: Mains voltage
+    name: Voltage phase 1
     class: voltage
     dps:
       - id: 102
+        name: sensor
+        type: integer
+        optional: true
+        unit: V
+        class: measurement
+
+  - entity: sensor
+    name: Voltage phase 2
+    class: voltage
+    dps:
+      - id: 103
+        name: sensor
+        type: integer
+        optional: true
+        unit: V
+        class: measurement
+
+  - entity: sensor
+    name: Voltage phase 3
+    class: voltage
+    dps:
+      - id: 104
         name: sensor
         type: integer
         optional: true
@@ -95,7 +108,7 @@ entities:
     name: Current phase 2
     class: current
     dps:
-      - id: 103
+      - id: 106
         name: sensor
         type: integer
         optional: true
@@ -106,7 +119,7 @@ entities:
     name: Current phase 3
     class: current
     dps:
-      - id: 104
+      - id: 107
         name: sensor
         type: integer
         optional: true
@@ -117,26 +130,23 @@ entities:
     name: Active power
     class: power
     dps:
-      - id: 106
+      - id: 108
         name: sensor
         type: integer
         optional: true
-        unit: W
+        unit: kW
         class: measurement
 
   - entity: sensor
     name: Charging session energy
-    class: energy_storage
-    icon: "mdi:battery-charging-100"
+    class: energy
     dps:
-      - id: 107
+      - id: 109
         name: sensor
         type: integer
         optional: true
         unit: kWh
-        class: measurement
-        mapping:
-          - scale: 100
+        class: total_increasing
 
   - entity: sensor
     name: Internal temperature
@@ -205,18 +215,6 @@ entities:
         name: sensor
         type: string
         optional: true
-
-  - entity: sensor
-    class: energy
-    dps:
-      - id: 109
-        name: sensor
-        type: integer
-        optional: true
-        unit: kWh
-        class: total_increasing
-        mapping:
-          - scale: 100
 
   - entity: sensor
     name: Phase type


### PR DESCRIPTION
## Summary

Follow-up refinement for the Feyree Lion EV-Ultra profile before it reaches a tuya-local release.

Additional real charging tests showed that some DP mappings needed correction:

- DP108 is the real-time active power value, in kW.
- DP109 is the charging session energy value, in kWh, without `scale: 100`.
- DP102/103/104 are voltage phases 1/2/3.
- DP105/106/107 are current phases 1/2/3.
- DP18 is removed, as it was previously exposed as a backlight but appears to be inoperative on the latest tested MCU firmware.

## Test results

During a real charging session, the charger screen and Smart Life mini-app showed about 3.0 kW and 4.0 kWh.

At the same time, tuya-local diagnostics showed:

- DP101 = `charing`
- DP102 = `235`
- DP105 = `14`
- DP108 = `3`
- DP109 = `4`
- DP122 = `01:17:56`
- DP124 = `OpenCharging`

When the vehicle was disconnected, diagnostics showed:

- DP101 = `no_connet`
- DP105 = `0`
- DP108 = `0`
- DP109 = `0`
- DP122 = `00:00:00`

This confirms that DP108 is the current active power value and DP109 is the current charging session energy, not a lifetime energy counter.

## Display backlight

DP18 was previously exposed as a display backlight.

However, the user manual only documents an automatic screen saver / wake behavior for the display. It does not document a controllable backlight setting.

On the tested device, after updating to MCU firmware `SV:1.0.5 20260525_GA`, DP18 appears to be inoperative and has no confirmed visible effect. It is therefore removed from the profile for now.

## Undocumented vendor data

DP112 appears to contain an undocumented vendor / mini-app encoded status string and is intentionally not exposed.

## Setup note

During testing, this charger only worked reliably when the Tuya Local protocol version was explicitly set to `3.5`.

Using `auto` or other protocol versions did not work reliably on my setup and could make the local connection unstable. All diagnostics and DP validation for this profile were done with protocol version `3.5`.

This is not a device YAML mapping change, but it may be useful context for users adding this device through the Tuya Local config flow.

## Tested device

Tested with:

- Feyree Lion EV-Ultra
- 3.5 kW / 16 A single-phase model
- Protocol version 3.5
- MCU firmware `SV:1.0.5 20260525_GA`
- Hardware version `HV:1.0.2 20260206_GA`

The user manual covers the same Lion EV-Ultra product family across the available 3.5 kW, 7 kW and 11 kW variants, including single-phase and three-phase models. The reported firmware naming appears to be shared across the product family, but the real-world validation was performed on the 3.5 kW / 16 A unit.