### PR TITLE
Add Qlima SC 7035S Air Conditioner

### DIFF
--- a/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
@@ -144,7 +144,7 @@ entities:
           - dps_val: null
             value: none
             hidden: true
-            
+
   - entity: sensor
     name: Outdoor temperature
     class: temperature
@@ -156,7 +156,7 @@ entities:
         optional: true
         mapping:
           - scale: 100
-          
+
   - entity: sensor
     class: energy
     dps:
@@ -178,7 +178,7 @@ entities:
         type: integer
         unit: rpm
         optional: true
-        
+ 
   - entity: sensor
     name: Compressor frequency
     class: frequency
@@ -261,7 +261,7 @@ entities:
             conditions:
               - dps_val: ["0", "2", "3", "4"]
                 invalid: true
-        
+
   - entity: switch
     name: Self-Clean Evaporator
     icon: mdi:water-sync
@@ -279,7 +279,7 @@ entities:
             conditions:
               - dps_val: true
                 invalid: true
-        
+
   - entity: select
     name: Sleep Mode
     icon: mdi:bed

--- a/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
@@ -141,9 +141,6 @@ entities:
             conditions:
               - dps_val: ["0", "2", "3"]
                 hidden: true
-          - dps_val: null
-            value: none
-            hidden: true
 
   - entity: sensor
     name: Outdoor temperature
@@ -171,7 +168,7 @@ entities:
 
   - entity: sensor
     name: External fan speed
-    icon: mdi:fan
+    icon: "mdi:fan"
     dps:
       - id: 117
         name: sensor
@@ -198,9 +195,9 @@ entities:
         type: boolean
         optional: true
 
-  - entity: switch
-    name: Display
-    icon: mdi:overscan
+  - entity: light
+    translation_key: display
+    icon: "mdi:overscan"
     category: config
     dps:
       - id: 13
@@ -209,18 +206,22 @@ entities:
         optional: true
 
   - entity: switch
-    name: Beep
-    icon: mdi:volume-high
+    translation_key: sound
+    icon: "mdi:volume-high"
     category: config
     dps:
       - id: 16
         name: switch
         type: boolean
         optional: true
+        mapping:
+          - dps_val: false
+            value: true
+          - dps_val: true
+            value: false
 
   - entity: switch
-    name: Health Mode
-    icon: mdi:medication-outline
+    translation_key: ionizer
     dps:
       - id: 4
         name: hvac_mode_internal
@@ -237,8 +238,8 @@ entities:
                 invalid: true
 
   - entity: switch
-    name: Gentle Wind
-    icon: mdi:weather-windy
+    name: Gentle wind
+    icon: "mdi:weather-windy"
     dps:
       - id: 4
         name: hvac_mode_internal
@@ -263,26 +264,26 @@ entities:
                 invalid: true
 
   - entity: switch
-    name: Self-Clean Evaporator
-    icon: mdi:water-sync
+    name: Self clean
+    icon: "mdi:water-sync"
     dps:
       - id: 1
-        name: power_state
+        name: available
         type: boolean
         hidden: true
+        mapping:
+          - dps_val: true
+            value: false
+          - dps_val: false
+            value: true
       - id: 27
         name: switch
         type: boolean
         optional: true
-        mapping:
-          - constraint: power_state
-            conditions:
-              - dps_val: true
-                invalid: true
 
   - entity: select
-    name: Sleep Mode
-    icon: mdi:bed
+    name: Sleep mode
+    icon: "mdi:bed"
     dps:
       - id: 126
         name: option

