### PR TITLE
feat: Atomi coffee maker device config

### DIFF
--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -36,11 +36,12 @@ entities:
   - entity: sensor
     # read only
     # status of the machine
-    # Manual Schedule - tapping the "timer/clock" icon on the device sets this status.
-    #   However, I can't figure out how to set up the device such that it reports a Minutes Until Brew
-    #   Press and hold the timer button and then use the hour/minute buttons to set a time, presumably
+    # Manual Schedule - tapping the "timer/clock" icon on the device sets
+    #   this status. However, I can't figure out how to set up the device
+    #   such that it reports a Minutes Until Brew Press and hold the timer
+    #   button and then use the hour/minute buttons to set a time, presumably
     #   when the device should start brewing
-    name: Status
+    translation_key: status
     class: enum
     category: diagnostic
     dps:
@@ -76,8 +77,9 @@ entities:
 
   - entity: sensor
     # read only
-    # value of fault - this is for development, and can be removed when figure out what other bits mean.
-    #  When (if) the other bits are determined, setup a binary_sensor like Carafe not on base
+    # value of fault - this is for development, and can be removed when
+    #   figure out what other bits mean. When (if) the other bits are
+    #   determined, setup a binary_sensor like Carafe not on base
     #  (bit 2 is carafe not on base)
     name: Raw fault status
     category: diagnostic
@@ -113,9 +115,11 @@ entities:
     # read only
     # marking as optional and hidden.  I've tested a bunch and
     #   I can't figure out to render a value in this field.
-    # I've setup a manual schedule, which worked, but didn't see any changes in the data.
-    # The SmartLife app has a schedule but it doesn't seem to translate to a value for this field.
-    #   My guess is the schedule is a cloud only based feature
+    # I've setup a manual schedule, which worked, but didn't see any changes
+    #   in the data.
+    # The SmartLife app has a schedule but it doesn't seem to translate to a
+    #   value for this field. My guess is the schedule is a cloud only based
+    #   feature
     name: Minutes Until Brew
     hidden: true
     category: diagnostic
@@ -130,8 +134,8 @@ entities:
 
   - entity: button
     name: Start Brewing
-    # The switch may or may not turn on the machine.  For instance, if there isn't
-    #   enough water or carafe is missing
+    # The switch may or may not turn on the machine.
+    #   For instance, if there isn't enough water or carafe is missing
     dps:
       - id: 103
         type: boolean
@@ -173,8 +177,8 @@ entities:
     name: Set Time
     # write only
     # calibration - sets the time when called
-    #   marked as optional because it isn't reported when adding a device and throws off
-    #   the matching algorithm
+    #   marked as optional because it isn't reported when adding a device
+    #   and throws off the matching algorithm
     dps:
       - id: 105
         optional: true

--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -1,11 +1,9 @@
-name: Atomi Coffee Maker
+name: Coffee maker
 products:
-  - id: 000002cuuc
-    manufacturer: Atomi
-    name: Atomi Smart Coffee Maker
   - id: gmbbmrpkqecjoeoa
     manufacturer: Atomi
-    name: Atomi Smart Coffee Maker
+    model: RE70X-TC02
+    model_id: 000002cuuc
 
 entities:
   - entity: binary_sensor
@@ -54,16 +52,16 @@ entities:
           - dps_val: status2
             value: Brewing
           - dps_val: status3
-            value: Warming
+            value: Keeping warm
           - dps_val: status4
-            value: Manual Schedule
+            value: Scheduled on device
 
   - entity: binary_sensor
     # read only
     # bit 0 (value = 0), OK (carafe on base)
     # bit 2 (value = 4), carafe not on base
     # not sure what other bits can be set or what they mean
-    class: problem
+    class: occupancy
     name: Carafe
     category: diagnostic
     dps:
@@ -72,8 +70,17 @@ entities:
         name: sensor
         mapping:
           - dps_val: 4
