### PR TITLE
Add Inkbird ISC-028-BW and CRC16/MODBUS checksum support

### DIFF
--- a/custom_components/tuya_local/devices/device_config_schema.json
+++ b/custom_components/tuya_local/devices/device_config_schema.json
@@ -227,6 +227,11 @@
                                     "enum": ["big", "little"],
                                     "description": "The endianness of masked data in the base64 or hex DP. Default is 'big', so only 'little' needs to be explicitly specified."
                                 },
+                                "crc16_modbus": {
+                                    "type": "integer",
+                                    "minimum": 2,
+                                    "description": "Byte offset of a CRC-16/MODBUS checksum stored as uint16 little-endian. Recomputed over bytes 0 to offset-1 whenever this DP is written."
+                                },
                                 "unit": {
                                     "type": "string",
                                     "description": "The unit of measurement for a sensor DP (e.g., °C, %, W). Some units can use ASCII replacements like C for °C, F for °F, and ugm3 for μg/m³ to simplify input and avoid accidental incorrect Unicode character usage."

--- a/custom_components/tuya_local/devices/inkbird_isc028bw_smokercontrol.yaml
+++ b/custom_components/tuya_local/devices/inkbird_isc028bw_smokercontrol.yaml
@@ -1,0 +1,351 @@
+# Inkbird ISC-028-BW WiFi smoker (5 probes, fan PID, hold target)
+# Product id: 8l5th5vqvszbuvlm | Tuya model id: e1ku12z0
+# DP 101 real_time_data: 11 bytes — 5x uint16 LE (÷10 °F) + fan % (byte 10, read-only)
+# DP 102 setting_para: 92 bytes — byte 0 fan; byte 1 °C/°F; bytes 7-8 hold (÷10 °F); byte 80 sound
+# DP 102 bytes 90-91: CRC-16/MODBUS over bytes 0-89 (crc16_modbus: 90 on writes)
+# Masks for endianness: little — FFFF at LSB end (see INT-12-BW pattern)
+# Requires Tuya protocol 3.5 locally
+
+name: BBQ smoker
+products:
+  - id: 8l5th5vqvszbuvlm
+    manufacturer: Inkbird
+    model: ISC-028-BW
+
+entities:
+  - entity: climate
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        force: true
+        crc16_modbus: 90
+        name: hvac_mode
+        mask: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff"
+        endianness: little
+        mapping:
+          - dps_val: 0
+            value: "off"
+          - dps_val: 1
+            value: heat
+          - value: heat
+            hidden: true
+      - id: 101
+        type: base64
+        optional: true
+        force: true
+        name: current_temperature
+        mask: "000000000000000000FFFF"
+        endianness: little
+        unit: F
+        mapping:
+          - scale: 10
+          - dps_val: 6000
+            value: null
+      - id: 102
+        type: base64
+        optional: true
+        crc16_modbus: 90
+        name: temperature
+        mask: "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000FFFF00000000000000"
+        endianness: little
+        unit: F
+        range:
+          min: 0
+          max: 3080
+        mapping:
+          - scale: 10
+
+  # Press once if fan/climate writes fail with "Cannot mask unknown current value"
+  # (device had not yet reported DP 102 locally). Safe to repeat.
+  - entity: button
+    name: Initialize settings
+    category: config
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        crc16_modbus: 90
+        name: button
+        mapping:
+          - value: true
+            dps_val: "AQEAAAAAANAIDBcMFwwXDBcMFwAAAAAAAAAAAAAAAAAAAAUFBQUFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAp3s="
+
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        crc16_modbus: 90
+        name: option
+        mask: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000FF00"
+        endianness: little
+        mapping:
+          - dps_val: 0
+            value: celsius
+          - dps_val: 1
+            value: fahrenheit
+
+  - entity: switch
+    name: Sound
+    category: config
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        crc16_modbus: 90
+        name: switch
+        mask: "0000000000000000000000FF0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        endianness: little
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 1
+            value: true
+
+  - entity: sensor
+    name: Fan output
+    category: diagnostic
+    dps:
+      - id: 101
+        type: base64
+        optional: true
+        name: sensor
+        class: measurement
+        mask: "FF00000000000000000000"
+        endianness: little
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+
+  - entity: sensor
+    name: Grill temperature
+    class: temperature
+    hidden: unavailable
+    dps:
+      - id: 101
+        type: base64
+        optional: true
+        name: sensor
+        class: measurement
+        mask: "000000000000000000FFFF"
+        endianness: little
+        unit: F
+        mapping:
+          - scale: 10
+          - dps_val: 6000
+            value: null
+      - id: 101
+        type: base64
+        optional: true
+        name: available
+        mask: "000000000000000000FFFF"
+        endianness: little
+        mapping:
+          - dps_val: 6000
+            value: false
+          - value: true
+
+  - entity: sensor
+    name: Meat probe 1
+    class: temperature
+    hidden: unavailable
+    dps:
+      - id: 101
+        type: base64
+        optional: true
+        name: sensor
+        class: measurement
+        mask: "00000000000000FFFF0000"
+        endianness: little
+        unit: F
+        mapping:
+          - scale: 10
+          - dps_val: 6000
+            value: null
+      - id: 101
+        type: base64
+        optional: true
+        name: available
+        mask: "00000000000000FFFF0000"
+        endianness: little
+        mapping:
+          - dps_val: 6000
+            value: false
+          - value: true
+
+  - entity: sensor
+    name: Meat probe 2
+    class: temperature
+    hidden: unavailable
+    dps:
+      - id: 101
+        type: base64
+        optional: true
+        name: sensor
+        class: measurement
+        mask: "0000000000FFFF00000000"
+        endianness: little
+        unit: F
+        mapping:
+          - scale: 10
+          - dps_val: 6000
+            value: null
+      - id: 101
+        type: base64
+        optional: true
+        name: available
+        mask: "0000000000FFFF00000000"
+        endianness: little
+        mapping:
+          - dps_val: 6000
+            value: false
+          - value: true
+
+  - entity: sensor
+    name: Meat probe 3
+    class: temperature
+    hidden: unavailable
+    dps:
+      - id: 101
+        type: base64
+        optional: true
+        name: sensor
+        class: measurement
+        mask: "000000FFFF000000000000"
+        endianness: little
+        unit: F
+        mapping:
+          - scale: 10
+          - dps_val: 6000
+            value: null
+      - id: 101
+        type: base64
+        optional: true
+        name: available
+        mask: "000000FFFF000000000000"
+        endianness: little
+        mapping:
+          - dps_val: 6000
+            value: false
+          - value: true
+
+  - entity: sensor
+    name: Meat probe 4
+    class: temperature
+    hidden: unavailable
+    dps:
+      - id: 101
+        type: base64
+        optional: true
+        name: sensor
+        class: measurement
+        mask: "00FFFF0000000000000000"
+        endianness: little
+        unit: F
+        mapping:
+          - scale: 10
+          - dps_val: 6000
+            value: null
+      - id: 101
+        type: base64
+        optional: true
+        name: available
+        mask: "00FFFF0000000000000000"
+        endianness: little
+        mapping:
+          - dps_val: 6000
+            value: false
+          - value: true
+
+  - entity: binary_sensor
+    name: Grill open
+    class: door
+    category: diagnostic
+    dps:
+      - id: 103
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 65536
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    name: Meat probe 1 lost
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 103
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 1024
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    name: Meat probe 2 lost
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 103
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 2048
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    name: Meat probe 3 lost
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 103
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4096
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    name: Meat probe 4 lost
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 103
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 8192
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 103
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 103
+        type: bitfield
+        name: fault_code
+
+  - entity: switch
+    name: OTA update
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+        optional: true

--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -95,6 +95,24 @@ def to_signed(val, bits):
     return val
 
 
+def _crc16_modbus(data):
+    """CRC-16/MODBUS over data."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xA001 if crc & 1 else crc >> 1
+    return crc
+
+
+def _apply_crc16_modbus(payload, offset):
+    """Write CRC-16/MODBUS (uint16 LE) at byte offset."""
+    data = bytearray(payload)
+    crc = _crc16_modbus(data[:offset])
+    data[offset : offset + 2] = crc.to_bytes(2, "little")
+    return bytes(data)
+
+
 class TuyaDeviceConfig:
     """Representation of a device config for Tuya Local devices."""
 
@@ -1134,6 +1152,14 @@ class TuyaDpsConfig:
                 current_value = int.from_bytes(decoded_value, endianness)
                 result = (current_value & ~mask) | (mask & int(result * mask_scale))
                 result = self.encode_value(result.to_bytes(length, endianness))
+
+        crc_offset = self._config.get("crc16_modbus")
+        if crc_offset is not None and self.rawtype in ["hex", "base64", "utf16b64"]:
+            decoded = self.decode_value(result, device)
+            if isinstance(decoded, bytes) and len(decoded) >= crc_offset + 2:
+                result = self.encode_value(
+                    _apply_crc16_modbus(decoded, crc_offset)
+                )
 
         dps_map[self.id] = self._correct_type(result)
         return dps_map

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -11,6 +11,7 @@ from custom_components.tuya_local.helpers.device_config import (
     TuyaDpsConfig,
     TuyaEntityConfig,
     _bytes_to_fmt,
+    _crc16_modbus,
     _typematch,
     available_configs,
     get_config,
@@ -120,6 +121,7 @@ DP_SCHEMA = vol.Schema(
         vol.Optional("mask"): str,
         vol.Optional("endianness"): vol.In(["little"]),
         vol.Optional("mask_signed"): True,
+        vol.Optional("crc16_modbus"): int,
     }
 )
 ENTITY_SCHEMA = vol.Schema(
@@ -836,6 +838,41 @@ def test_setting_masked_b64_with_special_case_mapping(mocker):
     mock_device.get_property.return_value = "AAA="
     cfg = TuyaDpsConfig(mock_entity, mock_config)
     assert cfg.get_values_to_set(mock_device, "special_case") == {"1": "AQA="}
+
+
+def test_setting_masked_b64_with_crc16_modbus(mocker):
+    """Masked base64 writes update CRC-16/MODBUS when crc16_modbus is set."""
+    import base64
+
+    sound_on_b64 = (
+        "AAEAAAAAAMoIDBcMFwwXDBcMFwAAAAAAAAAAAAAAAAAAAAUFBQUFAAAAAAAA/wAAAAAAAP8A"
+        "AAAAAAD/AAAAAAAA/wAAAAAAAP8AAAAAAAEBAAD/SSYCAwQZkbc="
+    )
+    sound_on = base64.b64decode(sound_on_b64)
+    assert len(sound_on) == 92
+
+    mock_entity = mocker.MagicMock()
+    mock_config = {
+        "id": "102",
+        "name": "switch",
+        "type": "base64",
+        "crc16_modbus": 90,
+        "endianness": "little",
+        "mask": "0000000000000000000000FF0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "mapping": [
+            {"dps_val": 0, "value": False},
+            {"dps_val": 1, "value": True},
+        ],
+    }
+    mock_device = mocker.MagicMock()
+    mock_device.get_property.return_value = sound_on_b64
+    cfg = TuyaDpsConfig(mock_entity, mock_config)
+
+    result = cfg.get_values_to_set(mock_device, False)["102"]
+    out = base64.b64decode(result)
+
+    assert out[80] == 0
+    assert _crc16_modbus(out[:90]) == int.from_bytes(out[90:92], "little")
 
 
 def test_default_without_mapping(mocker):


### PR DESCRIPTION
## Summary

Adds support for the **Inkbird ISC-028-BW** WiFi smoker controller and introduces
`crc16_modbus` for device configs that use masked writes into CRC-protected
base64/hex blobs.

The ISC-028-BW stores all user settings in DP `102` (`setting_para`, 92 bytes).
Bytes 90–91 hold a **CRC-16/MODBUS** checksum over bytes 0–89. Standard masked
writes merge the changed field but leave the old checksum, which the device
silently rejects. DP `109` (boolean OTA) works without this because it is not
a blob DP.

Verified against Tuya IoT **Device Logs** and live Home Assistant testing
(protocol **3.5** required).

## Device: Inkbird ISC-028-BW

| Field | Value |
|-------|-------|
| Product ID | `8l5th5vqvszbuvlm` |
| Model ID | `e1ku12z0` |
| Protocol | 3.5 (3.3/auto failed in testing) |

### DPs

| DP | Code | Access | Notes |
|----|------|--------|-------|
| 101 | `real_time_data` | ro | 11 bytes: 5 temps (uint16 LE ÷10 °F) + fan PID % (byte 10) |
| 102 | `setting_para` | rw | 92 bytes; CRC at bytes 90–91 |
| 103 | `alarm` | ro | Bitmap (probe lost, grill open, etc.) |
| 104–108 | presets | rw | Not decoded yet |
| 109 | `ota_update` | rw | Boolean |

### DP 102 layout (verified)

| Offset | Field |
|--------|-------|
| 0 | Fan on/off (`0`/`1`) |
| 1 | LCD unit (`0`=°C, `1`=°F) |
| 7–8 | Hold target (uint16 LE ÷10, stored as °F internally) |
| 80 | Sound (`0`/`1`) |
| 90–91 | CRC-16/MODBUS over bytes 0–89 (uint16 LE) |

Disconnected probe sentinel on DP 101: `6000` (`0x1770`).

### Home Assistant entities

- **Climate** — grill temp (read), fan on/off + hold target (write via DP 102)
- **Fan output** sensor — PID fan % (read-only, DP 101 byte 10)
- **Temperature unit** select — DP 102 byte 1
- **Sound** switch — DP 102 byte 80
- **Initialize settings** button — seeds DP 102 if not yet cached locally
- Temperature sensors for grill + 4 meat probes
- Alarm binary sensors (grill open, probe lost)

Fan on/off is controlled via **Climate** (Heat/Off), not a separate fan entity,
because byte 10 of DP 101 is PID output only.

## Core change: `crc16_modbus`

Optional integer on a DP config. When set (byte offset of checksum), any write
to that DP recomputes CRC-16/MODBUS over `payload[0:offset]` and stores the
result as uint16 little-endian at `payload[offset:offset+2]`.

This is generic and may help other Inkbird/raw-blob devices; ISC-028-BW is
the first consumer.

## Test plan

- [x] `pytest tests/test_device_config.py -k crc16_modbus`
- [ ] Add device in Tuya Local with protocol **3.5**, product `8l5th5vqvszbuvlm`
- [ ] Reads: grill/meat temps, fan PID %, hold target match hardware LCD
- [ ] Write **Sound** off → device stops beeping
- [ ] Write **Temperature unit** °C → LCD switches to Celsius
- [ ] **Climate Off** → fan stops; **Heat** + target temp → fan runs toward hold
- [ ] Diagnostics: cached DP 102 changes after writes; bytes 90–91 match new CRC

## Notes

- Different protocol from ISC-007-BW (integer DPs) and IBBQ-4BW (integer probe DPs).
- Similar raw/base64 style to INT-12-BW, but ISC-028 uses one CRC-protected settings blob.
- Presets (DP 104–108) not exposed yet.
