### PR TITLE
Add Klarta Stor 3 Air purifier support

### DIFF
--- a/custom_components/tuya_local/devices/klarta_stor3_purifier.yaml
+++ b/custom_components/tuya_local/devices/klarta_stor3_purifier.yaml
@@ -47,8 +47,7 @@ entities:
         class: measurement
         unit: ugm3
   - entity: sensor
-    name: Active filter life
-    icon: "mdi:air-filter"
+    translation_key: filter_life
     category: diagnostic
     dps:
       - id: 5
@@ -57,18 +56,18 @@ entities:
         unit: "%"
   - entity: select
     name: Auto mode
-    icon: "mdi:auto-mode"
+    translation_key: mode
     dps:
       - id: 101
         name: option
         type: string
         mapping:
           - dps_val: sleep
-            value: Sleep
+            value: sleep
           - dps_val: normal
-            value: Normal
+            value: medium
           - dps_val: turbo
-            value: Turbo
+            value: high
   - entity: switch
     translation_key: ionizer
     category: config

--- a/custom_components/tuya_local/devices/klarta_stor3_purifier.yaml
+++ b/custom_components/tuya_local/devices/klarta_stor3_purifier.yaml
@@ -1,0 +1,146 @@
+name: Air purifier
+products:
+  - id: d3t8x46xs23ncow8
+    manufacturer: Klarta
+    model: Stor 3
+entities:
+  - entity: fan
+    translation_key: air_purifier
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 3
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: manual
+            value: manual
+          - dps_val: sleep
+            value: sleep
+          - dps_val: screenoff
+            value: displayoff
+      - id: 4
+        type: integer
+        name: speed
+        mapping:
+          - dps_val: 1
+            value: 17
+          - dps_val: 2
+            value: 33
+          - dps_val: 3
+            value: 50
+          - dps_val: 4
+            value: 67
+          - dps_val: 5
+            value: 83
+          - dps_val: 6
+            value: 100
+  - entity: sensor
+    class: pm25
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        class: measurement
+        unit: ugm3
+  - entity: sensor
+    name: Active filter life
+    icon: "mdi:air-filter"
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: select
+    name: Auto mode
+    icon: "mdi:auto-mode"
+    dps:
+      - id: 101
+        name: option
+        type: string
+        mapping:
+          - dps_val: sleep
+            value: Sleep
+          - dps_val: normal
+            value: Normal
+          - dps_val: turbo
+            value: Turbo
+  - entity: switch
+    translation_key: ionizer
+    category: config
+    dps:
+      - id: 6
+        type: boolean
+        name: switch
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+  - entity: button
+    translation_key: filter_reset
+    category: config
+    dps:
+      - id: 11
+        type: boolean
+        name: button
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 18
+        name: option
+        type: string
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: 1h
+            value: "1h"
+          - dps_val: 2h
+            value: "2h"
+          - dps_val: 4h
+            value: "4h"
+          - dps_val: 8h
+            value: "8h"
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 12
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    translation_key: air_quality
+    class: enum
+    dps:
+      - id: 21
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: good
+            value: excellent
+          - dps_val: moderate
+            value: good
+          - dps_val: medium
+            value: moderate
+          - dps_val: unhealthy
+            value: poor
+          - dps_val: severe
+            value: severe
+          - dps_val: hazard
+            value: danger


### PR DESCRIPTION
Added all available functionality of Klarta Stor 3 Air purifier.
- On/Off switch
- Mode: auto, manual, sleep, display off
- Auto Mode: sleep, normal, turbo
- Speed: 1-6
- PM2.5 sensor
- Filter usage
- Ioniser switch
- Filter usage reset button
- Temperature
- Humidity
- Air quality
<img width="332" height="1058" alt="obraz" src="https://github.com/user-attachments/assets/5360fa07-7f1a-44bd-adf1-d7096c3d628b" />
