### PR TITLE
kolanky_evcharger: support GOODCELL 32A variant charge current

### DIFF
--- a/custom_components/tuya_local/devices/kolanky_evcharger.yaml
+++ b/custom_components/tuya_local/devices/kolanky_evcharger.yaml
@@ -1,11 +1,7 @@
 name: EV charger
 products:
   - id: 7bvgooyjhiua1yyq
-    manufacturer: Kolanky
-    model: "3.6kW"
-  - id: 7bvgooyjhiua1yyq
-    manufacturer: GOODCELL
-    model: "7.2kW 32A"
+    manufacturer: Kolanky / Goodcell
 entities:
   - entity: sensor
     translation_key: status

--- a/custom_components/tuya_local/devices/kolanky_evcharger.yaml
+++ b/custom_components/tuya_local/devices/kolanky_evcharger.yaml
@@ -54,29 +54,29 @@ entities:
     category: config
     class: current
     dps:
-      - id: 115
+      - id: 114
         type: integer
         name: value
         unit: A
         range:
-          min: 8
-          max: 32
+          min: 6
+          max: 16
         mapping:
           - constraint: max_current
             conditions:
-              - dps_val: Max16A
+              - dps_val: Max32A
                 value_redirect: value_alt
                 range:
-                  min: 6
-                  max: 16
-      - id: 114
+                  min: 8
+                  max: 32
+      - id: 115
         type: integer
         optional: true
         name: value_alt
         unit: A
         range:
-          min: 6
-          max: 16
+          min: 8
+          max: 32
       - id: 113
         type: string
         name: max_current

--- a/custom_components/tuya_local/devices/kolanky_evcharger.yaml
+++ b/custom_components/tuya_local/devices/kolanky_evcharger.yaml
@@ -3,6 +3,9 @@ products:
   - id: 7bvgooyjhiua1yyq
     manufacturer: Kolanky
     model: "3.6kW"
+  - id: 7bvgooyjhiua1yyq
+    manufacturer: GOODCELL
+    model: "7.2kW 32A"
 entities:
   - entity: sensor
     translation_key: status
@@ -51,13 +54,37 @@ entities:
     category: config
     class: current
     dps:
-      - id: 114
+      - id: 115
         type: integer
         name: value
         unit: A
         range:
+          min: 8
+          max: 32
+        mapping:
+          - constraint: max_current
+            conditions:
+              - dps_val: Max16A
+                value_redirect: value_alt
+                range:
+                  min: 6
+                  max: 16
+      - id: 114
+        type: integer
+        optional: true
+        name: value_alt
+        unit: A
+        range:
           min: 6
           max: 16
+      - id: 113
+        type: string
+        name: max_current
+        mapping:
+          - dps_val: Max16A
+            value: Max16A
+          - dps_val: Max32A
+            value: Max32A
   - entity: number
     name: Delay
     class: duration


### PR DESCRIPTION
## Why

The `7bvgooyjhiua1yyq` product id ships as both a Kolanky 3.6kW (16A) and a GOODCELL 7.2kW 32A charger, but the charge current was hardcoded to dp 114 (`Set16A`, 6–16A). On a 32A unit that dp clamps at 16, so anything above 16A just snaps back — there's no way to set the real current from HA.

## What

- Charge current now follows `DeviceMaxSetA` (dp 113): writes `Set32A` (dp 115, 8–32A) by default, and redirects to `Set16A` (dp 114, 6–16A) when the charger reports `Max16A`.
- Added GOODCELL 7.2kW 32A to the product list (same product id as the existing Kolanky 3.6kW entry).

Same `constraint`/`value_redirect` approach already used in `goodcell_ev_charger.yaml`.

## How to Test

- 32A unit (`DeviceMaxSetA` = `Max32A`): charge current exposes 8–32A and writes dp 115; the setpoint now holds instead of reverting to 16. Verified on a GOODCELL 7.2kW 32A unit.
- 16A unit (`DeviceMaxSetA` = `Max16A`): the redirect sends writes to dp 114 with the original 6–16A range — i.e. unchanged from current behaviour. (Not tested on physical 16A hardware; behaviour mirrors the pre-change config and the goodcell pattern.)
- `uv run pytest tests/test_device_config.py` and `uv run yamllint custom_components/tuya_local/devices`.
