### PR TITLE
Add Timberk T-HU5-A101E-WF Humidifier

### DIFF
--- a/custom_components/tuya_local/devices/timberk_a101e_wf_humidifier.yaml
+++ b/custom_components/tuya_local/devices/timberk_a101e_wf_humidifier.yaml
@@ -1,0 +1,146 @@
+name: Humidifier
+products:
+  - id: qnwki7iygqaaxaft
+    manufacturer: Timberk
+    model: Smart Humidifier
+    model_id: T-HU5-A101E-WF
+
+entities:
+  - entity: humidifier
+    class: humidifier
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 101
+        type: string
+        name: humidity
+        mapping:
+          - dps_val: "cancel"
+            value: 0
+          - dps_val: "40"
+            value: 40
+          - dps_val: "45"
+            value: 45
+          - dps_val: "50"
+            value: 50
+          - dps_val: "55"
+            value: 55
+          - dps_val: "60"
+            value: 60
+          - dps_val: "65"
+            value: 65
+          - dps_val: "70"
+            value: 70
+          - dps_val: "75"
+            value: 75
+          - dps_val: "80"
+            value: 80
+          - dps_val: "85"
+            value: 85
+          - dps_val: "90"
+            value: 90
+      - id: 14
+        type: integer
+        name: current_humidity
+      - id: 23
+        type: string
+        name: mode
+        translation_key: mode
+        mapping:
+          - dps_val: level_0
+            value: off
+          - dps_val: level_1
+            value: low
+          - dps_val: level_2
+            value: medium
+          - dps_val: level_3
+            value: high
+            
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        unit: °C
+        class: measurement
+
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 14
+        type: integer
+        name: sensor
+        unit: '%'
+        class: measurement
+        
+  - entity: switch
+    translation_key: sleep
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        name: switch
+
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: 1h
+            value: 1h
+          - dps_val: 2h
+            value: 2h
+          - dps_val: 3h
+            value: 3h
+          - dps_val: 4h
+            value: 4h
+          - dps_val: 5h
+            value: 5h
+          - dps_val: 6h
+            value: 6h
+          - dps_val: 7h
+            value: 7h
+          - dps_val: 8h
+            value: 8h
+  - entity: binary_sensor
+    class: problem
+    translation_key: tank_empty
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        optional: true
+        name: fault_code
+
+  - entity: select
+    translation_key: mode
+    icon: "mdi:spray"
+    dps:
+      - id: 23
+        type: string
+        name: option
+        mapping:
+          - dps_val: level_0
+            value: off
+          - dps_val: level_1
+            value: low
+          - dps_val: level_2
+            value: medium
+          - dps_val: level_3
+            value: high

--- a/custom_components/tuya_local/devices/timberk_a101e_wf_humidifier.yaml
+++ b/custom_components/tuya_local/devices/timberk_a101e_wf_humidifier.yaml
@@ -46,7 +46,6 @@ entities:
       - id: 23
         type: string
         name: mode
-        translation_key: mode
         mapping:
           - dps_val: level_0
             value: off
@@ -56,7 +55,6 @@ entities:
             value: medium
           - dps_val: level_3
             value: high
-            
   - entity: sensor
     class: temperature
     dps:
@@ -65,7 +63,6 @@ entities:
         name: sensor
         unit: °C
         class: measurement
-
   - entity: sensor
     class: humidity
     dps:
@@ -74,7 +71,6 @@ entities:
         name: sensor
         unit: '%'
         class: measurement
-        
   - entity: switch
     translation_key: sleep
     category: config
@@ -82,7 +78,6 @@ entities:
       - id: 16
         type: boolean
         name: switch
-
   - entity: select
     translation_key: timer
     category: config
@@ -121,13 +116,7 @@ entities:
           - dps_val: 0
             value: false
           - dps_val: null
-            value: false
           - value: true
-      - id: 22
-        type: bitfield
-        optional: true
-        name: fault_code
-
   - entity: select
     translation_key: mode
     icon: "mdi:spray"


### PR DESCRIPTION
Added timberk_a101e_wf_humidifier.yaml to support Timberk T-HU5-A101E-WF Humidifier. Have been using the config for a few weeks and has been stable.

LOCAL DPs from integration logs:
{"updated_at": 1780946308.9915004, "1": false, "10": 26, "14": 45, "16": false, "19": "cancel", "22": 0, "23": "level_1", "101": "75"}

Brand name - Timberk
Model - T-HU5-A101E-WF
Device type - Humidifier

Manual - https://www.timberk.ru/upload/iblock/2cf/qamcv6di83kzi3pzl5lvzy69xsscdtx2.pdf
Official link - https://www.timberk.ru/catalog/product/t-hu5-a101e-wf/