### PR TITLE
Add BW salt chlorinator device config

### DIFF
--- a/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
+++ b/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
@@ -53,6 +53,15 @@ entities:
         class: measurement
 
   - entity: sensor
+    name: Fault Bitmap
+    category: diagnostic
+    dps:
+      - id: 105
+        name: sensor
+        type: integer
+        optional: true
+
+  - entity: sensor
     name: Fault Status
     class: enum
     category: diagnostic
@@ -65,25 +74,27 @@ entities:
           - dps_val: "work"
             value: "working"
           - dps_val: "F1"
-            value: "F1"
-          - dps_val: "F1_L"
-            value: "F1_L"
+            value: "F1 - Water temperature outside normal range"
           - dps_val: "F2"
-            value: "F2"
+            value: "F2 - Water flow error"
           - dps_val: "F3"
-            value: "F3"
+            value: "F3 - Water temperature sensor breakdown"
           - dps_val: "F4"
-            value: "F4"
+            value: "F4 - Electrode abnormal"
+          - dps_val: "F5"
+            value: "F5 - Low salinity"
+          - dps_val: "F6"
+            value: "F6 - High salinity"
           - dps_val: "F8"
-            value: "F8"
+            value: "F8 - Low input voltage"
           - dps_val: "F9"
-            value: "F9"
+            value: "F9 - High output current"
           - dps_val: "FC"
-            value: "FC"
+            value: "FC - Circuit abnormal"
           - dps_val: "FP"
-            value: "FP"
+            value: "FP - Power off abnormal"
           - dps_val: "Fb"
-            value: "Fb"
+            value: "Fb - Communication failure"
 
   - entity: sensor
     name: Salinity Status
@@ -176,13 +187,3 @@ entities:
         type: integer
         unit: h
         class: measurement
-
-  - entity: sensor
-    name: Fault Bitmap
-    class: enum
-    category: diagnostic
-    dps:
-      - id: 105
-        name: sensor
-        type: integer
-        optional: true

--- a/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
+++ b/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
@@ -55,7 +55,7 @@ entities:
   - entity: sensor
     name: Fault Bitmap
     category: diagnostic
-    disabled: true
+    hidden: true
     dps:
       - id: 105
         name: sensor
@@ -151,7 +151,7 @@ entities:
   - entity: sensor
     name: Salinity
     category: diagnostic
-    disabled: true
+    hidden: true
     dps:
       - id: 111
         name: sensor

--- a/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
+++ b/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
@@ -5,7 +5,7 @@ products:
 
 entities:
   - entity: switch
-    name: 24-hour cycle
+    name: Daily cycle
     dps:
       - id: 101
         name: switch
@@ -42,6 +42,7 @@ entities:
   - entity: sensor
     name: Water temperature
     class: temperature
+    icon: "mdi:pool-thermometer"
     dps:
       - id: 104
         name: sensor

--- a/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
+++ b/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
@@ -1,28 +1,25 @@
-name: Salt Chlorinator
+name: Salt chlorinator
 products:
   - id: ypdzzmgqbq3dqhqu
-    name: BW Salt Chlorinator
-    model_id: fxalqw
     manufacturer: BW
 
 entities:
   - entity: switch
-    name: Power
+    name: 24-hour cycle
     dps:
       - id: 101
         name: switch
         type: boolean
 
-  - entity: switch
-    name: Child Lock
-    category: config
+  - entity: lock
+    translation_key: child_lock
     dps:
       - id: 102
-        name: switch
+        name: lock
         type: boolean
 
   - entity: select
-    name: Output Level
+    name: Chlorination output
     category: config
     dps:
       - id: 103
@@ -30,20 +27,20 @@ entities:
         type: string
         mapping:
           - dps_val: "25"
-            value: "25%"
+            value: "25% (3 h)"
           - dps_val: "50"
-            value: "50%"
+            value: "50% (6 h)"
           - dps_val: "75"
-            value: "75%"
+            value: "75% (9 h)"
           - dps_val: "100"
