### PR TITLE
fix(light): reserve zero brightness as off

### DIFF
--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -541,7 +541,8 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
             bright = 255
             r = self._brightness_dps.range(self._device)
             if r:
-                r = self._brightness_conversion_range(r, bright)
+                # Full HA brightness always maps to the DP max, so the zero-off
+                # range adjustment is only needed for non-max brightness values.
                 bright = color_util.brightness_to_value(r, bright)
             _LOGGER.info(
                 "%s turning light on to brightness %d",

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -191,8 +191,17 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
             r = self._brightness_dps.range(self._device)
             val = self._brightness_dps.get_value(self._device)
             if r and val:
+                r = self._brightness_conversion_range(r, val)
                 val = color_util.value_to_brightness(r, val)
             return val
+
+    def _brightness_conversion_range(self, dp_range, value):
+        """Return the range used to convert non-off brightness values."""
+        if not self._switch_dps and dp_range[0] == 0 and dp_range[1] > 0 and value:
+            first_on_value = max(1, self._brightness_dps.step(self._device))
+            if first_on_value <= dp_range[1]:
+                return (first_on_value, dp_range[1])
+        return dp_range
 
     @property
     def _unpacked_rgbhsv(self):
@@ -304,6 +313,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
                 bright = params.get(ATTR_WHITE)
                 r = self._brightness_dps.range(self._device)
                 if r:
+                    r = self._brightness_conversion_range(r, bright)
                     bright = _ha_brightness_to_dp_value(bright, r)
 
                 _LOGGER.info(
@@ -477,6 +487,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
 
             r = self._brightness_dps.range(self._device)
             if r:
+                r = self._brightness_conversion_range(r, bright)
                 bright = _ha_brightness_to_dp_value(bright, r)
             _LOGGER.info("%s setting brightness to %d", self._config.config_id, bright)
             settings = {
@@ -530,6 +541,7 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
             bright = 255
             r = self._brightness_dps.range(self._device)
             if r:
+                r = self._brightness_conversion_range(r, bright)
                 bright = color_util.brightness_to_value(r, bright)
             _LOGGER.info(
                 "%s turning light on to brightness %d",

--- a/custom_components/tuya_local/light.py
+++ b/custom_components/tuya_local/light.py
@@ -196,7 +196,10 @@ class TuyaLocalLight(TuyaLocalEntity, LightEntity):
             return val
 
     def _brightness_conversion_range(self, dp_range, value):
-        """Return the range used to convert non-off brightness values."""
+        """Return the conversion range for non-off brightness values.
+
+        Falsy source values keep the original range because 0 is treated as off.
+        """
         if not self._switch_dps and dp_range[0] == 0 and dp_range[1] > 0 and value:
             first_on_value = max(1, self._brightness_dps.step(self._device))
             if first_on_value <= dp_range[1]:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -377,6 +377,43 @@ async def test_async_turn_on_brightness_only_zero_range_write_uses_first_on_valu
 
 
 @pytest.mark.parametrize(
+    ("brightness_range", "mapping", "expected_dps"),
+    [
+        ({"min": 0, "max": 100}, [], 100),
+        ({"min": 0, "max": 1000}, [{"step": 10}], 1000),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_turn_on_brightness_only_zero_range_without_brightness_writes_max_value(
+    brightness_range, mapping, expected_dps
+):
+    """Brightness-only zero ranges should turn on to max when no brightness is set."""
+    mock_device = AsyncMock()
+    mock_device.get_property = Mock()
+    device_dps = {"1": 0}
+    mock_device.get_property.side_effect = lambda arg: device_dps[arg]
+    mock_config = Mock()
+    config = TuyaEntityConfig(
+        mock_config,
+        {
+            "entity": "light",
+            "dps": [
+                {
+                    "id": "1",
+                    "name": "brightness",
+                    "type": "integer",
+                    "range": brightness_range,
+                    "mapping": mapping,
+                },
+            ],
+        },
+    )
+    light = TuyaLocalLight(mock_device, config)
+    await light.async_turn_on()
+    mock_device.async_set_properties.assert_called_once_with({"1": expected_dps})
+
+
+@pytest.mark.parametrize(
     ("brightness_range", "mapping", "dps_value", "expected_brightness"),
     [
         ({"min": 0, "max": 100}, [], 1, 3),

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -376,6 +376,33 @@ async def test_async_turn_on_brightness_only_zero_range_write_uses_first_on_valu
     mock_device.async_set_properties.assert_called_once_with({assert_dp: expected_dps})
 
 
+@pytest.mark.asyncio
+async def test_async_turn_on_brightness_only_non_zero_range_write_keeps_range_min():
+    """Brightness-only non-zero ranges should not use the zero-off adjustment."""
+    mock_device = AsyncMock()
+    mock_device.get_property = Mock()
+    device_dps = {"1": 10}
+    mock_device.get_property.side_effect = lambda arg: device_dps[arg]
+    mock_config = Mock()
+    config = TuyaEntityConfig(
+        mock_config,
+        {
+            "entity": "light",
+            "dps": [
+                {
+                    "id": "1",
+                    "name": "brightness",
+                    "type": "integer",
+                    "range": {"min": 10, "max": 1000},
+                },
+            ],
+        },
+    )
+    light = TuyaLocalLight(mock_device, config)
+    await light.async_turn_on(brightness=1)
+    mock_device.async_set_properties.assert_called_once_with({"1": 10})
+
+
 @pytest.mark.parametrize(
     ("brightness_range", "mapping", "expected_dps"),
     [

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -314,3 +314,100 @@ async def test_is_off_when_off_by_brightness():
     light = TuyaLocalLight(mock_device, config)
     assert light.is_on is False
     assert light.brightness == 0
+
+
+@pytest.mark.parametrize(
+    ("brightness_range", "mapping", "expected_dps", "path"),
+    [
+        ({"min": 0, "max": 100}, [], 1, "brightness"),
+        ({"min": 0, "max": 1000}, [{"step": 10}], 10, "brightness"),
+        ({"min": 0, "max": 100}, [], 1, "white"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_turn_on_brightness_only_zero_range_write_uses_first_on_value(
+    brightness_range, mapping, expected_dps, path
+):
+    """Brightness-only zero ranges should reserve DP 0 for off."""
+    mock_device = AsyncMock()
+    mock_device.get_property = Mock()
+
+    if path == "white":
+        dps_config = [
+            {
+                "id": "1",
+                "name": "color_mode",
+                "type": "string",
+                "mapping": [
+                    {"dps_val": "white", "value": "white"},
+                    {"dps_val": "colour", "value": "hs"},
+                ],
+            },
+            {
+                "id": "2",
+                "name": "brightness",
+                "type": "integer",
+                "range": brightness_range,
+                "mapping": mapping,
+            },
+        ]
+        device_dps = {"1": "white", "2": 0}
+        call_kwargs = {"white": 1}
+        assert_dp = "2"
+    else:
+        dps_config = [
+            {
+                "id": "1",
+                "name": "brightness",
+                "type": "integer",
+                "range": brightness_range,
+                "mapping": mapping,
+            },
+        ]
+        device_dps = {"1": 0}
+        call_kwargs = {"brightness": 1}
+        assert_dp = "1"
+
+    mock_device.get_property.side_effect = lambda arg: device_dps[arg]
+    mock_config = Mock()
+    config = TuyaEntityConfig(mock_config, {"entity": "light", "dps": dps_config})
+    light = TuyaLocalLight(mock_device, config)
+    await light.async_turn_on(**call_kwargs)
+    mock_device.async_set_properties.assert_called_once_with({assert_dp: expected_dps})
+
+
+@pytest.mark.parametrize(
+    ("brightness_range", "mapping", "dps_value", "expected_brightness"),
+    [
+        ({"min": 0, "max": 100}, [], 1, 3),
+        ({"min": 0, "max": 1000}, [], 1, 1),
+        ({"min": 0, "max": 1000}, [{"step": 10}], 10, 1),
+    ],
+)
+def test_brightness_only_zero_range_read_uses_first_on_value_as_min_brightness(
+    brightness_range, mapping, dps_value, expected_brightness
+):
+    """Brightness-only zero ranges should read DP 1 using the on range."""
+    mock_device = AsyncMock()
+    mock_device.get_property = Mock()
+    device_dps = {"1": dps_value}
+    mock_device.get_property.side_effect = lambda arg: device_dps[arg]
+    mock_config = Mock()
+    config = TuyaEntityConfig(
+        mock_config,
+        {
+            "entity": "light",
+            "dps": [
+                {
+                    "id": "1",
+                    "name": "brightness",
+                    "type": "integer",
+                    "range": brightness_range,
+                    "mapping": mapping,
+                },
+            ],
+        },
+    )
+    light = TuyaLocalLight(mock_device, config)
+    assert light.is_on is True
+    assert light.brightness == expected_brightness


### PR DESCRIPTION
## Problem
Brightness-only light entities use the brightness DP as their on/off state. For zero-based ranges, DP 0 is the off value. Very low non-zero Home Assistant brightness can otherwise be converted or rounded to DP 0, so `light.turn_on(brightness=1)` can turn the light off instead of setting the first visible level (related analysis: #5197).

## Example
Kogan KAWHTNOSLPA `kogan_noise_machine.yaml` defines the light entity as DP 104 brightness with range `0..255` and no switch DP on the light entity. In this configured entity shape, tuya-local uses DP 104 for brightness and infers the on/off state from the same value.

This is a code-path example derived from the config only. I found neither a test on actual Kogan hardware nor a device-owner report confirming the physical behavior of DP 104.

## Change
For brightness-only lights with zero-based ranges, non-zero HA brightness is converted over the first-on value to max range, keeping DP 0 reserved for off. This also accounts for configured `step`, so low brightness does not round back to 0.

Regression tests were added for low-brightness writes and for reading the first on value.

## Impact / risk
A config scan found 36 light entities across 29 device configs matching the condition changed here: no `switch` DP on the light entity and a brightness range starting at 0.

For this entity shape, tuya-local already treats DP 0 as off: `async_turn_off()` writes 0, and `is_on` requires brightness greater than 0. Device-specific evidence for that convention exists for other matching devices (#2589, #2767, #1173), but it does not establish the behavior of Kogan DP 104. Some devices with the same config shape may still use DP 0 differently, so side effects are possible.

## Test plan
The integration code path was exercised with Home Assistant 2026.5.4 using a local fake Tuya device matching Kogan KAWHTNOSLPA / `kogan_noise_machine.yaml` ([fake_kogan_noise_machine.py](https://github.com/user-attachments/files/28507550/fake_kogan_noise_machine.py)), where DP 104 controlled the simulated light entity state, and with the regression tests.

The fake-device result validates the integration code path only; it is not hardware validation for the Kogan device.