-            value: true
-          - value: false
+            value: false
+          - value: true
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 6
+        type: bitfield
+        name: sensor
 
   - entity: sensor
     # read only
@@ -81,7 +88,7 @@ entities:
     #   figure out what other bits mean. When (if) the other bits are
     #   determined, setup a binary_sensor like Carafe not on base
     #  (bit 2 is carafe not on base)
-    name: Raw fault status
+    name: Fault Code
     category: diagnostic
     hidden: true
     dps:
@@ -99,8 +106,7 @@ entities:
     #   to become "Needs water"
     #   Also, even though it has units of ML, seems
     #   to only be a 1 or 0 (needs water or ready)
-    name: Water Tank
-    class: problem
+    translation_key: tank_empty
     category: diagnostic
     dps:
       - id: 18
@@ -115,7 +121,7 @@ entities:
     # read only
     # marking as optional and hidden.  I've tested a bunch and
     #   I can't figure out to render a value in this field.
-    # I've setup a manual schedule, which worked, but didn't see any changes
+    # I've setup "schedule on device", which works, but don't see any changes
     #   in the data.
     # The SmartLife app has a schedule but it doesn't seem to translate to a
     #   value for this field. My guess is the schedule is a cloud only based

--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -3,7 +3,6 @@ products:
   - id: gmbbmrpkqecjoeoa
     manufacturer: Atomi
     model: RE70X-TC02
-    model_id: 000002cuuc
 
 entities:
   - entity: binary_sensor
@@ -41,20 +40,19 @@ entities:
     #   when the device should start brewing
     translation_key: status
     class: enum
-    category: diagnostic
     dps:
       - id: 3
         type: string
         name: sensor
         mapping:
           - dps_val: status1
-            value: Idle
+            value: idle
           - dps_val: status2
-            value: Brewing
+            value: brewing
           - dps_val: status3
-            value: Keeping warm
+            value: keeping_warm
           - dps_val: status4
-            value: Scheduled on device
+            value: scheduled
 
   - entity: binary_sensor
     # read only
@@ -63,7 +61,6 @@ entities:
     # not sure what other bits can be set or what they mean
     class: occupancy
     name: Carafe
-    category: diagnostic
     dps:
       - id: 6
         type: bitfield
@@ -76,25 +73,19 @@ entities:
   - entity: binary_sensor
     class: problem
     category: diagnostic
-    hidden: true
     dps:
       - id: 6
         type: bitfield
         name: sensor
-
-  - entity: sensor
-    # read only
-    # value of fault - this is for development, and can be removed when
-    #   figure out what other bits mean. When (if) the other bits are
-    #   determined, setup a binary_sensor like Carafe not on base
-    #  (bit 2 is carafe not on base)
-    name: Fault Code
-    category: diagnostic
-    hidden: true
-    dps:
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 4
+            value: false
+          - value: true
       - id: 6
         type: bitfield
-        name: sensor
+        name: fault_code
 
   - entity: binary_sensor
     # Read only
@@ -107,17 +98,16 @@ entities:
     #   Also, even though it has units of ML, seems
     #   to only be a 1 or 0 (needs water or ready)
     translation_key: tank_empty
-    category: diagnostic
     dps:
       - id: 18
-        type: integer
+        type: bitfield
         name: sensor
         mapping:
-          - dps_val: 1
-            value: true
-          - value: false
+          - dps_val: 0
+            value: false
+          - value: true
 
-  - entity: number
+  - entity: time
     # read only
     # marking as optional and hidden.  I've tested a bunch and
     #   I can't figure out to render a value in this field.
@@ -126,20 +116,19 @@ entities:
     # The SmartLife app has a schedule but it doesn't seem to translate to a
     #   value for this field. My guess is the schedule is a cloud only based
     #   feature
-    name: Minutes Until Brew
+    name: Brew timer
+    category: config
     hidden: true
-    category: diagnostic
     dps:
       - id: 102
         optional: true
         type: integer
-        name: value
+        name: minute
         range:
           min: 0
