### PR TITLE
feat(devices): add Ucomen 3-outlet socket

### DIFF
--- a/custom_components/tuya_local/devices/ucomen_triple_socket.yaml
+++ b/custom_components/tuya_local/devices/ucomen_triple_socket.yaml
@@ -1,0 +1,112 @@
+name: 3-outlet socket
+products:
+  - id: uebm8smvenxx8pil
+    manufacturer: Ucomen
+entities:
+  - entity: switch
+    translation_key: outlet_x
+    translation_placeholders:
+      x: "1"
+    class: outlet
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 42
+        type: string
+        name: cyclic_schedule
+      - id: 43
+        type: string
+        name: random_schedule
+      - id: 44
+        type: string
+        name: inching
+  - entity: switch
+    translation_key: outlet_x
+    translation_placeholders:
+      x: "2"
+    class: outlet
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: outlet_x
+    translation_placeholders:
+      x: "3"
+    class: outlet
+    dps:
+      - id: 3
+        type: boolean
+        name: switch
+  - entity: time
+    category: config
+    translation_key: timer_x
+    translation_placeholders:
+      x: "1"
+    dps:
+      - id: 9
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+  - entity: time
+    category: config
+    translation_key: timer_x
+    translation_placeholders:
+      x: "2"
+    dps:
+      - id: 10
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+  - entity: time
+    category: config
+    translation_key: timer_x
+    translation_placeholders:
+      x: "3"
+    dps:
+      - id: 11
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+  - entity: select
+    translation_key: initial_state
+    category: config
+    dps:
+      - id: 38
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "off"
+          - dps_val: "on"
+            value: "on"
+          - dps_val: memory
+            value: memory
+  - entity: select
+    translation_key: light_mode
+    category: config
+    dps:
+      - id: 40
+        type: string
+        name: option
+        mapping:
+          - dps_val: relay
+            value: state
+          - dps_val: pos
+            value: locator
+          - dps_val: none
+            value: "off"
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 41
+        type: boolean
+        name: lock


### PR DESCRIPTION
Adds a config for the Ucomen 3-outlet EU socket strip (WiFi+BLE), product id `uebm8smvenxx8pil`, category `pc`. The closest existing config (`simple_triple_switch_timer` / W-W603) covers only the switches and timers; this adds the remaining DPs. Existing translation keys only.

| DP | code | type | entity |
|---|---|---|---|
| 1/2/3 | switch_1/2/3 | bool | switch (outlet_x) |
| 9/10/11 | countdown_1/2/3 | int 0–86400 | time (timer_x) |
| 38 | relay_status | enum off/on/memory | select (initial_state) |
| 40 | light_mode | enum relay/pos/none | select (light_mode) |
| 41 | child_lock | bool | lock (child_lock) |
| 42/43/44 | cycle_time/random_time/switch_inching | string | attributes on outlet 1 |

Note: the cloud schema for DP 38 claims `power_off/power_on/last`, but the live device uses `off/on/memory` (verified by writing each value).

Live DPS snapshot:

```
{"1": true, "2": true, "3": true, "9": 0, "10": 0, "11": 0, "38": "memory", "40": "relay", "41": false, "42": "", "43": "", "44": ""}
```

Tested on hardware: deployed to HA 2026.6.2, device matches this config at 100% quality (vs 83% for the previous best match), all entities verified working including outlet toggles and DP 38 enum round-trip (`on` → `memory`) over local protocol 3.3.

`yamllint` and `pytest tests/test_device_config.py` pass apart from the pre-existing `powerworld_pw060_waterheatpump.yaml` validation error on main, which is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
