### PR TITLE
Change MPa to mPa

### DIFF
--- a/custom_components/tuya_local/devices/intaflo_intabloc_airwaterheatpump.yaml
+++ b/custom_components/tuya_local/devices/intaflo_intabloc_airwaterheatpump.yaml
@@ -312,7 +312,7 @@ entities:
       - id: 114
         type: integer
         name: sensor
-        unit: MPa
+        unit: mPa
         class: measurement
         mapping:
           - scale: 1000
@@ -324,7 +324,7 @@ entities:
       - id: 115
         type: integer
         name: sensor
-        unit: MPa
+        unit: mPa
         class: measurement
         mapping:
           - scale: 1000


### PR DESCRIPTION
Entity sensor.heat_pump_high_pressure (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using native unit of measurement 'MPa' which is not a valid unit for the device class ('pressure') it is using; expected one of ['Pa', 'kPa', 'inHg', 'bar', 'psi', 'inH₂O', 'hPa', 'cbar', 'mPa', 'mmHg', 'mbar']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues Entity 

sensor.heat_pump_low_pressure (<class 'custom_components.tuya_local.sensor.TuyaLocalSensor'>) is using native unit of measurement 'MPa' which is not a valid unit for the device class ('pressure') it is using; expected one of ['Pa', 'kPa', 'inHg', 'bar', 'psi', 'inH₂O', 'hPa', 'cbar', 'mPa', 'mmHg', 'mbar']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/make-all/tuya-local/issues

- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Please describe in simple terms what you are submitting. Do not paste a multi-page AI generated rambling story here, as the maintainers do not have time to read that.
