### PR TITLE
Add Aquark Heat Pump.

### DIFF
--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -14,12 +14,12 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            constraint: work_mode
+            constraint: mode
             conditions:
-              - dps_val: cool
-                value: cool
               - dps_val: warm
                 value: heat
+              - dps_val: cool
+                value: cool
               - dps_val: smart
                 value: heat_cool
       - id: 102
@@ -34,7 +34,7 @@ entities:
           - dps_val: true
             value: C
       - id: 105
-        name: work_mode
+        name: mode
         type: string
         hidden: true
       - id: 106
@@ -51,11 +51,11 @@ entities:
           min: 12
           max: 40
       - id: 107
+        type: integer
         name: min_temperature
-        type: integer
       - id: 108
-        name: max_temperature
         type: integer
+        name: max_temperature
       - id: 117
         name: preset_mode
         type: boolean
@@ -65,15 +65,15 @@ entities:
           - dps_val: true
             value: boost
   - entity: sensor
-    name: Speed
     category: diagnostic
+    name: Speed
     icon: "mdi:speedometer"
     dps:
       - id: 104
-        name: sensor
         type: integer
-        class: measurement
+        name: sensor
         unit: "%"
+        class: measurement
   - entity: binary_sensor
     name: Water flow
     class: problem

--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -119,17 +119,3 @@ entities:
       - id: 116
         type: bitfield
         name: fault_code_2
-  - entity: sensor
-    name: Fault Code 1
-    category: diagnostic
-    dps:
-      - id: 115
-        name: sensor
-        type: integer
-  - entity: sensor
-    name: Fault Code 2
-    category: diagnostic
-    dps:
-      - id: 116
-        name: sensor
-        type: integer

--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -119,3 +119,17 @@ entities:
       - id: 116
         type: bitfield
         name: fault_code_2
+  - entity: sensor
+    name: Fault Code 1
+    category: diagnostic
+    dps:
+      - id: 115
+        name: sensor
+        type: integer
+  - entity: sensor
+    name: Fault Code 2
+    category: diagnostic
+    dps:
+      - id: 116
+        name: sensor
+        type: integer

--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -1,14 +1,11 @@
 name: Pool heat pump
 products:
-  - id: qrlLaHWwIsZsV31f
-    manufacturer: Phalén
-    model: Calidi XP
-    # - id: UNKNOWN
-    #   manufacturer: Fairland
-    #   model InverterPlus
+  - id: eeih95rmks0mjflz
+    manufacturer: Aquark
+    model: Mr. Silence
 entities:
   - entity: climate
-    translation_only_key: pool_heatpump
+    translation_key: pool_heatpump
     dps:
       - id: 1
         name: hvac_mode
@@ -48,11 +45,11 @@ entities:
             conditions:
               - dps_val: false
                 range:
-                  min: 55
-                  max: 115
+                  min: 54
+                  max: 104
         range:
           min: 12
-          max: 45
+          max: 40
       - id: 107
         name: min_temperature
         type: integer
@@ -64,17 +61,17 @@ entities:
         type: boolean
         mapping:
           - dps_val: false
-            value: sleep
+            value: silent
           - dps_val: true
             value: boost
   - entity: sensor
-    name: Power level
+    name: Speed
     category: diagnostic
-    icon: "mdi:signal"
+    icon: "mdi:speedometer"
     dps:
       - id: 104
-        type: integer
         name: sensor
+        type: integer
         class: measurement
         unit: "%"
   - entity: binary_sensor

--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -91,7 +91,7 @@ entities:
     category: config
     dps:
       - id: 103
-        type: string
+        type: boolean
         name: option
         mapping:
           - dps_val: false

--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -3,6 +3,9 @@ products:
   - id: eeih95rmks0mjflz
     manufacturer: Aquark
     model: Mr. Silence
+  - id: pkm5dso5i0lmx1dy
+    manufacturer: Aquark
+    model: Mr. Silence
 entities:
   - entity: climate
     translation_key: pool_heatpump

--- a/custom_components/tuya_local/devices/aquark_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aquark_heatpump.yaml
@@ -61,7 +61,7 @@ entities:
         type: boolean
         mapping:
           - dps_val: false
-            value: silent
+            value: quiet
           - dps_val: true
             value: boost
   - entity: sensor

--- a/custom_components/tuya_local/devices/fairland_iphcr15_heatpump.yaml
+++ b/custom_components/tuya_local/devices/fairland_iphcr15_heatpump.yaml
@@ -94,7 +94,7 @@ entities:
     category: config
     dps:
       - id: 103
-        type: string
+        type: boolean
         name: option
         mapping:
           - dps_val: false

