### PR TITLE
feat(devices): add Petzengo PF28-C camera pet feeder

### DIFF
--- a/custom_components/tuya_local/devices/pf28c_camera_petfeeder.yaml
+++ b/custom_components/tuya_local/devices/pf28c_camera_petfeeder.yaml
@@ -1,0 +1,179 @@
+name: Pet feeder
+products:
+  - id: lnhpwq8ydzwbxc9s
+    manufacturer: Petzengo
+    model: PF28-C
+entities:
+  - entity: switch
+    translation_key: watermark
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        optional: true
+        name: switch
+  - entity: switch
+    name: Camera privacy
+    icon: "mdi:incognito"
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        optional: true
+        name: switch
+  - entity: select
+    translation_key: motion_sensitivity
+    category: config
+    dps:
+      - id: 106
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: low
+          - dps_val: "1"
+            value: medium
+          - dps_val: "2"
+            value: high
+  - entity: select
+    translation_key: night_vision
+    category: config
+    dps:
+      - id: 108
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: auto
+          - dps_val: "1"
+            value: "off"
+          - dps_val: "2"
+            value: "on"
+  - entity: switch
+    name: Motion detection
+    icon: "mdi:motion-sensor"
+    category: config
+    dps:
+      - id: 134
+        type: boolean
+        optional: true
+        name: switch
+        mapping:
+          - dps_val: null
+            value: false
+            hidden: true
+  - entity: event
+    class: motion
+    dps:
+      - id: 115
+        type: base64
+        name: event
+        optional: true
+        mapping:
+          - dps_val: null
+            value: null
+          - value: detected
+      - id: 115
+        type: base64
+        name: snapshot
+        optional: true
+  - entity: number
+    translation_key: manual_feed
+    category: config
+    dps:
+      - id: 203
+        type: integer
+        optional: true
+        name: value
+        unit: portions
+        range:
+          min: 1
+          max: 12
+  - entity: sensor
+    translation_key: status
+    class: enum
+    icon: "mdi:food-drumstick"
+    dps:
+      - id: 204
+        type: string
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: standby
+            value: standby
+          - dps_val: feeding
+            value: feeding
+          - dps_val: done
+            value: feeding_complete
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 210
+        type: integer
+        optional: true
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: event
+    name: Notification
+    dps:
+      - id: 212
+        type: utf16b64
+        name: event
+        optional: true
+        mapping:
+          - dps_val: null
+            value: null
+          - value: message
+      - id: 212
+        type: utf16b64
+        optional: true
+        name: message
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 219
+        type: bitfield
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 219
+        type: bitfield
+        optional: true
+        name: fault_code
+  - entity: text
+    translation_key: schedule
+    category: config
+    hidden: true
+    dps:
+      - id: 130
+        type: string
+        optional: true
+        name: value
+  - entity: sensor
+    name: Feed record
+    category: diagnostic
+    icon: "mdi:history"
+    dps:
+      - id: 131
+        type: string
+        optional: true
+        name: sensor
+  - entity: binary_sensor
+    name: Factory reset
+    category: diagnostic
+    dps:
+      - id: 236
+        type: boolean
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: null
+            value: false


### PR DESCRIPTION
Adds support for the Petzengo PF28-C, a Wi-Fi camera pet feeder (product id lnhpwq8ydzwbxc9s).

I captured the DPs locally from my own device over the LAN (protocol 3.4) and confirmed them by operating the feeder while monitoring DP changes:

- 104/105/106/108/134 – camera controls (watermark, privacy, motion sensitivity, night vision, motion detection)
- 203 – manual feed (portions, write-only)
- 204 – feed state (standby/feeding/done)
- 210 – battery
- 219 – fault/problem (bitfield)
- 130 – feeding schedule, 131 – feed record, 236 – factory reset

DPs 210 and 219 are mapped the same way as the existing Frienhund ACF180W-A config, which uses the same Tuya template.