-          max: 1440
-
+          max: 1439
   - entity: button
-    name: Start Brewing
+    name: Start brewing
     # The switch may or may not turn on the machine.
     #   For instance, if there isn't enough water or carafe is missing
     dps:
@@ -151,7 +140,7 @@ entities:
             value: true
 
   - entity: button
-    name: Power Off
+    name: Power off
     # The switch may or may not turn on the machine.  If there isn't
     #   enough water or carafe is missing, then
     #   HA will show the switch as ON, but the machine will remain OFF
@@ -163,24 +152,26 @@ entities:
           - dps_val: false
             value: false
 
-  - entity: number
+  - entity: time
     # read only
     # I've tested with various scenarios and never get a value for this.
     #   The SmartLife app doesn't show warming time either
-    name: Warming Time
+    name: Warm timer
+    category: config
     hidden: true
-    category: diagnostic
     dps:
       - id: 104
         optional: true
         type: integer
-        name: value
+        name: minute
         range:
           min: 0
-          max: 1440
+          max: 1439
 
   - entity: button
-    name: Set Time
+    name: Sync time
+    icon: "mdi:clock"
+    category: config
     # write only
     # calibration - sets the time when called
     #   marked as optional because it isn't reported when adding a device

--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -2,14 +2,15 @@ name: Atomi Coffee Maker
 products:
   - id: 000002cuuc
     manufacturer: Atomi
-    name: Atomi Smart Coffee Maker (2nd Gen)
+    name: Atomi Smart Coffee Maker
   - id: gmbbmrpkqecjoeoa
     manufacturer: Atomi
-    name: Atomi Smart Coffee Maker (2nd Gen)
+    name: Atomi Smart Coffee Maker
 
 entities:
   - entity: binary_sensor
-    # power status - read only
+    # read only
+    # power status
     name: Brewing
     category: diagnostic
     dps:
@@ -18,7 +19,8 @@ entities:
         name: sensor
 
   - entity: select
-    # brew strength (mode) - read/write
+    # read/write
+    # brew strength
     name: Brew strength
     category: config
     dps:
@@ -32,9 +34,12 @@ entities:
             value: Strong
 
   - entity: sensor
-    # status of the machine - read only
-    # Manual Schedule - seems to be what happens when you press the "timer/clock" icon on
-    #   the device (not the app.)  However, I can't figure out how to set the Schedule on the device
+    # read only
+    # status of the machine
+    # Manual Schedule - tapping the "timer/clock" icon on the device sets this status.
+    #   However, I can't figure out how to set up the device such that it reports a Minutes Until Brew
+    #   Press and hold the timer button and then use the hour/minute buttons to set a time, presumably
+    #   when the device should start brewing
     name: Status
     class: enum
     category: diagnostic
@@ -53,8 +58,9 @@ entities:
             value: Manual Schedule
 
   - entity: binary_sensor
-    # value = 0, OK (carafe on base)
-    # bit 2 (value = 4), carafe not on base - read only
+    # read only
+    # bit 0 (value = 0), OK (carafe on base)
+    # bit 2 (value = 4), carafe not on base
     # not sure what other bits can be set or what they mean
     class: problem
     name: Carafe
@@ -69,9 +75,10 @@ entities:
           - value: false
 
   - entity: sensor
+    # read only
     # value of fault - this is for development, and can be removed when figure out what other bits mean.
     #  When (if) the other bits are determined, setup a binary_sensor like Carafe not on base
-    #  (bit 2 is carafe not on base) - read only
+    #  (bit 2 is carafe not on base)
     name: Raw fault status
     category: diagnostic
     hidden: true
@@ -81,15 +88,17 @@ entities:
         name: sensor
 
   - entity: binary_sensor
