### PR TITLE
Add SRNE battery capacity sensors

### DIFF
--- a/custom_components/tuya_local/devices/srne_energy_storage_battery.yaml
+++ b/custom_components/tuya_local/devices/srne_energy_storage_battery.yaml
@@ -34,10 +34,56 @@ entities:
         mapping:
           - scale: 100
   - entity: sensor
+    category: diagnostic
+    name: State of health
+    dps:
+      - id: 104
+        type: integer
+        optional: true
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    name: Remaining capacity
+    dps:
+      - id: 105
+        type: integer
+        optional: true
+        name: sensor
+        unit: Ah
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    category: diagnostic
+    name: Rated capacity
+    dps:
+      - id: 106
+        type: integer
+        optional: true
+        name: sensor
+        unit: Ah
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    category: diagnostic
+    name: Full charge capacity
+    dps:
+      - id: 107
+        type: integer
+        optional: true
+        name: sensor
+        unit: Ah
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
     name: Discharge cycles
     dps:
       - id: 108
         type: integer
+        optional: true
         name: sensor
         unit: cycles
         class: total


### PR DESCRIPTION
Adds optional SRNE battery sensors to the existing `srne_energy_storage_battery.yaml` device config.
I have the EOS10B battery: https://www.srnesolar.com/productdetail/Energy-Storage-System-EOS-10kWh.html
The existing  one seems to be made for a different model which shares the product id.
Currently the existing config is missing some fields that ive added that work on my battery.
Ive also made cycle count optional since the current DP for it does not match my battery, and even the DP my battery provides for it is wrong. It shows a constant number, meanwhile smartlife app shoes 0, meanwhile srne laptop sw shows 24 so cycle count is just wrong for me.
Tested by deploying on my ha.
This is tested against fw 1.1.6-2 of the batteries. It used to also work on 1.1.7 - but srne says 1.1.6-2 is 'newer' ...

Claude writes:
  This exposes additional read-only values reported by the SRNE EOS/SR-SE battery modules:

  - State of health, DP104
  - Remaining capacity, DP105
  - Rated capacity, DP106     <== human note: DP106 and DP107 show the same value for me. since my SOH is 100% I can't tell which is which, so i took a guess.
  - Full charge capacity, DP107

  It also marks discharge cycles, DP108, as optional because this firmware does not report it.

  All added DPs are optional so existing matching should not be broken. No translations, generated docs, or code changes are included.
