### PR TITLE
Add generic water tank level monitor support

### DIFF
--- a/custom_components/tuya_local/devices/generic_water_tank_level_monitor.yaml
+++ b/custom_components/tuya_local/devices/generic_water_tank_level_monitor.yaml
@@ -1,0 +1,32 @@
+name: Water tank level monitor
+products:
+  - id: h8lvyoahr6s6aybf
+    manufacturer: Generic
+    model: Water Tank Level Indicator Monitor (Gauge)
+entities:
+  - entity: sensor
+    name: Water level
+    icon: "mdi:waves-arrow-up"
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        class: measurement
+        unit: "%"
+  - entity: sensor
+    name: Liquid level depth
+    category: diagnostic
+    class: distance
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        class: measurement
+        unit: mm
+  - entity: sensor
+    name: Liquid state
+    category: diagnostic
+    dps:
+      - id: 1
+        type: string
+        name: sensor

--- a/custom_components/tuya_local/devices/webber_ap9750_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/webber_ap9750_airpurifier.yaml
@@ -129,4 +129,4 @@ entities:
     dps:
       - id: 105
         type: boolean
-        name: switch
+        name: sensor


### PR DESCRIPTION
Adds support for a generic water tank level indicator/monitor (product ID: h8lvyoahr6s6aybf).

Exposes water level as a percentage (DPS 22), liquid depth in mm (DPS 2, diagnostic), and liquid state as a string sensor (DPS 1, diagnostic).