-    name: Water Tank
-    class: problem
-    # water in the tank - readonly - this sensor is only evaluated when
-    #   brewing is started, so can't be used to warn ahead of brewing.
-    #   Furthermore, the sensor will change to "Ready" before testing,
-    #   and if the coffee maker is "cold" it will take almost a minute
+    # Read only
+    # water in the tank - this sensor is only evaluated when
+    #   brewing starts, so can't be used to warn ahead of brewing.
+    #   Furthermore, the sensor will change to "Ready" when brewing starts,
+    #   and then change to "Needs water" if the water is low.
+    #   If the coffee maker is "cold" it will take almost a minute
     #   to become "Needs water"
     #   Also, even though it has units of ML, seems
     #   to only be a 1 or 0 (needs water or ready)
+    name: Water Tank
+    class: problem
     category: diagnostic
     dps:
       - id: 18
@@ -100,11 +109,14 @@ entities:
             value: true
           - value: false
 
-  # Leaving this here and marking as hidden.  I just see Unknown in HA and can't
-  #   find any way to set it using app or directly on device
-  - entity: time
-    # time - read only
-    name: Time
+  - entity: number
+    # read only
+    # marking as optional and hidden.  I've tested a bunch and
+    #   I can't figure out to render a value in this field.
+    # I've setup a manual schedule, which worked, but didn't see any changes in the data.
+    # The SmartLife app has a schedule but it doesn't seem to translate to a value for this field.
+    #   My guess is the schedule is a cloud only based feature
+    name: Minutes Until Brew
     hidden: true
     category: diagnostic
     dps:
@@ -112,6 +124,9 @@ entities:
         optional: true
         type: integer
         name: value
+        range:
+          min: 0
+          max: 1440
 
   - entity: button
     name: Start Brewing
@@ -138,22 +153,28 @@ entities:
           - dps_val: false
             value: false
 
-  # Leaving this here as a reminder that ID=104 doesn't seem to be passed during
-  #   normal operation of the device through the app or directly on device
-  - entity: sensor
-    # countdown - read only
-    name: Countdown
+  - entity: number
+    # read only
+    # I've tested with various scenarios and never get a value for this.
+    #   The SmartLife app doesn't show warming time either
+    name: Warming Time
     hidden: true
     category: diagnostic
     dps:
       - id: 104
         optional: true
         type: integer
-        name: sensor
+        name: value
+        range:
+          min: 0
+          max: 1440
 
   - entity: button
     name: Set Time
-    # calibration - sets the time when called - write only
+    # write only
+    # calibration - sets the time when called
+    #   marked as optional because it isn't reported when adding a device and throws off
+    #   the matching algorithm
     dps:
       - id: 105
         optional: true

--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -100,7 +100,7 @@ entities:
     translation_key: tank_empty
     dps:
       - id: 18
-        type: bitfield
+        type: integer
         name: sensor
         mapping:
           - dps_val: 0

