### PR TITLE
Add Etna AB791 rangehood

### DIFF
--- a/custom_components/tuya_local/devices/etna_ab791_rangehood.yaml
+++ b/custom_components/tuya_local/devices/etna_ab791_rangehood.yaml
@@ -47,36 +47,6 @@ entities:
             value: 128
           - dps_val: Level_2
             value: 255
-  - entity: select
-    name: Fan speed
-    dps:
-      - id: 2
-        type: string
-        name: option
-        mapping:
-          - dps_val: "0"
-            value: "Off"
-          - dps_val: "1"
-            value: Speed 1
-          - dps_val: "2"
-            value: Speed 2
-          - dps_val: "3"
-            value: Speed 3
-          - dps_val: "4"
-            value: Speed 4
-  - entity: select
-    name: Light level
-    dps:
-      - id: 104
-        type: string
-        name: option
-        mapping:
-          - dps_val: Turn_off
-            value: "Off"
-          - dps_val: Level_1
-            value: Level 1
-          - dps_val: Level_2
-            value: Level 2
   - entity: number
     translation_key: timer
     class: duration

--- a/custom_components/tuya_local/devices/etna_ab791_rangehood.yaml
+++ b/custom_components/tuya_local/devices/etna_ab791_rangehood.yaml
@@ -34,11 +34,12 @@ entities:
       - id: 3
         type: boolean
         name: lock
+        optional: true
   - entity: light
     dps:
       - id: 104
-        name: brightness
         type: string
+        name: brightness
         mapping:
           - dps_val: Turn_off
             value: 0
@@ -47,35 +48,35 @@ entities:
           - dps_val: Level_2
             value: 255
   - entity: select
-    name: Ventilatorstand
+    name: Fan speed
     dps:
       - id: 2
         type: string
         name: option
         mapping:
           - dps_val: "0"
-            value: Uit
+            value: "Off"
           - dps_val: "1"
-            value: Stand 1
+            value: Speed 1
           - dps_val: "2"
-            value: Stand 2
+            value: Speed 2
           - dps_val: "3"
-            value: Stand 3
+            value: Speed 3
           - dps_val: "4"
-            value: Stand 4
+            value: Speed 4
   - entity: select
-    name: Lichtstand
+    name: Light level
     dps:
       - id: 104
         type: string
         name: option
         mapping:
           - dps_val: Turn_off
-            value: Uit
+            value: "Off"
           - dps_val: Level_1
-            value: Stand 1
+            value: Level 1
           - dps_val: Level_2
-            value: Stand 2
+            value: Level 2
   - entity: number
     translation_key: timer
     class: duration
@@ -103,6 +104,22 @@ entities:
         type: integer
         name: sensor
         unit: min
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 14
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 14
+        type: bitfield
+        name: fault_code
+        optional: true
   - entity: sensor
     name: Total runtime
     class: duration

--- a/custom_components/tuya_local/devices/etna_ab791_rangehood.yaml
+++ b/custom_components/tuya_local/devices/etna_ab791_rangehood.yaml
@@ -1,0 +1,114 @@
+name: Range hood
+products:
+  - id: ckrqmfj3mjoecvev
+    manufacturer: ETNA
+    model: AB791
+entities:
+  - entity: fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "0"
+            value: 0
+          - dps_val: "1"
+            value: 25
+          - dps_val: "2"
+            value: 50
+          - dps_val: "3"
+            value: 75
+          - dps_val: "4"
+            value: 100
+      - id: 12
+        type: string
+        name: status
+        optional: true
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 3
+        type: boolean
+        name: lock
+  - entity: light
+    dps:
+      - id: 104
+        name: brightness
+        type: string
+        mapping:
+          - dps_val: Turn_off
+            value: 0
+          - dps_val: Level_1
+            value: 128
+          - dps_val: Level_2
+            value: 255
+  - entity: select
+    name: Ventilatorstand
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Uit
+          - dps_val: "1"
+            value: Stand 1
+          - dps_val: "2"
+            value: Stand 2
+          - dps_val: "3"
+            value: Stand 3
+          - dps_val: "4"
+            value: Stand 4
+  - entity: select
+    name: Lichtstand
+    dps:
+      - id: 104
+        type: string
+        name: option
+        mapping:
+          - dps_val: Turn_off
+            value: Uit
+          - dps_val: Level_1
+            value: Stand 1
+          - dps_val: Level_2
+            value: Stand 2
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 5
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 99
+  - entity: button
+    name: Quick timer
+    dps:
+      - id: 6
+        type: boolean
+        name: button
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: min
+  - entity: sensor
+    name: Total runtime
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 15
+        type: integer
+        name: sensor
+        unit: h


### PR DESCRIPTION
Add a device profile for the ETNA AB791 range hood.

This is a device config only:
- One new device YAML file
- No code changes
- No translation changes
- No DEVICES.md or ACKNOWLEDGEMENTS.md changes

Tested with:
- Manufacturer: ETNA
- Model: AB791
- Product ID: ckrqmfj3mjoecvev
- Protocol version: 3.4

Observed DPS:
- 1: main switch/status boolean
- 2: fan speed string values "0".."4"
- 5: timer value
- 6: quick timer button
- 12: status
- 13: time remaining
- 14: fault/diagnostic bitfield
- 15: total runtime
- 104: light level values Turn_off / Level_1 / Level_2

The YAML was prepared with AI assistance from observed/tested DPS values, and I reviewed and tested the resulting device profile locally in Home Assistant before submitting.