### PR TITLE
Fix SL60D vacuum start command

### DIFF
--- a/custom_components/tuya_local/devices/lublueblu_sl60d_vacuum.yaml
+++ b/custom_components/tuya_local/devices/lublueblu_sl60d_vacuum.yaml
@@ -10,32 +10,6 @@ entities:
         type: boolean
         name: activate
         optional: true
-        mapping:
-          - dps_val: false
-            constraint: pause
-            conditions:
-              - dps_val: true
-                value: false
-              - dps_val: false
-                value: false
-                hidden: true
-              - dps_val: null
-                value: false
-                hidden: true
-          - dps_val: true
-            constraint: pause
-            conditions:
-              - dps_val: false
-                value: true
-              - dps_val: true
-                value: true
-                hidden: true
-              - dps_val: null
-                value: true
-                hidden: true
-          - dps_val: null
-            value: false
-            hidden: true
       - id: 2
         type: boolean
         optional: true


### PR DESCRIPTION
Fixes #5241

This PR fixes `vacuum.start` for the LuBlueLu SL60D vacuum config.

The current `lublueblu_sl60d_vacuum.yaml` config maps DPS 1 / `activate` with a `pause` constraint. In practice, this makes `vacuum.start` send both DPS 1 and DPS 2:

```json
{"1": true, "2": false}
```

On my SL60D, the vacuum acknowledges that DPS update but does not start cleaning.

I compared this with the official Tuya cloud integration. The working cloud command is:

```yaml
command: power_go
params:
  - true
```

Removing the constrained mapping from DPS 1 makes Tuya Local send only DPS 1 / `activate=true`. After restarting Home Assistant, `vacuum.start` works correctly.

I also tested sending DPS 4 / `smart` locally via `vacuum.send_command`:

```yaml
action: vacuum.send_command
target:
  entity_id: vacuum.upstairs
data:
  command: smart
```

That sent:

```json
{"4": "smart"}
```

but did not start cleaning, so the working local fix is to make DPS 1 a plain boolean `activate` DP.

The resulting DPS 1 block is:

```yaml
- id: 1
  type: boolean
  name: activate
  optional: true
```