--- a/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
@@ -1,0 +1,299 @@
+name: Air conditioner
+products:
+  - id: nn2ooaacswz6uyi0
+    manufacturer: Qlima
+    model: SC 7035S Air Conditioner
+entities:
+  - entity: climate
+    translation_key: aircon_extra
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "0"
+                value: heat_cool
+              - dps_val: "1"
+                value: cool
+              - dps_val: "2"
+                value: dry
+              - dps_val: "3"
+                value: fan_only
+              - dps_val: "4"
+                value: heat
+      - id: 4
+        name: mode
+        type: string
+        hidden: true
+      - id: 2
+        name: temperature
+        type: integer
+        unit: C
+        range:
+          min: 1600
+          max: 3100
+        mapping:
+          - scale: 100
+            step: 50
+      - id: 3
+        name: current_temperature
+        type: integer
+        unit: C
+        mapping:
+          - scale: 100
+      - id: 5
+        type: string
+        name: manual_fan_mode
+        hidden: true
+      - id: 7
+        name: fan_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            value: auto
+          - dps_val: false
+            constraint: manual_fan_mode
+            conditions:
+              - dps_val: "0"
+                value: "off"
+                hidden: true
+              - dps_val: "1"
+                value: quiet
+              - dps_val: "2"
+                value: low
+              - dps_val: "3"
+                value: medlow
+              - dps_val: "4"
+                value: medium
+              - dps_val: "5"
+                value: medhigh
+              - dps_val: "6"
+                value: high
+              - dps_val: "7"
+                value: strong
+      - id: 31
+        name: swing_mode
+        type: string
+        mapping:
+          - dps_val: "8"
+            value: "off"
+          - dps_val: "1"
+            value: "on"
+          - dps_val: "2"
+            value: upper_half
+          - dps_val: "3"
+            value: lower_half
+          - dps_val: "6"
+            value: surround
+          - dps_val: "9"
+            value: topmost
+          - dps_val: "10"
+            value: top
+          - dps_val: "11"
+            value: middle
+          - dps_val: "12"
+            value: down
+          - dps_val: "13"
+            value: downmost
+      - id: 34
+        name: swing_horizontal_mode
+        type: string
+        mapping:
+          - dps_val: "8"
+            value: "off"
+          - dps_val: "1"
+            value: "on"
+          - dps_val: "2"
+            value: left_swing
+          - dps_val: "3"
+            value: center_swing
+          - dps_val: "4"
+            value: right_swing
+          - dps_val: "5"
+            value: direct
+          - dps_val: "9"
+            value: leftmost
+          - dps_val: "10"
+            value: left
+          - dps_val: "11"
+            value: center
+          - dps_val: "12"
+            value: right
+          - dps_val: "13"
+            value: rightmost
+          - dps_val: "17"
+            value: surround
+      - id: 8
+        name: preset_mode
+        type: boolean
+        optional: true
+        mapping:
+          - dps_val: false
+            value: none
+          - dps_val: true
+            value: eco
+            constraint: mode
+            conditions:
+              - dps_val: ["0", "2", "3"]
+                hidden: true
+          - dps_val: null
+            value: none
+            hidden: true
+            
+  - entity: sensor
+    name: Outdoor temperature
+    class: temperature
+    dps:
+      - id: 116
+        name: sensor
+        type: integer
+        unit: C
+        optional: true
+        mapping:
+          - scale: 100
+          
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 127
+        name: sensor
+        type: integer
+        unit: kWh
+        class: total_increasing
+        optional: true
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: External fan speed
+    icon: mdi:fan
+    dps:
+      - id: 117
+        name: sensor
+        type: integer
+        unit: rpm
+        optional: true
+        
+  - entity: sensor
+    name: Compressor frequency
+    class: frequency
+    dps:
+      - id: 119
+        name: sensor
+        type: integer
+        unit: Hz
+        optional: true
+
+  - entity: binary_sensor
+    name: Filter blockage
+    class: problem
+    dps:
+      - id: 110
+        name: sensor
+        type: boolean
+        optional: true
+
+  - entity: switch
+    name: Display
+    icon: mdi:overscan
+    category: config
+    dps:
+      - id: 13
+        name: switch
+        type: boolean
+        optional: true
+
+  - entity: switch
+    name: Beep
+    icon: mdi:volume-high
+    category: config
+    dps:
+      - id: 16
+        name: switch
+        type: boolean
+        optional: true
+
+  - entity: switch
+    name: Health Mode
+    icon: mdi:medication-outline
+    dps:
+      - id: 4
+        name: hvac_mode_internal
+        type: string
+        hidden: true
+      - id: 26
+        name: switch
+        type: boolean
+        optional: true
+        mapping:
+          - constraint: hvac_mode_internal
+            conditions:
+              - dps_val: ["0", "2", "3"]
+                invalid: true
+
+  - entity: switch
+    name: Gentle Wind
+    icon: mdi:weather-windy
+    dps:
+      - id: 4
+        name: hvac_mode_internal
+        type: string
+        hidden: true
+      - id: 123
+        name: switch
+        type: string
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: false
+            constraint: hvac_mode_internal
+            conditions:
+              - dps_val: ["0", "2", "3", "4"]
+                invalid: true
+          - dps_val: "1"
+            value: true
+            constraint: hvac_mode_internal
+            conditions:
+              - dps_val: ["0", "2", "3", "4"]
+                invalid: true
+        
+  - entity: switch
+    name: Self-Clean Evaporator
+    icon: mdi:water-sync
+    dps:
+      - id: 1
+        name: power_state
+        type: boolean
+        hidden: true
+      - id: 27
+        name: switch
+        type: boolean
+        optional: true
+        mapping:
+          - constraint: power_state
+            conditions:
+              - dps_val: true
+                invalid: true
+        
+  - entity: select
+    name: Sleep Mode
+    icon: mdi:bed
+    dps:
+      - id: 126
+        name: option
+        type: string
+        optional: true
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: "standard"
+          - dps_val: "2"
+            value: "elderly"
+          - dps_val: "3"
+            value: "child"

--- a/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/qlima_sc7035s_air_conditioner.yaml
@@ -178,7 +178,7 @@ entities:
         type: integer
         unit: rpm
         optional: true
- 
+
   - entity: sensor
     name: Compressor frequency
     class: frequency


### PR DESCRIPTION
Adds a new device configuration file for the Qlima SC 7035S Air Conditioner. 

Supported features include:
- **Climate:** HVAC modes (auto, cool, dry, fan_only, heat), target/current temperature, fan speeds (auto + 7 manual levels).
- **Swing:** Vertical and horizontal swing control.
- **Presets:** Eco mode and Sleep curves (Standard, Elderly, Child) with mode constraints.
- **Switches:** Display, Beep, Health Mode, Gentle Wind, and Self-Clean Evaporator (with appropriate power/mode constraints).
- **Sensors:** Outdoor temperature, compressor frequency, external fan speed, energy consumption, and error codes.

The configuration has been tested locally and works correctly.
