### PR TITLE
feat(cityenergy_l10wfe_gaswaterheater): add fault sensor, optional meter resets

### DIFF
--- a/custom_components/tuya_local/devices/cityenergy_l10wfe_gaswaterheater.yaml
+++ b/custom_components/tuya_local/devices/cityenergy_l10wfe_gaswaterheater.yaml
@@ -102,6 +102,7 @@ entities:
     dps:
       - id: 107
         type: boolean
+        optional: true
         name: button
   - entity: button
     name: Reset gas meter
@@ -110,4 +111,20 @@ entities:
     dps:
       - id: 108
         type: boolean
+        optional: true
         name: button
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code

--- a/custom_components/tuya_local/devices/cityenergy_l10wfe_gaswaterheater.yaml
+++ b/custom_components/tuya_local/devices/cityenergy_l10wfe_gaswaterheater.yaml
@@ -114,7 +114,6 @@ entities:
         optional: true
         name: button
   - entity: binary_sensor
-    name: Fault
     class: problem
     category: diagnostic
     dps:


### PR DESCRIPTION
## Summary

Enhances the existing **City Energy L10WFE gas water heater** config (added in #4921):

- Adds a `problem` **binary_sensor** exposing the device's fault state plus the raw fault code (dp `20`), using the established `sensor` + `fault_code` bitfield pattern (as in `eurom_alutherm_heater.yaml`, `vacplus_dehumidifier.yaml`, etc.).
- Marks the **reset water/gas meter buttons** (dp `107`/`108`) as `optional`, since not all units report these dps — improves match reliability without disqualifying the config.

## Testing

- Verified against my own City Energy L10WFE (product id `di9ybnrv3s2d1axk`) on the local network.
- `yamllint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)