### PR TITLE
fix: wrap filter() with list() in water_heater operation_list

### DIFF
--- a/custom_components/tuya_local/water_heater.py
+++ b/custom_components/tuya_local/water_heater.py
@@ -136,8 +136,10 @@ class TuyaLocalWaterHeater(TuyaLocalEntity, WaterHeaterEntity):
         if self._operation_mode_dps is None:
             return []
         else:
-            return list(filter(
-                lambda x: x != "away", self._operation_mode_dps.values(self._device))
+            return list(
+                filter(
+                    lambda x: x != "away", self._operation_mode_dps.values(self._device)
+                )
             )
 
     @property

--- a/custom_components/tuya_local/water_heater.py
+++ b/custom_components/tuya_local/water_heater.py
@@ -136,8 +136,8 @@ class TuyaLocalWaterHeater(TuyaLocalEntity, WaterHeaterEntity):
         if self._operation_mode_dps is None:
             return []
         else:
-            return filter(
-                lambda x: x != "away", self._operation_mode_dps.values(self._device)
+            return list(filter(
+                lambda x: x != "away", self._operation_mode_dps.values(self._device))
             )
 
     @property


### PR DESCRIPTION
## Description

`TuyaLocalWaterHeater.operation_list` returns a `filter` object instead of a `list`. This is a regression from the 2026.5.4 to 2026.6.0 cycle.

Because `operation_list` is part of the water heater's `capability_attributes`, the lazy `filter` iterator breaks JSON serialisation in Home Assistant, producing errors like:

```
Type is not JSON serializable: filter
```

## Fix

Wrap the `filter()` call with `list()` at line 139 of `water_heater.py`.

## Testing

- `uv run ruff check` passes
- Confirmed the returned value is now a `list` type

Fixes #5215
