### PR TITLE
Add support for Comfort Zone Tower Fan (CZTF423S)

### DIFF
--- a/custom_components/tuya_local/devices/ciztf423s_tower_fan.yaml
+++ b/custom_components/tuya_local/devices/ciztf423s_tower_fan.yaml
@@ -1,64 +1,63 @@
-name: Tallboy Tower Fan
+name: Comfort Zone Tower Fan
 products:
   - id: eb414680be46558e014mtb
-    name: TOWER FAN（CZTF423S）
-primary_entity:
-  entity: fan
-  dps:
-    - dp: 1
-      name: switch
-      type: boolean
-    - dp: 2
-      name: preset_mode
-      type: string
-      mapping:
-        - dpsval: normal
-          value: normal
-        - dpsval: nature
-          value: nature
-        - dpsval: sleep
-          value: sleep
-    - dp: 3
-      name: speed
-      type: integer
-      range:
-        min: 1
-        max: 5
-    - dp: 5
-      name: oscillate
-      type: boolean
-secondary_entities:
+    name: Tower Fan（CZTF423S）
+entities:
+  - entity: fan
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: normal
+            value: normal
+          - dps_val: nature
+            value: nature
+          - dps_val: sleep
+            value: sleep
+      - id: 3
+        name: speed
+        type: integer
+        range:
+          min: 1
+          max: 5
+      - id: 5
+        name: oscillate
+        type: boolean
   - entity: select
     name: Sleep Timer
     icon: mdi:timer-outline
     dps:
-      - dp: 22
-        name: select_option
+      - id: 22
+        name: option
         type: string
         mapping:
-          - dpsval: cancel
+          - dps_val: cancel
             value: cancel
-          - dpsval: 1h
+          - dps_val: 1h
             value: 1h
-          - dpsval: 2h
+          - dps_val: 2h
             value: 2h
-          - dpsval: 3h
+          - dps_val: 3h
             value: 3h
-          - dpsval: 4h
+          - dps_val: 4h
             value: 4h
-          - dpsval: 5h
+          - dps_val: 5h
             value: 5h
-          - dpsval: 6h
+          - dps_val: 6h
             value: 6h
-          - dpsval: 7h
+          - dps_val: 7h
             value: 7h
-          - dpsval: 8h
+          - dps_val: 8h
             value: 8h
-          - dpsval: 9h
+          - dps_val: 9h
             value: 9h
-          - dpsval: 10h
+          - dps_val: 10h
             value: 10h
-          - dpsval: 11h
+          - dps_val: 11h
             value: 11h
-          - dpsval: 12h
+          - dps_val: 12h
             value: 12h

--- a/custom_components/tuya_local/devices/ciztf423s_tower_fan.yaml
+++ b/custom_components/tuya_local/devices/ciztf423s_tower_fan.yaml
@@ -1,0 +1,64 @@
+name: Tallboy Tower Fan
+products:
+  - id: eb414680be46558e014mtb
+    name: TOWER FAN（CZTF423S）
+primary_entity:
+  entity: fan
+  dps:
+    - dp: 1
+      name: switch
+      type: boolean
+    - dp: 2
+      name: preset_mode
+      type: string
+      mapping:
+        - dpsval: normal
+          value: normal
+        - dpsval: nature
+          value: nature
+        - dpsval: sleep
+          value: sleep
+    - dp: 3
+      name: speed
+      type: integer
+      range:
+        min: 1
+        max: 5
+    - dp: 5
+      name: oscillate
+      type: boolean
+secondary_entities:
+  - entity: select
+    name: Sleep Timer
+    icon: mdi:timer-outline
+    dps:
+      - dp: 22
+        name: select_option
+        type: string
+        mapping:
+          - dpsval: cancel
+            value: cancel
+          - dpsval: 1h
+            value: 1h
+          - dpsval: 2h
+            value: 2h
+          - dpsval: 3h
+            value: 3h
+          - dpsval: 4h
+            value: 4h
+          - dpsval: 5h
+            value: 5h
+          - dpsval: 6h
+            value: 6h
+          - dpsval: 7h
+            value: 7h
+          - dpsval: 8h
+            value: 8h
+          - dpsval: 9h
+            value: 9h
+          - dpsval: 10h
+            value: 10h
+          - dpsval: 11h
+            value: 11h
+          - dpsval: 12h
+            value: 12h

--- a/custom_components/tuya_local/devices/ciztf423s_tower_fan.yaml
+++ b/custom_components/tuya_local/devices/ciztf423s_tower_fan.yaml
@@ -1,9 +1,11 @@
-name: Comfort Zone Tower Fan
+name: Tower Fan
 products:
   - id: eb414680be46558e014mtb
-    name: Tower Fan（CZTF423S）
+    manufacturer: Comfort Zone
+    model: CZTF423S
 entities:
   - entity: fan
+    translation_key: fan_with_presets
     dps:
       - id: 1
         name: switch
@@ -28,8 +30,8 @@ entities:
         name: oscillate
         type: boolean
   - entity: select
-    name: Sleep Timer
-    icon: mdi:timer-outline
+    translation_key: timer
+    category: config
     dps:
       - id: 22
         name: option


### PR DESCRIPTION
Adds device configuration for the Comfort Zone CZTF423S tower fan with:
- Primary fan entity with speed control (1-5) and oscillation
- Sleep timer select entity with 1-12 hour options
- Support for normal, nature, and sleep preset modes

All gathered using the tinytuya monitor and tested on my device.