--- a/custom_components/tuya_local/devices/fairland_iphcr15_heatpump.yaml
+++ b/custom_components/tuya_local/devices/fairland_iphcr15_heatpump.yaml
@@ -17,12 +17,12 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            constraint: work_mode
+            constraint: mode
             conditions:
-              - dps_val: cool
-                value: cool
               - dps_val: warm
                 value: heat
+              - dps_val: cool
+                value: cool
               - dps_val: smart
                 value: heat_cool
       - id: 102
@@ -37,7 +37,7 @@ entities:
           - dps_val: true
             value: C
       - id: 105
-        name: work_mode
+        name: mode
         type: string
         hidden: true
       - id: 106
@@ -54,11 +54,11 @@ entities:
           min: 12
           max: 45
       - id: 107
+        type: integer
         name: min_temperature
-        type: integer
       - id: 108
-        name: max_temperature
         type: integer
+        name: max_temperature
       - id: 117
         name: preset_mode
         type: boolean
@@ -68,15 +68,15 @@ entities:
           - dps_val: true
             value: boost
   - entity: sensor
-    name: Power level
     category: diagnostic
+    name: Power level
     icon: "mdi:signal"
     dps:
       - id: 104
         type: integer
         name: sensor
-        class: measurement
         unit: "%"
+        class: measurement
   - entity: binary_sensor
     name: Water flow
     class: problem

--- a/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
+++ b/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
@@ -83,7 +83,7 @@ entities:
     category: config
     dps:
       - id: 103
-        type: string
+        type: boolean
         name: option
         mapping:
           - dps_val: false

--- a/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
+++ b/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
@@ -27,8 +27,9 @@ entities:
           - dps_val: true
             value: C
       - id: 105
-        name: work_mode
+        name: mode
         type: string
+        hidden: true
       - id: 106
         name: temperature
         type: integer
@@ -43,11 +44,11 @@ entities:
           min: 18
           max: 45
       - id: 107
+        type: integer
         name: min_temperature
-        type: integer
       - id: 108
-        name: max_temperature
         type: integer
+        name: max_temperature
       - id: 117
         name: preset_mode
         type: boolean
@@ -57,15 +58,15 @@ entities:
           - dps_val: true
             value: smart
   - entity: sensor
-    name: Power level
     category: diagnostic
+    name: Power level
     icon: "mdi:signal"
     dps:
       - id: 104
-        name: sensor
         type: integer
-        class: measurement
+        name: sensor
         unit: "%"
+        class: measurement
   - entity: binary_sensor
     name: Water flow
     class: problem

--- a/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
+++ b/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
@@ -43,11 +43,11 @@ entities:
           min: 18
           max: 45
       - id: 107
-        type: integer
         name: min_temperature
-      - id: 108
         type: integer
+      - id: 108
         name: max_temperature
+        type: integer
       - id: 117
         name: preset_mode
         type: boolean
@@ -58,14 +58,14 @@ entities:
             value: smart
   - entity: sensor
     name: Power level
-    icon: "mdi:signal"
     category: diagnostic
+    icon: "mdi:signal"
     dps:
       - id: 104
         name: sensor
         type: integer
-        unit: "%"
         class: measurement
+        unit: "%"
   - entity: binary_sensor
     name: Water flow
     class: problem
@@ -78,6 +78,18 @@ entities:
           - dps_val: 4
             value: true
           - value: false
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: option
+        mapping:
+          - dps_val: false
+            value: fahrenheit
+          - dps_val: true
+            value: celsius
   - entity: binary_sensor
     class: problem
     category: diagnostic

--- a/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
+++ b/custom_components/tuya_local/devices/gardenpac_heatpump.yaml
@@ -27,9 +27,8 @@ entities:
           - dps_val: true
             value: C
       - id: 105
-        name: mode
+        name: work_mode
         type: string
-        hidden: true
       - id: 106
         name: temperature
         type: integer
@@ -58,13 +57,13 @@ entities:
           - dps_val: true
             value: smart
   - entity: sensor
-    category: diagnostic
     name: Power level
     icon: "mdi:signal"
+    category: diagnostic
     dps:
       - id: 104
-        type: integer
         name: sensor
+        type: integer
         unit: "%"
         class: measurement
   - entity: binary_sensor


### PR DESCRIPTION
Add Aquark Heat Pump.

I found that this matches `fairland_iphcr15_heatpump.yaml` and `gardenpac_heatpump.yaml`, except for the temperature range and some naming differences. I have formatted them so the diff between them is minimal.

However, after adding this, adding a new device doesn't suggest any of the three device types. Not sure what is wrong.