### PR TITLE
Atomi Smart Coffee Maker (2nd Gen) config added to devices

### DIFF
--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -1,0 +1,164 @@
+name: Atomi Coffee Maker
+products:
+  - id: 000002cuuc
+    manufacturer: Atomi
+    name: Atomi Smart Coffee Maker (2nd Gen)
+  - id: gmbbmrpkqecjoeoa
+    manufacturer: Atomi
+    name: Atomi Smart Coffee Maker (2nd Gen)
+
+entities:
+  - entity: binary_sensor
+    # power status - read only
+    name: Brewing
+    category: diagnostic
+    dps:
+      - id: 1
+        type: boolean
+        name: sensor
+
+  - entity: select
+    # brew strength (mode) - read/write
+    name: Brew strength
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: smart
+            value: Regular
+          - dps_val: auto
+            value: Strong
+
+  - entity: sensor
+    # status of the machine - read only
+    # Manual Schedule - seems to be what happens when you press the "timer/clock" icon on
+    #   the device (not the app.)  However, I can't figure out how to set the Schedule on the device
+    name: Status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: status1
+            value: Idle
+          - dps_val: status2
+            value: Brewing
+          - dps_val: status3
+            value: Warming
+          - dps_val: status4
+            value: Manual Schedule
+
+  - entity: binary_sensor
+    # value = 0, OK (carafe on base)
+    # bit 2 (value = 4), carafe not on base - read only
+    # not sure what other bits can be set or what they mean
+    class: problem
+    name: Carafe
+    category: diagnostic
+    dps:
+      - id: 6
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+
+  - entity: sensor
+    # value of fault - this is for development, and can be removed when figure out what other bits mean.
+    #  When (if) the other bits are determined, setup a binary_sensor like Carafe not on base
+    #  (bit 2 is carafe not on base) - read only
+    name: Raw fault status
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 6
+        type: bitfield
+        name: sensor
+
+  - entity: binary_sensor
+    name: Water Tank
+    class: problem
+    # water in the tank - readonly - this sensor is only evaluated when
+    #   brewing is started, so can't be used to warn ahead of brewing.
+    #   Furthermore, the sensor will change to "Ready" before testing,
+    #   and if the coffee maker is "cold" it will take almost a minute
+    #   to become "Needs water"
+    #   Also, even though it has units of ML, seems
+    #   to only be a 1 or 0 (needs water or ready)
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 1
+            value: true
+          - value: false
+
+  # Leaving this here and marking as hidden.  I just see Unknown in HA and can't
+  #   find any way to set it using app or directly on device
+  - entity: time
+    # time - read only
+    name: Time
+    hidden: true
+    category: diagnostic
+    dps:
+      - id: 102
+        optional: true
+        type: integer
+        name: value
+
+  - entity: button
+    name: Start Brewing
+    # The switch may or may not turn on the machine.  For instance, if there isn't
+    #   enough water or carafe is missing
+    dps:
+      - id: 103
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: true
+            value: true
+
+  - entity: button
+    name: Power Off
+    # The switch may or may not turn on the machine.  If there isn't
+    #   enough water or carafe is missing, then
+    #   HA will show the switch as ON, but the machine will remain OFF
+    dps:
+      - id: 103
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: false
+            value: false
+
+  # Leaving this here as a reminder that ID=104 doesn't seem to be passed during
+  #   normal operation of the device through the app or directly on device
+  - entity: sensor
+    # countdown - read only
+    name: Countdown
+    hidden: true
+    category: diagnostic
+    dps:
+      - id: 104
+        optional: true
+        type: integer
+        name: sensor
+
+  - entity: button
+    name: Set Time
+    # calibration - sets the time when called - write only
+    dps:
+      - id: 105
+        optional: true
+        type: string
+        name: button
+        mapping:
+          - dps_val: calibration
+            value: calibration


### PR DESCRIPTION
## Device

Atomi Smart Coffee Maker (2nd Gen)
- Product Category = kfj
- modelId = 000002cuuc

## Testing
- HA Core production deployment = 2026.6.0
- Made lots of notes in the device config
- Only thing I couldn't figure out is how to set a schedule for the coffee make - can't even figure it out using the manual and the controls on the actual device.  Could say something about me, or the device :)


[atomi-coffee-maker-discovery.json](https://github.com/user-attachments/files/28656452/atomi-coffee-maker-discovery.json)

