### PR TITLE
Add support for Parkside PAMRC 250 A1 City lawnmower

### DIFF
--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -99,7 +99,7 @@ entities:
           - dps_val: StartFixedMowing
             value: true
   - entity: button
-    name: Cancel mowing
+    name: Cancel work
     icon: "mdi:mower"
     dps:
       - id: 115

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -17,7 +17,7 @@ entities:
         type: string
         mapping:
           - dps_val: STANDBY
-            value: paused
+            value: docked
           - dps_val: MOWING
             value: mowing
           - dps_val: CHARGING
@@ -40,8 +40,6 @@ entities:
             value: docked
           - dps_val: SELF_TEST
             value: docked
-          - dps_val: EDGE
-            value: mowing
       - id: 115
         name: command
         type: string
@@ -62,9 +60,6 @@ entities:
             hidden: true
           - dps_val: StartReturnStation
             value: dock
-          - dps_val: EDGE
-            value: start_mowing
-            hidden: true
       - id: 101
         name: raw_activity
         type: string
@@ -96,7 +91,7 @@ entities:
           - dps_val: StartFixedMowing
             value: true
   - entity: button
-    name: Cancel work
+    name: Cancel mowing
     icon: "mdi:mower"
     dps:
       - id: 115
@@ -116,17 +111,6 @@ entities:
         optional: true
         mapping:
           - dps_val: ContinueWork
-            value: true
-  - entity: button
-    name: Edge mowing
-    icon: "mdi:mower-on"
-    dps:
-      - id: 115
-        type: string
-        name: button
-        optional: true
-        mapping:
-          - dps_val: EDGE
             value: true
   - entity: sensor
     class: battery
@@ -218,10 +202,6 @@ entities:
             value: Manually dock
             icon: "mdi:home-alert"
             icon_priority: 1
-          - dps_val: PLACE_INSIDE
-            value: Manually dock
-            icon: "mdi:home-alert"
-            icon_priority: 1
           - dps_val: FIXED_END
             value: Finished fixed mowing
             icon: "mdi:mower"
@@ -239,10 +219,6 @@ entities:
             icon: "mdi:alert-octogon"
             icon_priority: 1
           - dps_val: FIXED_MOWING_INTERRUPT
-            value: Interrupted fixed mowing
-            icon: "mdi:alert-octogon"
-            icon_priority: 1
-          - dps_val: FIXED_MOWING_INTERUPT
             value: Interrupted fixed mowing
             icon: "mdi:alert-octogon"
             icon_priority: 1
@@ -285,22 +261,6 @@ entities:
           - dps_val: MOWER_UI_LOCKED
             value: UI locked
             icon: "mdi:hand-back-right-off"
-            icon_priority: 1
-          - dps_val: DISCHARGE_ERROR
-            value: Discharge error
-            icon: "mdi:battery-alert"
-            icon_priority: 1
-          - dps_val: CHARGE_TEMP_ERROR
-            value: Charging temperature error
-            icon: "mdi:thermometer-alert"
-            icon_priority: 1
-          - dps_val: HEDGEHOG
-            value: Hedgehog detected
-            icon: "mdi:paw"
-            icon_priority: 1
-          - dps_val: NTC
-            value: Temperature sensor error
-            icon: "mdi:thermometer-alert"
             icon_priority: 1
   - entity: switch
     name: Rain mode
@@ -405,12 +365,3 @@ entities:
           - dps_val: null
             value: false
           - value: true
-  - entity: sensor
-    name: Firmware version
-    icon: "mdi:information"
-    category: diagnostic
-    dps:
-      - id: 134
-        type: string
-        name: sensor
-        optional: true

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -9,6 +9,9 @@ products:
   - id: 7yr5iwga
     manufacturer: Parkside
     model: PMRC 250 Ai Bluetooth
+  - id: 9hdajpiw
+    manufacturer: Parkside
+    model: PAMRC 250 A1 City
 entities:
   - entity: lawn_mower
     dps:
@@ -40,6 +43,8 @@ entities:
             value: docked
           - dps_val: SELF_TEST
             value: docked
+          - dps_val: EDGE
+            value: mowing
       - id: 115
         name: command
         type: string
@@ -60,6 +65,9 @@ entities:
             hidden: true
           - dps_val: StartReturnStation
             value: dock
+          - dps_val: EDGE
+            value: start_mowing
+            hidden: true
       - id: 101
         name: raw_activity
         type: string
@@ -111,6 +119,17 @@ entities:
         optional: true
         mapping:
           - dps_val: ContinueWork
+            value: true
+  - entity: button
+    name: Edge mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: EDGE
             value: true
   - entity: sensor
     class: battery