--- a/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
+++ b/custom_components/tuya_local/devices/atomi_coffee_maker.yaml
@@ -1,0 +1,164 @@
+name: Atomi Coffee Maker
+products:
+  - id: 000002cuuc
+    manufacturer: Atomi
+    name: Atomi Smart Coffee Maker (2nd Gen)
+  - id: gmbbmrpkqecjoeoa
+    manufacturer: Atomi
+    name: Atomi Smart Coffee Maker (2nd Gen)
+
+entities:
+  - entity: binary_sensor
+    # power status - read only
+    name: Brewing
+    category: diagnostic
+    dps:
+      - id: 1
+        type: boolean
+        name: sensor
+
+  - entity: select
+    # brew strength (mode) - read/write
+    name: Brew strength
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: smart
+            value: Regular
+          - dps_val: auto
+            value: Strong
+
+  - entity: sensor
+    # status of the machine - read only
+    # Manual Schedule - seems to be what happens when you press the "timer/clock" icon on
+    #   the device (not the app.)  However, I can't figure out how to set the Schedule on the device
+    name: Status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: status1
+            value: Idle
+          - dps_val: status2
+            value: Brewing
+          - dps_val: status3
+            value: Warming
+          - dps_val: status4
+            value: Manual Schedule
+
+  - entity: binary_sensor
+    # value = 0, OK (carafe on base)
+    # bit 2 (value = 4), carafe not on base - read only
+    # not sure what other bits can be set or what they mean
+    class: problem
+    name: Carafe
+    category: diagnostic
+    dps:
+      - id: 6
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+
+  - entity: sensor
+    # value of fault - this is for development, and can be removed when figure out what other bits mean.
+    #  When (if) the other bits are determined, setup a binary_sensor like Carafe not on base
+    #  (bit 2 is carafe not on base) - read only
+    name: Raw fault status
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 6
+        type: bitfield
+        name: sensor
+
+  - entity: binary_sensor
+    name: Water Tank
+    class: problem
+    # water in the tank - readonly - this sensor is only evaluated when
+    #   brewing is started, so can't be used to warn ahead of brewing.
+    #   Furthermore, the sensor will change to "Ready" before testing,
+    #   and if the coffee maker is "cold" it will take almost a minute
+    #   to become "Needs water"
+    #   Also, even though it has units of ML, seems
+    #   to only be a 1 or 0 (needs water or ready)
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 1
+            value: true
+          - value: false
+
+  # Leaving this here and marking as hidden.  I just see Unknown in HA and can't
+  #   find any way to set it using app or directly on device
+  - entity: time
+    # time - read only
+    name: Time
+    hidden: true
+    category: diagnostic
+    dps:
+      - id: 102
+        optional: true
+        type: integer
+        name: value
+
+  - entity: button
+    name: Start Brewing
+    # The switch may or may not turn on the machine.  For instance, if there isn't
+    #   enough water or carafe is missing
+    dps:
+      - id: 103
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: true
+            value: true
+
+  - entity: button
+    name: Power Off
+    # The switch may or may not turn on the machine.  If there isn't
+    #   enough water or carafe is missing, then
+    #   HA will show the switch as ON, but the machine will remain OFF
+    dps:
+      - id: 103
+        type: boolean
+        name: button
+        mapping:
+          - dps_val: false
+            value: false
+
+  # Leaving this here as a reminder that ID=104 doesn't seem to be passed during
+  #   normal operation of the device through the app or directly on device
+  - entity: sensor
+    # countdown - read only
+    name: Countdown
+    hidden: true
+    category: diagnostic
+    dps:
+      - id: 104
+        optional: true
+        type: integer
+        name: sensor
+
+  - entity: button
+    name: Set Time
+    # calibration - sets the time when called - write only
+    dps:
+      - id: 105
+        optional: true
+        type: string
+        name: button
+        mapping:
+          - dps_val: calibration
+            value: calibration


### PR DESCRIPTION
## Device

Atomi Smart Coffee Maker
- Product Category = kfj
- product_name = Coffee Maker
- product_id = gmbbmrpkqecjoeoa
- Model = RE70X-TC02
- modelId = 000002cuuc

## Testing
- HA Core production deployment = 2026.6.1
- Made lots of notes in the device config
- Some of the reported fields don't seem to be used - noted in config as comments

attached are diagnostics from iot.tuya.com, and 000002cuuc-kfj-dashboard-card.yaml is a sample dashboard tile using stock components

[000002cuuc-kfj-category-instruction-set.json](https://github.com/user-attachments/files/28769416/000002cuuc-kfj-category-instruction-set.json)
[000002cuuc-kfj-dashboard-card.yaml](https://github.com/user-attachments/files/28769417/000002cuuc-kfj-dashboard-card.yaml)
[000002cuuc-query-device-details.json](https://github.com/user-attachments/files/28769418/000002cuuc-query-device-details.json)
[000002cuuc-query-properties.json](https://github.com/user-attachments/files/28769419/000002cuuc-query-properties.json)
[000002cuuc-query-things-data-model.json](https://github.com/user-attachments/files/28769420/000002cuuc-query-things-data-model.json)
