### PR TITLE
Add v2 Variant for Create ceiling fan with light (product id 9ecs16c53uqskxw6)

### DIFF
--- a/custom_components/tuya_local/devices/create_fan_light.yaml
+++ b/custom_components/tuya_local/devices/create_fan_light.yaml
@@ -3,6 +3,8 @@ products:
   - id: p8z27dfdwc4riyp9
     manufacturer: Create
     model: XW-FAN-215-D
+  - id: 9ecs16c53uqskxw6
+    manufacturer: Create
 entities:
   - entity: fan
     dps:
@@ -58,3 +60,12 @@ entities:
         range:
           min: 0
           max: 540
+  - entity: switch
+    translation_key: sound
+    category: config
+    hidden: unavailable
+    dps:
+      - id: 66
+        type: boolean
+        optional: true
+        name: switch


### PR DESCRIPTION
👋 

This PR adds a v2 variant of the create_fan_light (just received 2x devices reported as "v2" in their firmware, this is the device https://www.create-store.com/fr/acheter-ventilateurs-de-plafond/83193-wind-stylance-ventilateur-de-plafond-40w-silencieux-o132-cm-100-bois.html?id_c=181311):
- Added the new product id 9ecs16c53uqskxw6 for the v2 model
- Add fan_beep switch entity (DP 66) (with "hidden: unavailable" so it auto-enables on v2 devices and stays disabled on v1)

(cloud device spec for posterity) 

```[{"id": 20, "name": "switch_led", "type": "Boolean", "format": "{}", "enumMap": {}}, {"id": 21, "name": "work_mode", "type": "Enum", "format": "{\"range\":[\"white\",\"colour\",\"scene\",\"music\"]}", "enumMap": {}}, {"id": 23, "name": "temp_value", "type": "Integer", "format": "{\"min\":0,\"max\":1000,\"scale\":0,\"step\":1}", "enumMap": {}}, {"id": 25, "name": "scene_data", "type": "String", "format": "{\"maxlen\":255}", "enumMap": {}}, {"id": 60, "name": "fan_switch", "type": "Boolean", "format": "{}", "enumMap": {}}, {"id": 62, "name": "fan_speed", "type": "Integer", "format": "{\"unit\":\"\",\"min\":1,\"max\":6,\"scale\":0,\"step\":1}", "enumMap": {}}, {"id": 63, "name": "fan_direction", "type": "Enum", "format": "{\"range\":[\"forward\",\"reverse\"]}", "enumMap": {}}, {"id": 64, "name": "fan_countdown_left", "type": "Integer", "format": "{\"unit\":\"min\",\"min\":0,\"max\":540,\"scale\":0,\"step\":1}", "enumMap": {}}, {"id": 66, "name": "fan_beep", "type": "Boolean", "format": "{}", "enumMap": {}}]``` 