### PR TITLE
fix(yuhome_laundry_rack): correct DP ids to match actual device

### DIFF
--- a/custom_components/tuya_local/devices/yuhome_laundry_rack.yaml
+++ b/custom_components/tuya_local/devices/yuhome_laundry_rack.yaml
@@ -5,6 +5,7 @@ products:
     model: Yu Turbo
 entities:
   - entity: switch
+    name: Power
     dps:
       - id: 1
         type: boolean
@@ -28,7 +29,7 @@ entities:
         range:
           min: 0
           max: 100
-      - id: 8
+      - id: 9
         type: string
         name: action
         mapping:
@@ -36,12 +37,25 @@ entities:
             value: closing
           - dps_val: down
             value: opening
+          - dps_val: stop
+            value: idle
           - value: null
   - entity: light
+    name: Light
     dps:
       - id: 4
         type: boolean
         name: switch
+      - id: 102
+        type: string
+        name: effect
+        mapping:
+          - dps_val: Warm_White
+            value: Warm white
+          - dps_val: Cool_White
+            value: Cool white
+          - dps_val: Dual_White
+            value: Dual white
   - entity: switch
     translation_key: uv_sterilization
     dps:
@@ -62,43 +76,16 @@ entities:
       - id: 7
         type: boolean
         name: switch
-  - entity: select
-    name: Disinfection timer
-    translation_key: timer
+  - entity: switch
+    name: Voice control
+    icon: "mdi:microphone"
     category: config
     dps:
-      - id: 9
-        type: string
-        name: option
-        mapping:
-          - dps_val: cancel
-            value: cancel
-          - dps_val: "1h"
-            value: "1h"
-          - dps_val: "2h"
-            value: "2h"
-          - dps_val: "3h"
-            value: "3h"
-          - dps_val: "4h"
-            value: "4h"
-          - dps_val: "5h"
-            value: "5h"
-          - dps_val: "6h"
-            value: "6h"
-          - dps_val: "7h"
-            value: "7h"
-          - dps_val: "8h"
-            value: "8h"
-          - dps_val: "9h"
-            value: "9h"
-          - dps_val: "10h"
-            value: "10h"
-          - dps_val: "11h"
-            value: "11h"
-          - dps_val: "12h"
-            value: "12h"
+      - id: 104
+        type: boolean
+        name: switch
   - entity: select
-    name: Hot dry timer
+    name: Disinfection timer
     translation_key: timer
     category: config
     dps:
@@ -133,11 +120,46 @@ entities:
           - dps_val: "12h"
             value: "12h"
   - entity: select
-    name: Wind dry timer
+    name: Hot dry timer
     translation_key: timer
     category: config
     dps:
       - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: "1h"
+            value: "1h"
+          - dps_val: "2h"
+            value: "2h"
+          - dps_val: "3h"
+            value: "3h"
+          - dps_val: "4h"
+            value: "4h"
+          - dps_val: "5h"
+            value: "5h"
+          - dps_val: "6h"
+            value: "6h"
+          - dps_val: "7h"
+            value: "7h"
+          - dps_val: "8h"
+            value: "8h"
+          - dps_val: "9h"
+            value: "9h"
+          - dps_val: "10h"
+            value: "10h"
+          - dps_val: "11h"
+            value: "11h"
+          - dps_val: "12h"
+            value: "12h"
+  - entity: select
+    name: Wind dry timer
+    translation_key: timer
+    category: config
+    dps:
+      - id: 13
         type: string
         name: option
         mapping:
@@ -172,7 +194,7 @@ entities:
     class: duration
     category: diagnostic
     dps:
-      - id: 12
+      - id: 15
         type: integer
         optional: true
         name: sensor
@@ -182,7 +204,7 @@ entities:
     class: duration
     category: diagnostic
     dps:
-      - id: 13
+      - id: 16
         type: integer
         optional: true
         name: sensor
@@ -192,8 +214,23 @@ entities:
     class: duration
     category: diagnostic
     dps:
-      - id: 14
+      - id: 17
         type: integer
         optional: true
         name: sensor
         unit: min
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 18
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 18
+        type: bitfield
+        name: fault_code

--- a/custom_components/tuya_local/devices/yuhome_laundry_rack.yaml
+++ b/custom_components/tuya_local/devices/yuhome_laundry_rack.yaml
@@ -5,7 +5,6 @@ products:
     model: Yu Turbo
 entities:
   - entity: switch
-    name: Power
     dps:
       - id: 1
         type: boolean
@@ -41,7 +40,6 @@ entities:
             value: idle
           - value: null
   - entity: light
-    name: Light
     dps:
       - id: 4
         type: boolean
@@ -220,7 +218,6 @@ entities:
         name: sensor
         unit: min
   - entity: binary_sensor
-    name: Fault
     class: problem
     category: diagnostic
     dps:


### PR DESCRIPTION
## Summary

I'm the original author of this config (#4643). After reading the **live DPS** off my device (product id `ttawi9yohqflpt4a`, protocol 3.4), the original DP ids were wrong — several pointed at DPs the device doesn't expose. This corrects them and adds a few capabilities the device actually has.

## Live DPS evidence

| Function | Original (#4643) | Corrected | Live device |
|---|---|---|---|
| action/state | dp 8 | dp **9** | dp9 = `stop` |
| timers | dp 9,10,11 | dp **10,11,13** | dp10/11/13 = `cancel` |
| duration sensors | dp 12,13,14 | dp **15,16,17** | dp15/16/17 = `0` |
| fault | — | dp **18** | dp18 = `0` |
| light effect | — | dp **102** | dp102 = `Cool_White` |
| voice control | — | dp **104** | dp104 = `False` |

The device exposes **no dp 8/12/14** at all, so the original entities on those ids never worked.

## Changes

- Correct action/timer/duration DP ids to match the hardware.
- Add light `effect` (dp 102: Warm/Cool/Dual white).
- Add **Voice control** switch (dp 104).
- Add **Fault** `problem` binary_sensor (dp 18, sensor + fault_code bitfield).
- Add `stop` → idle cover-action mapping.

## Testing

- Verified against my own unit by polling live DPS over the local protocol (v3.4).
- `yamllint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)