### PR TITLE
Add GoDrone 01B smart cat litter box

### DIFF
--- a/custom_components/tuya_local/devices/godrone_01b_litterbox.yaml
+++ b/custom_components/tuya_local/devices/godrone_01b_litterbox.yaml
@@ -60,6 +60,21 @@ entities:
       - id: 130
         type: boolean
         name: deport_mode
+      # 131/132/133 are device-specific status values, meaning unknown.
+      # They did not change in response to any app setting (scheduled clean,
+      # sterilization and do-not-disturb are cloud timers, not local dps).
+      - id: 131
+        type: integer
+        optional: true
+        name: unknown_131
+      - id: 132
+        type: boolean
+        optional: true
+        name: unknown_132
+      - id: 133
+        type: boolean
+        optional: true
+        name: unknown_133
   - entity: button
     name: Clean
     category: config
@@ -211,37 +226,3 @@ entities:
           max: 1500
         mapping:
           - step: 100
-  # 131/132/133 are device-specific status values, meaning unknown.
-  # They did not change in response to any app setting (scheduled clean,
-  # sterilization and do-not-disturb are cloud timers, not local dps).
-  # Exposed hidden until their purpose is identified.
-  - entity: sensor
-    name: DP 131
-    category: diagnostic
-    icon: "mdi:help-circle"
-    hidden: true
-    dps:
-      - id: 131
-        type: integer
-        optional: true
-        name: sensor
-  - entity: binary_sensor
-    name: DP 132
-    category: diagnostic
-    icon: "mdi:help-circle"
-    hidden: true
-    dps:
-      - id: 132
-        type: boolean
-        optional: true
-        name: sensor
-  - entity: binary_sensor
-    name: DP 133
-    category: diagnostic
-    icon: "mdi:help-circle"
-    hidden: true
-    dps:
-      - id: 133
-        type: boolean
-        optional: true
-        name: sensor

--- a/custom_components/tuya_local/devices/smart_01b_litterbox.yaml
+++ b/custom_components/tuya_local/devices/smart_01b_litterbox.yaml
@@ -1,0 +1,247 @@
+name: Litter box
+products:
+  - id: qyvypzich5aywr9q
+    manufacturer: GoDrone
+    model: 01B
+entities:
+  - entity: sensor
+    class: weight
+    dps:
+      - id: 6
+        type: integer
+        optional: true
+        name: sensor
+        unit: g
+        class: measurement
+      - id: 129
+        type: integer
+        optional: true
+        name: lbs
+  - entity: sensor
+    name: Daily time spent
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 8
+        type: integer
+        optional: true
+        name: sensor
+        unit: s
+        class: measurement
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+      - id: 22
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: motor_fault
+          - dps_val: 2
+            value: program_fault
+          - dps_val: 4
+            value: g_sensor_fault
+      - id: 128
+        type: integer
+        name: number
+      - id: 130
+        type: boolean
+        name: deport_mode
+  - entity: button
+    name: Clean
+    category: config
+    dps:
+      - id: 101
+        type: boolean
+        name: button
+  - entity: button
+    name: Empty
+    category: config
+    dps:
+      - id: 102
+        type: boolean
+        name: button
+  - entity: event
+    name: Presence
+    dps:
+      - id: 104
+        type: boolean
+        name: event
+        optional: true
+        mapping:
+          - dps_val: true
+            value: enter
+          - dps_val: false
+            value: leave
+  - entity: switch
+    name: Induction cleaning
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Infrared detection
+    icon: "mdi:motion-sensor"
+    category: config
+    dps:
+      - id: 111
+        type: boolean
+        name: switch
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 114
+        type: boolean
+        name: lock
+  - entity: button
+    name: Calibrate scale
+    icon: "mdi:scale-balance"
+    category: config
+    dps:
+      - id: 115
+        type: boolean
+        optional: true
+        name: button
+  - entity: number
+    name: Induction clean delay
+    category: config
+    icon: "mdi:camera-timer"
+    dps:
+      - id: 117
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 60
+  - entity: number
+    name: Induction clean interval
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 118
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 120
+  - entity: button
+    name: Deodorize
+    icon: "mdi:spray"
+    category: config
+    dps:
+      - id: 120
+        type: boolean
+        name: button
+  - entity: switch
+    name: Smart cleaning
+    category: config
+    dps:
+      - id: 121
+        type: boolean
+        optional: true
+        name: switch
+  - entity: sensor
+    name: Usage
+    category: diagnostic
+    dps:
+      - id: 123
+        type: integer
+        optional: true
+        name: sensor
+        unit: times
+        class: measurement
+  - entity: number
+    name: Capacity calibration
+    category: config
+    icon: "mdi:resize"
+    dps:
+      - id: 124
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 15
+  - entity: number
+    name: Sand calibration
+    category: config
+    icon: "mdi:dots-hexagon"
+    dps:
+      - id: 125
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 6
+  - entity: switch
+    name: Auto deodorize
+    icon: "mdi:spray"
+    category: config
+    dps:
+      - id: 126
+        type: boolean
+        name: switch
+  - entity: number
+    name: Detection sensitivity
+    class: weight
+    category: config
+    dps:
+      - id: 127
+        type: integer
+        name: value
+        unit: g
+        range:
+          min: 600
+          max: 1500
+        mapping:
+          - step: 100
+  # 131/132/133 are device-specific status values, meaning unknown.
+  # They did not change in response to any app setting (scheduled clean,
+  # sterilization and do-not-disturb are cloud timers, not local dps).
+  # Exposed hidden until their purpose is identified.
+  - entity: sensor
+    name: DP 131
+    category: diagnostic
+    icon: "mdi:help-circle"
+    hidden: true
+    dps:
+      - id: 131
+        type: integer
+        optional: true
+        name: sensor
+  - entity: binary_sensor
+    name: DP 132
+    category: diagnostic
+    icon: "mdi:help-circle"
+    hidden: true
+    dps:
+      - id: 132
+        type: boolean
+        optional: true
+        name: sensor
+  - entity: binary_sensor
+    name: DP 133
+    category: diagnostic
+    icon: "mdi:help-circle"
+    hidden: true
+    dps:
+      - id: 133
+        type: boolean
+        optional: true
+        name: sensor


### PR DESCRIPTION
Adds support for the GoDrone 01B smart cat litter box (product id qyvypzich5aywr9q).

I captured the DPs locally from my own device over the LAN (protocol 3.5). It uses the same Tuya dp layout as the existing Sailesi litter box, so the mapping is based on that config: cat weight, time in box, fault reporting, clean/empty/deodorize/calibrate buttons, presence event, child lock, induction clean delay/interval, capacity and litter calibration, detection sensitivity, etc.

DP 131/132/133 are present on this device but not on the Sailesi one. They did not respond to any app setting (scheduled cleaning, sterilization and do-not-disturb turned out to be cloud timers, not local dps), so their purpose is unknown and they are exposed hidden for now.