-            value: "100%"
+            value: "100% (12 h)"
           - dps_val: "150"
-            value: "150%"
+            value: "150% (18 h)"
           - dps_val: "200"
-            value: "200%"
+            value: "200% (24 h)"
 
   - entity: sensor
-    name: Water Temperature
+    name: Water temperature
     class: temperature
     dps:
       - id: 104
@@ -52,30 +49,27 @@ entities:
         unit: C
         class: measurement
 
-  - entity: sensor
-    name: Fault Bitmap
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 105
-        name: sensor
-        type: integer
-        optional: true
-
-  - entity: sensor
-    name: Fault Status
-    class: enum
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
     dps:
       - id: 106
         name: sensor
         type: string
-        optional: true
         mapping:
           - dps_val: "work"
-            value: "working"
+            value: false
+          - value: true
+      - id: 106
+        type: string
+        name: description
+        mapping:
+          - dps_val: "work"
+            value: "Working"
           - dps_val: "F1"
             value: "F1 - Water temperature outside normal range"
+          - dps_val: "F1_L"
+            value: "F1_L - Water temperature outside normal range"
           - dps_val: "F2"
             value: "F2 - Water flow error"
           - dps_val: "F3"
@@ -98,14 +92,14 @@ entities:
             value: "Fb - Communication failure"
 
   - entity: sensor
-    name: Salinity Status
+    name: Salinity status
+    translation_key: status
     class: enum
     category: diagnostic
     dps:
       - id: 107
         name: sensor
         type: string
-        optional: true
         mapping:
           - dps_val: "salinity_low"
             value: "low"
@@ -115,32 +109,30 @@ entities:
             value: "high"
 
   - entity: button
-    name: Clear Fault
-    category: config
+    name: Clear fault
     dps:
       - id: 108
         name: button
         type: boolean
-        optional: true
 
-  - entity: number
-    name: Self-Clean Time
+  - entity: select
+    name: Self-clean interval
     category: config
     dps:
       - id: 109
-        name: value
+        name: option
         type: integer
-        range:
-          min: 4
-          max: 12
-        unit: h
         mapping:
-          - step: 4
+          - dps_val: 4
+            value: "4 h"
+          - dps_val: 8
+            value: "8 h"
+          - dps_val: 12
+            value: "12 h"
 
   - entity: sensor
-    name: Self-Clean Remaining
+    name: Runtime until self-clean
     class: duration
-    category: diagnostic
     dps:
       - id: 110
         name: sensor
@@ -148,30 +140,16 @@ entities:
         unit: h
         class: measurement
 
-  - entity: sensor
-    name: Salinity
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 111
-        name: sensor
-        type: integer
-        unit: ppm
-        class: measurement
-        optional: true
-
   - entity: button
-    name: Clear Salinity Fault
-    category: config
+    name: Clear salinity fault
     dps:
       - id: 112
         name: button
         type: boolean
 
   - entity: sensor
-    name: Work Countdown
+    name: Runtime remaining
     class: duration
-    category: diagnostic
     dps:
       - id: 113
         name: sensor
@@ -180,9 +158,8 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Work Time
+    name: Runtime duration
     class: duration
-    category: diagnostic
     dps:
       - id: 114
         name: sensor

--- a/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
+++ b/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
@@ -55,6 +55,7 @@ entities:
   - entity: sensor
     name: Fault Bitmap
     category: diagnostic
+    disabled: true
     dps:
       - id: 105
         name: sensor
@@ -150,6 +151,7 @@ entities:
   - entity: sensor
     name: Salinity
     category: diagnostic
+    disabled: true
     dps:
       - id: 111
         name: sensor

