### PR TITLE
feat(moes_wcmp52_camera): make privacy visible and recording controllable

### DIFF
--- a/custom_components/tuya_local/devices/moes_wcmp52_camera.yaml
+++ b/custom_components/tuya_local/devices/moes_wcmp52_camera.yaml
@@ -412,7 +412,6 @@ entities:
   - entity: button
     name: Stop zooming
     icon: "mdi:stop-circle-outline"
-    category: config
     dps:
       - id: 164
         type: boolean

--- a/custom_components/tuya_local/devices/moes_wcmp52_camera.yaml
+++ b/custom_components/tuya_local/devices/moes_wcmp52_camera.yaml
@@ -21,6 +21,23 @@ entities:
       - id: 150
         type: boolean
         name: record
+  # DP 105 also controls camera power (inverted there); on = privacy engaged.
+  - entity: switch
+    name: Privacy
+    icon: "mdi:eye-off"
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+  # DP 150 also drives the camera's is_recording; on = recording enabled.
+  - entity: switch
+    name: Recording
+    icon: "mdi:record-rec"
+    category: config
+    dps:
+      - id: 150
+        type: boolean
+        name: switch
   - entity: light
     translation_key: indicator
     category: config


### PR DESCRIPTION
On the WCM-P52, privacy and recording-enable are only reachable through the `camera` entity, which leaves two gaps: privacy can be toggled but has no visible state, and recording-enable is visible but read-only. This adds a switch for each (Privacy on DP 105, Recording on DP 150) so both are visible and controllable.

Both DPs already back the `camera` entity; the switches share them, as the PTZ buttons already share DP 119. The camera entity is unchanged and nothing is renamed or removed.

Also moves the "Stop zooming" button out of the config category to sit with the other pan/zoom controls, matching "Pan stop".

Background and the broader camera-state question: #5246.

Drafted with AI assistance and reviewed by me.