### PR TITLE
Add Intex PureSpa inflatable spa (salt water model)

### DIFF
--- a/custom_components/tuya_local/devices/intex_purespa_spa.yaml
+++ b/custom_components/tuya_local/devices/intex_purespa_spa.yaml
@@ -4,17 +4,16 @@ products:
     manufacturer: Intex
     model: PureSpa
 entities:
-  - entity: climate
-    translation_key: thermostat
+  - entity: water_heater
     dps:
       - id: 108
         type: boolean
-        name: hvac_mode
+        name: operation_mode
         mapping:
           - dps_val: false
             value: "off"
           - dps_val: true
-            value: heat
+            value: electric
       - id: 109
         type: integer
         name: temperature
@@ -26,12 +25,6 @@ entities:
         type: integer
         name: current_temperature
         unit: F
-      - id: 117
-        type: string
-        name: preset_mode
-        mapping:
-          - dps_val: warm
-            value: warm
   - entity: switch
     name: Power
     dps:
@@ -53,17 +46,15 @@ entities:
         type: boolean
         name: switch
   - entity: switch
-    name: Sanitizer
-    icon: "mdi:shaker-outline"
+    translation_key: electrolytic_sterilization
     dps:
       - id: 103
         type: boolean
         name: switch
   - entity: sensor
-    name: Timer
-    category: diagnostic
+    translation_key: time_remaining
     class: duration
-    icon: "mdi:timer-outline"
+    category: diagnostic
     dps:
       - id: 114
         type: integer

--- a/custom_components/tuya_local/devices/intex_purespa_spa.yaml
+++ b/custom_components/tuya_local/devices/intex_purespa_spa.yaml
@@ -1,0 +1,71 @@
+name: Spa
+products:
+  - id: chsaskllmust5d7a
+    manufacturer: Intex
+    model: PureSpa
+entities:
+  - entity: climate
+    translation_key: thermostat
+    dps:
+      - id: 108
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+      - id: 109
+        type: integer
+        name: temperature
+        unit: F
+        range:
+          min: 68
+          max: 104
+      - id: 110
+        type: integer
+        name: current_temperature
+        unit: F
+      - id: 117
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: warm
+            value: warm
+  - entity: switch
+    name: Power
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Filtration
+    icon: "mdi:air-filter"
+    dps:
+      - id: 106
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Bubbles
+    icon: "mdi:chart-bubble"
+    dps:
+      - id: 107
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Sanitizer
+    icon: "mdi:shaker-outline"
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: sensor
+    name: Timer
+    category: diagnostic
+    class: duration
+    icon: "mdi:timer-outline"
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        unit: min


### PR DESCRIPTION
Adds support for the Intex PureSpa inflatable spa (salt water model, controller SB-HSWF20-2, product key chsaskllmust5d7a)

Climate entity (heat/off via DP 108, setpoint DP 109, current temp DP 110). The device reports temperatures in Fahrenheit, converted to the user's unit via unit: F
Switches: power (104), filtration (106), bubbles (107), salt sanitizer (103). All switch mappings verified against the physical control panel states
Diagnostic timer sensor (114)
Preset mode (117) observed only with value warm; other values not confirmed

Tested on a single device