### PR TITLE
Honor target_range in number min/max; fix Frizzlife LP365P volume scaling

### DIFF
--- a/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
+++ b/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
@@ -309,43 +309,10 @@ entities:
           - dps_val: us_units
             value: gal
           - value: L
-      - id: 111
-        type: string
-        name: value
-        unit: gal
-        range:
-          min: 20
-          max: 1300
-        mapping:
-          - dps_val: mode4
-            value_redirect: mode4_val
-          - dps_val: mode5
-            value_redirect: mode5_val
-          - dps_val: mode6
-            value_redirect: mode6_val
       - id: 115
         type: integer
-        name: mode4_val
-        range:
-          min: 0
-          max: 64
-        mapping:
-          - target_range:
-              min: 20
-              max: 1300
-      - id: 116
-        type: integer
-        name: mode5_val
-        range:
-          min: 0
-          max: 64
-        mapping:
-          - target_range:
-              min: 20
-              max: 1300
-      - id: 117
-        type: integer
-        name: mode6_val
+        name: value
+        unit: gal
         range:
           min: 0
           max: 64

--- a/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
+++ b/custom_components/tuya_local/devices/frizzlife_lp365p_watermonitorandshutdoff.yaml
@@ -312,49 +312,47 @@ entities:
       - id: 111
         type: string
         name: value
+        unit: gal
         range:
-          min: 0
-          max: 5000
+          min: 20
+          max: 1300
         mapping:
           - dps_val: mode4
-            step: 100
             value_redirect: mode4_val
           - dps_val: mode5
-            step: 100
             value_redirect: mode5_val
           - dps_val: mode6
-            step: 100
             value_redirect: mode6_val
       - id: 115
         type: integer
         name: mode4_val
         range:
           min: 0
-          max: 50
+          max: 64
         mapping:
-          - dps_val: 0
-            value: 50
-          - scale: 0.01
+          - target_range:
+              min: 20
+              max: 1300
       - id: 116
         type: integer
         name: mode5_val
         range:
           min: 0
-          max: 50
+          max: 64
         mapping:
-          - dps_val: 0
-            value: 50
-          - scale: 0.01
+          - target_range:
+              min: 20
+              max: 1300
       - id: 117
         type: integer
         name: mode6_val
         range:
           min: 0
-          max: 50
+          max: 64
         mapping:
-          - dps_val: 0
-            value: 50
-          - scale: 0.01
+          - target_range:
+              min: 20
+              max: 1300
   - entity: select
     translation_key: temperature_unit
     category: config

--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -652,15 +652,28 @@ class TuyaDpsConfig:
                     )
 
     def range(self, device, scaled=True):
-        """Return the range for this dps if configured."""
+        """Return the range for this dps if configured.
+
+        When a target_range remap is configured, the value exposed to HA is
+        in target_range units, so report the range in those units too. This
+        keeps a number entity's min/max consistent with the values it reads
+        and writes; otherwise the slider shows raw units and values outside
+        the raw range are rejected before the target_range conversion runs.
+        """
         scale = self.scale(device) if scaled else 1
         mapping = self._find_map_for_dps(device.get_property(self.id), device)
         r = self._config.get("range")
+        target = None
         if mapping:
             r = mapping.get("range", r)
+            target = mapping.get("target_range")
             cond = self._active_condition(mapping, device)
             if cond:
                 r = cond.get("range", r)
+                target = cond.get("target_range", target)
+
+        if scaled and target and "min" in target and "max" in target:
+            return (target["min"], target["max"])
 
         if r and "min" in r and "max" in r:
             return _scale_range(r, scale)


### PR DESCRIPTION
Fixes #5323

### What

1. **`DpsConfig.range()` now honors `target_range`.** A `number`'s
   `native_min_value`/`native_max_value` come from `range()`, which applied
   `scale` but ignored `target_range`, so numbers with a `target_range` remap
   exposed their bounds in raw dps units. That made sliders show raw units
   (e.g. a 0.01–0.1 min-flow showing 0–9) and rejected values outside the raw
   range before the `target_range` conversion could run. `range()` now returns
   the `target_range` bounds when configured (guarded by `scaled`; the write
   path reads the raw range from config directly, so it is unaffected).

2. **Frizzlife LP365P "Allowed flow volume" fixed (scale + writability).**
   The firmware offset-encodes this value: `gallons = raw*20 + 20`
   (raw `0–64` ⇄ `20–1300` gal). The old mapping used `scale: 0.01` plus a
   `{dps_val: 0, value: 50}` special case, which mis-read (~900 for a real
   200 gal). It also routed the value through `value_redirect`
   (mode4/5/6 → modeN_val), which does **not** apply the leaf `target_range`
   on write — so sets never reached the device. Replaced with a direct
   `target_range` mapping on the value DP.

### Verified on a live LP365P (protocol 3.5)

- Min-flow slider bounds correct (0.01–0.1). ✅
- Allowed-flow-volume **reads** correctly, matching the Smart Life app
  (raw 0/7/9/64 ⇄ 20/160/200/1300 gal). ✅
- Allowed-flow-volume **writes** correctly from HA — set 200 gal → dp115
  raw 9, confirmed by direct device read. ✅ (Through `value_redirect` the
  same set left dp115 unchanged; direct binding fixes it.)

### Note on multi-mode

The direct mapping tracks the Mode 4 register (dp115). The previous
`value_redirect` form auto-followed the active advanced mode but was
non-writable for this offset encoding. If preserving auto-follow is
preferred, the `value_redirect` write path would need to apply the
redirected dp's `target_range` (it currently honors `scale` but not
`target_range`); happy to take it that direction instead.
