### PR TITLE
add: Support of Afyeev 32A EV Charger

### DIFF
--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -33,13 +33,6 @@ entities:
         type: string
         name: system_version
   - entity: sensor
-    name: Firmware version
-    category: diagnostic
-    dps:
-      - id: 23
-        type: string
-        name: sensor
-  - entity: sensor
     class: energy
     dps:
       - id: 1
@@ -58,24 +51,23 @@ entities:
       - id: 4
         type: integer
         name: option
-        unit: A
         mapping:
           - dps_val: 6
-            value: "6"
+            value: "6A"
           - dps_val: 8
-            value: "8"
+            value: "8A"
           - dps_val: 10
-            value: "10"
+            value: "10A"
           - dps_val: 13
-            value: "13"
+            value: "13A"
           - dps_val: 16
-            value: "16"
+            value: "16A"
           - dps_val: 20
-            value: "20"
+            value: "20A"
           - dps_val: 24
-            value: "24"
+            value: "24A"
           - dps_val: 32
-            value: "32"
+            value: "32A"
   - entity: sensor
     class: power
     dps:
@@ -87,17 +79,9 @@ entities:
         optional: true
         mapping:
           - scale: 1000
-  - entity: sensor
-    name: "Single phase power"
-    class: power
-    category: diagnostic
-    hidden: true
-    dps:
       - id: 5
         type: integer
-        name: sensor
-        unit: kW
-        class: measurement
+        name: single_phase
         optional: true
         mapping:
           - scale: 1000

--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -209,16 +209,6 @@ entities:
             value: scheduled_charge
           - dps_val: charge_delay
             value: delayed_charge
-  - entity: button
-    name: Clear energy
-    class: restart
-    category: config
-    hidden: unavailable
-    dps:
-      - id: 16
-        type: boolean
-        optional: true
-        name: button
   - entity: switch
     icon: "mdi:ev-station"
     dps:
@@ -260,16 +250,3 @@ entities:
             value: false
           - dps_val: online
             value: true
-  - entity: number
-    translation_key: timer
-    class: duration
-    category: config
-    dps:
-      - id: 28
-        type: integer
-        name: value
-        unit: h
-        optional: true
-        range:
-          min: 0
-          max: 15

--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -33,6 +33,13 @@ entities:
         type: string
         name: system_version
   - entity: sensor
+    name: Firmware version
+    category: diagnostic
+    dps:
+      - id: 23
+        type: string
+        name: sensor
+  - entity: sensor
     class: energy
     dps:
       - id: 1
@@ -201,12 +208,6 @@ entities:
         mapping:
           - dps_val: charge_now
             value: immediate
-          - dps_val: charge_pct
-            value: charge_to_percent
-          - dps_val: charge_energy
-            value: fixed_charge
-          - dps_val: charge_schedule
-            value: scheduled_charge
           - dps_val: charge_delay
             value: delayed_charge
   - entity: switch
@@ -250,3 +251,17 @@ entities:
             value: false
           - dps_val: online
             value: true
+  - entity: number
+    name: "Charging start delay"
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 28
+        type: integer
+        name: value
+        unit: h
+        optional: true
+        range:
+          min: 0
+          max: 15

--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -70,6 +70,7 @@ entities:
           - dps_val: 32
             value: "32"
   - entity: sensor
+    name: Power total
     class: power
     dps:
       - id: 9
@@ -81,9 +82,10 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Single phase power
+    name: "Single phase power"
     class: power
     category: diagnostic
+    hidden: true
     dps:
       - id: 5
         type: integer
@@ -94,6 +96,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
+    name: Voltage
     class: voltage
     category: diagnostic
     dps:
@@ -106,6 +109,7 @@ entities:
         mapping:
           - scale: 10
   - entity: sensor
+    name: Current
     class: current
     category: diagnostic
     dps:
@@ -118,7 +122,9 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
+    name: Power
     class: power
+    hidden: true
     category: diagnostic
     dps:
       - id: 6