@@ -202,6 +221,10 @@ entities:
             value: Manually dock
             icon: "mdi:home-alert"
             icon_priority: 1
+          - dps_val: PLACE_INSIDE
+            value: Manually dock
+            icon: "mdi:home-alert"
+            icon_priority: 1
           - dps_val: FIXED_END
             value: Finished fixed mowing
             icon: "mdi:mower"
@@ -219,6 +242,10 @@ entities:
             icon: "mdi:alert-octogon"
             icon_priority: 1
           - dps_val: FIXED_MOWING_INTERRUPT
+            value: Interrupted fixed mowing
+            icon: "mdi:alert-octogon"
+            icon_priority: 1
+          - dps_val: FIXED_MOWING_INTERUPT
             value: Interrupted fixed mowing
             icon: "mdi:alert-octogon"
             icon_priority: 1
@@ -261,6 +288,22 @@ entities:
           - dps_val: MOWER_UI_LOCKED
             value: UI locked
             icon: "mdi:hand-back-right-off"
+            icon_priority: 1
+          - dps_val: DISCHARGE_ERROR
+            value: Discharge error
+            icon: "mdi:battery-alert"
+            icon_priority: 1
+          - dps_val: CHARGE_TEMP_ERROR
+            value: Charging temperature error
+            icon: "mdi:thermometer-alert"
+            icon_priority: 1
+          - dps_val: HEDGEHOG
+            value: Hedgehog detected
+            icon: "mdi:paw"
+            icon_priority: 1
+          - dps_val: NTC
+            value: Temperature sensor error
+            icon: "mdi:thermometer-alert"
             icon_priority: 1
   - entity: switch
     name: Rain mode
@@ -365,3 +408,12 @@ entities:
           - dps_val: null
             value: false
           - value: true
+  - entity: sensor
+    name: Firmware version
+    icon: "mdi:information"
+    category: diagnostic
+    dps:
+      - id: 134
+        type: string
+        name: sensor
+        optional: true

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -3,12 +3,6 @@ products:
   - id: mvt4l2evgq2l3nkn
     manufacturer: MoeBot
     model: S20
-  - id: icw5sal7xfcevsve
-    manufacturer: Parkside
-    model: PMRDA 20-Li A1
-  - id: 7yr5iwga
-    manufacturer: Parkside
-    model: PMRC 250 Ai Bluetooth
 entities:
   - entity: lawn_mower
     dps:
@@ -316,8 +310,6 @@ entities:
     dps:
       - id: 114
         type: string
-        # Parkside mowers mark this as boolean01Reserved, but as long as they
-        #  don't use it the incompatibility is just theoretical
         optional: true
         name: option
         mapping:

--- a/custom_components/tuya_local/devices/moebot_s_mower.yaml
+++ b/custom_components/tuya_local/devices/moebot_s_mower.yaml
@@ -20,7 +20,7 @@ entities:
         type: string
         mapping:
           - dps_val: STANDBY
-            value: docked
+            value: paused
           - dps_val: MOWING
             value: mowing
           - dps_val: CHARGING

--- a/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
@@ -4,6 +4,12 @@ products:
   - id: 9hdajpiw
     manufacturer: Parkside
     model: PAMRC 250 A1 City
+  - id: 7yr5iwga
+    manufacturer: Parkside
+    model: PMRC 250 Ai Bluetooth
+  - id: icw5sal7xfcevsve
+    manufacturer: Parkside
+    model: PMRDA 20-Li A1
 entities:
   - entity: lawn_mower
     dps:

--- a/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
@@ -85,6 +85,10 @@ entities:
         type: string
         name: zones
         optional: true
+      - id: 134
+        type: string
+        name: firmware_version
+        optional: true
   - entity: button
     name: Start fixed mowing
     icon: "mdi:mower-on"
@@ -395,12 +399,3 @@ entities:
           - dps_val: null
             value: false
           - value: true
-  - entity: sensor
-    name: Firmware version
-    icon: "mdi:information"
-    category: diagnostic
-    dps:
-      - id: 134
-        type: string
-        name: sensor
-        optional: true

--- a/custom_components/tuya_local/devices/parkside_pamrc_250_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_pamrc_250_mower.yaml
@@ -344,26 +344,7 @@ entities:
         type: boolean
         name: button
         optional: true
-  - entity: select
-    name: Mowing mode
-    icon: "mdi:mower"
-    category: config
-    dps:
-      - id: 3
-        type: string
-        optional: true
-        name: option
-        mapping:
-          - dps_val: standby
-            value: Standby
-          - dps_val: random
-            value: Random
-          - dps_val: smart
-            value: Smart
-          - dps_val: spot
-            value: Spot
-          - dps_val: goto_charge
-            value: Return to dock
+
   - entity: button
     name: Clear zones
     icon: "mdi:map-marker-remove"