--- a/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
+++ b/custom_components/tuya_local/devices/bw_salt_chlorinator.yaml
@@ -1,0 +1,188 @@
+name: Salt Chlorinator
+products:
+  - id: ypdzzmgqbq3dqhqu
+    name: BW Salt Chlorinator
+    model_id: fxalqw
+    manufacturer: BW
+
+entities:
+  - entity: switch
+    name: Power
+    dps:
+      - id: 101
+        name: switch
+        type: boolean
+
+  - entity: switch
+    name: Child Lock
+    category: config
+    dps:
+      - id: 102
+        name: switch
+        type: boolean
+
+  - entity: select
+    name: Output Level
+    category: config
+    dps:
+      - id: 103
+        name: option
+        type: string
+        mapping:
+          - dps_val: "25"
+            value: "25%"
+          - dps_val: "50"
+            value: "50%"
+          - dps_val: "75"
+            value: "75%"
+          - dps_val: "100"
+            value: "100%"
+          - dps_val: "150"
+            value: "150%"
+          - dps_val: "200"
+            value: "200%"
+
+  - entity: sensor
+    name: Water Temperature
+    class: temperature
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Fault Status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 106
+        name: sensor
+        type: string
+        optional: true
+        mapping:
+          - dps_val: "work"
+            value: "working"
+          - dps_val: "F1"
+            value: "F1"
+          - dps_val: "F1_L"
+            value: "F1_L"
+          - dps_val: "F2"
+            value: "F2"
+          - dps_val: "F3"
+            value: "F3"
+          - dps_val: "F4"
+            value: "F4"
+          - dps_val: "F8"
+            value: "F8"
+          - dps_val: "F9"
+            value: "F9"
+          - dps_val: "FC"
+            value: "FC"
+          - dps_val: "FP"
+            value: "FP"
+          - dps_val: "Fb"
+            value: "Fb"
+
+  - entity: sensor
+    name: Salinity Status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 107
+        name: sensor
+        type: string
+        optional: true
+        mapping:
+          - dps_val: "salinity_low"
+            value: "low"
+          - dps_val: "salinity_normal"
+            value: "normal"
+          - dps_val: "salinity_high"
+            value: "high"
+
+  - entity: button
+    name: Clear Fault
+    category: config
+    dps:
+      - id: 108
+        name: button
+        type: boolean
+        optional: true
+
+  - entity: number
+    name: Self-Clean Time
+    category: config
+    dps:
+      - id: 109
+        name: value
+        type: integer
+        range:
+          min: 4
+          max: 12
+        unit: h
+        mapping:
+          - step: 4
+
+  - entity: sensor
+    name: Self-Clean Remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 110
+        name: sensor
+        type: integer
+        unit: h
+        class: measurement
+
+  - entity: sensor
+    name: Salinity
+    category: diagnostic
+    dps:
+      - id: 111
+        name: sensor
+        type: integer
+        unit: ppm
+        class: measurement
+        optional: true
+
+  - entity: button
+    name: Clear Salinity Fault
+    category: config
+    dps:
+      - id: 112
+        name: button
+        type: boolean
+
+  - entity: sensor
+    name: Work Countdown
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 113
+        name: sensor
+        type: integer
+        unit: h
+        class: measurement
+
+  - entity: sensor
+    name: Work Time
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 114
+        name: sensor
+        type: integer
+        unit: h
+        class: measurement
+
+  - entity: sensor
+    name: Fault Bitmap
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 105
+        name: sensor
+        type: integer
+        optional: true


### PR DESCRIPTION
Add support for BW Series Salt Chlorinator, also sold as Thermotec Salt Chlorinator in the UK.

Product ID: ypdzzmgqbq3dqhqu
Model ID: fxalqw

Confirmed DPS:
101 power
102 child lock
103 work mode/output level
104 water temperature
105 fault bitmap
106 fault status
107 salinity status
108 fault clear
109 self-clean time
110 self-clean remaining
111 salinity
112 salinity clear
113 work countdown / remaining time
114 work time

Notes:
- F-code descriptions are taken from the BW Series user manual troubleshooting table.
- DPs 113 and 114 are marked rw in the Tuya model, but in cloud app they are read only, so they are exposed as diagnostic sensors only. May do further testing to see if they are safe to write to.
- Manual available here: https://manuals.plus/m/eddc529b18f8f768901ed1aa3c9a6035249842e99aa8044ef6688fde0a7daab2_optim.pdf