--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -1,0 +1,274 @@
+name: EV charger
+products:
+  - id: dsmsam7xpb3ht7rl
+    manufacturer: Afyeev
+    model: "32A 7kW EV charger"
+entities:
+  - entity: sensor
+    translation_key: status
+    icon: "mdi:ev-station"
+    class: enum
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: charger_charging
+            value: charging
+          - dps_val: charger_free
+            value: available
+          - dps_val: charger_insert
+            value: plugged_in
+          - dps_val: charger_free_fault
+            value: fault_unplugged
+          - dps_val: charger_wait
+            value: waiting
+          - dps_val: charger_pause
+            value: paused
+          - dps_val: charger_end
+            value: charged
+          - dps_val: charger_fault
+            value: fault
+      - id: 23
+        type: string
+        name: system_version
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        optional: true
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: select
+    name: Charging current
+    category: config
+    icon: "mdi:ev-plug-type2"
+    dps:
+      - id: 4
+        type: integer
+        name: option
+        unit: A
+        mapping:
+          - dps_val: 6
+            value: "6"
+          - dps_val: 8
+            value: "8"
+          - dps_val: 10
+            value: "10"
+          - dps_val: 13
+            value: "13"
+          - dps_val: 16
+            value: "16"
+          - dps_val: 20
+            value: "20"
+          - dps_val: 24
+            value: "24"
+          - dps_val: 32
+            value: "32"
+  - entity: sensor
+    class: power
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Single phase power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    translation_key: voltage_x
+    translation_placeholders:
+      x: A
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: current
+    category: diagnostic
+    translation_key: current_x
+    translation_placeholders:
+      x: A
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "000000FFFF000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: power
+    category: diagnostic
+    translation_key: power_x
+    translation_placeholders:
+      x: A
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        class: measurement
+        mask: "000000000000FFFF"
+        mapping:
+          - scale: 1000
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10
+        type: bitfield
+        name: fault_code
+      - id: 10
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: Over current
+          - dps_val: 2
+            value: Over voltage
+          - dps_val: 4
+            value: Under voltage
+          - dps_val: 8
+            value: Contact adhesion fault
+          - dps_val: 16
+            value: Contact fault
+          - dps_val: 32
+            value: Earth fault
+          - dps_val: 64
+            value: Meter fault
+          - dps_val: 128
+            value: Scram fault
+          - dps_val: 256
+            value: CP fault
+          - dps_val: 512
+            value: Communication fault
+          - dps_val: 1024
+            value: Card reader fault
+          - dps_val: 2048
+            value: Short circuit
+          - dps_val: 4096
+            value: Adhesion fault
+          - dps_val: 8192
+            value: Self test
+          - dps_val: 16384
+            value: Earth leak
+  - entity: select
+    translation_key: charging_mode
+    category: config
+    dps:
+      - id: 14
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: immediate
+          - dps_val: charge_pct
+            value: charge_to_percent
+          - dps_val: charge_energy
+            value: fixed_charge
+          - dps_val: charge_schedule
+            value: scheduled_charge
+          - dps_val: charge_delay
+            value: delayed_charge
+  - entity: button
+    name: Clear energy
+    class: restart
+    category: config
+    hidden: unavailable
+    dps:
+      - id: 16
+        type: boolean
+        optional: true
+        name: button
+  - entity: switch
+    icon: "mdi:ev-station"
+    dps:
+      - id: 18
+        type: boolean
+        optional: true
+        name: switch
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        optional: true
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Last charge
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
+        unit: kWh
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 100
+  - entity: binary_sensor
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 27
+        optional: true
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: offline
+            value: false
+          - dps_val: online
+            value: true
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 28
+        type: integer
+        name: value
+        unit: h
+        optional: true
+        range:
+          min: 0
+          max: 15

--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -70,7 +70,6 @@ entities:
           - dps_val: 32
             value: "32"
   - entity: sensor
-    name: Power total
     class: power
     dps:
       - id: 9
@@ -96,9 +95,11 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Voltage
     class: voltage
     category: diagnostic
+    translation_key: voltage_x
+    translation_placeholders:
+      x: A
     dps:
       - id: 6
         type: base64
@@ -109,9 +110,11 @@ entities:
         mapping:
           - scale: 10
   - entity: sensor
-    name: Current
     class: current
     category: diagnostic
+    translation_key: current_x
+    translation_placeholders:
+      x: A
     dps:
       - id: 6
         type: base64
@@ -122,10 +125,11 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Power
     class: power
-    hidden: true
     category: diagnostic
+    translation_key: power_x
+    translation_placeholders:
+      x: A
     dps:
       - id: 6
         type: base64

--- a/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
+++ b/custom_components/tuya_local/devices/afyeev_32a_evcharger.yaml
@@ -96,9 +96,6 @@ entities:
   - entity: sensor
     class: voltage
     category: diagnostic
-    translation_key: voltage_x
-    translation_placeholders:
-      x: A
     dps:
       - id: 6
         type: base64
@@ -111,9 +108,6 @@ entities:
   - entity: sensor
     class: current
     category: diagnostic
-    translation_key: current_x
-    translation_placeholders:
-      x: A
     dps:
       - id: 6
         type: base64
@@ -126,9 +120,6 @@ entities:
   - entity: sensor
     class: power
     category: diagnostic
-    translation_key: power_x
-    translation_placeholders:
-      x: A
     dps:
       - id: 6
         type: base64


### PR DESCRIPTION
Changes:
- Added a new device configuration for the Afyeev 32A 7kW EV Charger.
- Restricted the Charging Current selection to only the values supported by the device, so users can no longer select an out-of-range current.

Reference: [Charger manual](https://manuals.plus/ae/1005007587878624)