--- a/custom_components/tuya_local/devices/parkside_pamrc_250_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_pamrc_250_mower.yaml
@@ -327,7 +327,7 @@ entities:
         name: button
         optional: true
   - entity: button
-    name: Query schedule
+    name: Refresh schedule
     icon: "mdi:calendar-refresh"
     category: config
     dps:
@@ -336,7 +336,7 @@ entities:
         name: button
         optional: true
   - entity: button
-    name: Query zones
+    name: Refresh zones
     icon: "mdi:map-search"
     category: config
     dps:

--- a/custom_components/tuya_local/devices/parkside_pamrc_250_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_pamrc_250_mower.yaml
@@ -1,14 +1,9 @@
 name: Lawnmower
 products:
-  - id: mvt4l2evgq2l3nkn
-    manufacturer: MoeBot
-    model: S20
-  - id: icw5sal7xfcevsve
+
+  - id: 9hdajpiw
     manufacturer: Parkside
-    model: PMRDA 20-Li A1
-  - id: 7yr5iwga
-    manufacturer: Parkside
-    model: PMRC 250 Ai Bluetooth
+    model: PAMRC 250 A1 City
 entities:
   - entity: lawn_mower
     dps:
@@ -354,17 +349,30 @@ entities:
     icon: "mdi:mower"
     category: config
     dps:
-      - id: 114
+      - id: 3
         type: string
-        # Parkside mowers mark this as boolean01Reserved, but as long as they
-        #  don't use it the incompatibility is just theoretical
         optional: true
         name: option
         mapping:
-          - dps_val: AutoMode
-            value: Auto
-          - dps_val: GardenMode
-            value: Garden
+          - dps_val: standby
+            value: Standby
+          - dps_val: random
+            value: Random
+          - dps_val: smart
+            value: Smart
+          - dps_val: spot
+            value: Spot
+          - dps_val: goto_charge
+            value: Return to dock
+  - entity: button
+    name: Clear zones
+    icon: "mdi:map-marker-remove"
+    category: config
+    dps:
+      - id: 114
+        type: boolean
+        name: button
+        optional: true
   - entity: binary_sensor
     name: Cover
     category: diagnostic
@@ -389,16 +397,11 @@ entities:
     hidden: unavailable
     dps:
       - id: 121
-        type: integer
+        type: boolean
         name: switch
         optional: true
-        mapping:
-          - dps_val: 0
-            value: false
-          - dps_val: 1
-            value: true
       - id: 121
-        type: integer
+        type: boolean
         optional: true
         name: available
         mapping:


### PR DESCRIPTION
Closes #5287

This PR adds full support for the **Parkside PAMRC 250 A1 City** (Product ID: `9hdajpiw`).

### Architecture Change / File Split
Initially, I attempted to append this device to the existing `moebot_s_mower.yaml` since the basic commands and statuses match the older Parkside models in that file. However, during live hardware testing, discovered irreconcilable type conflicts in the DP specifications:

- **DP 114**: Older models use this as a `string` for "Mowing mode". The PAMRC 250 A1 City uses it as a `boolean` (Clear zones switch).
- **DP 121**: Older models use an `integer` (0/1) for blade stop. This model strictly uses a `boolean`.
- **Mowing Mode**: Older models used DP 114 as a Mowing Mode selector. The PAMRC 250 A1 City firmware does not support a dedicated "Mowing Mode" setting (it uses specific commands on DP 115 like Edge Mowing and Fixed Mowing instead).

Combining them caused the `tuya-local` type checker (`_typematch`) to reject the boolean values, breaking the configuration UI. 

To resolve this safely without breaking the existing older Parkside mowers, I've created a new dedicated `parkside_pamrc_250_mower.yaml` configuration file where all data types strictly match this newer firmware. 

**Note on Future Organization**: In the future, if it's deemed better for organization, it might be worth migrating the older Parkside models out of `moebot_s_mower.yaml` and into this new `parkside` file (with proper conditional mappings/types), but for now, they are kept separate to ensure we don't accidentally break the older untested models.

### Verified Functionality
This configuration has been tested against physical hardware. The following features are confirmed working via Home Assistant UI:
- **Statuses**: correctly maps device states (Charging, Mowing, Paused, etc.)
- **Return to Dock**
- **Edge cutting** (from Dock)
- **Configuration Switches**: Backward blade stop, Clear zones, Refresh schedules.
- **Diagnostics**: Firmware version, Problem code mappings.
