### PR TITLE
Use dynamic current limit for Feyree  Lion EV-Ultra charger

### DIFF
--- a/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
+++ b/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
@@ -23,25 +23,36 @@ entities:
     class: current
     category: config
     dps:
-      - id: 114
+      - id: 115
         name: value
         type: integer
         optional: true
+        unit: A
         range:
           min: 8
           max: 32
+        mapping:
+          - constraint: max_current
+            conditions:
+              - dps_val: "Max16A"
+                value_redirect: value_16a
+                range:
+                  min: 8
+                  max: 16
+
+      - id: 114
+        name: value_16a
+        type: integer
+        optional: true
         unit: A
+        range:
+          min: 8
+          max: 16
+
       - id: 113
-        name: maximum
+        name: max_current
         type: string
         optional: true
-        readonly: true
-        mapping:
-          - dps_val: "Max16A"
-            value: 16
-          - dps_val: "Max32A"
-            value: 32
-
   - entity: number
     name: Delayed start
     icon: "mdi:timer-sand"

--- a/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
+++ b/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
@@ -29,8 +29,18 @@ entities:
         optional: true
         range:
           min: 8
-          max: 16
+          max: 32
         unit: A
+      - id: 113
+        name: maximum
+        type: string
+        optional: true
+        readonly: true
+        mapping:
+          - dps_val: "Max16A"
+            value: 16
+          - dps_val: "Max32A"
+            value: 32
 
   - entity: number
     name: Delayed start

--- a/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
+++ b/custom_components/tuya_local/devices/feyree_lion_evcharger.yaml
@@ -23,31 +23,31 @@ entities:
     class: current
     category: config
     dps:
-      - id: 115
+      - id: 114
         name: value
         type: integer
         optional: true
         unit: A
         range:
           min: 8
-          max: 32
+          max: 16
         mapping:
           - constraint: max_current
             conditions:
-              - dps_val: "Max16A"
-                value_redirect: value_16a
+              - dps_val: "Max32A"
+                value_redirect: value_32a
                 range:
                   min: 8
-                  max: 16
+                  max: 32
 
-      - id: 114
-        name: value_16a
+      - id: 115
+        name: value_32a
         type: integer
         optional: true
         unit: A
         range:
           min: 8
-          max: 16
+          max: 32
 
       - id: 113
         name: max_current


### PR DESCRIPTION
## Summary

This updates the Feyree Lion EV-Ultra charger profile so the current limit uses the correct datapoint depending on the charger hardware limit reported by the device.

Additional testing showed that the 16A and 32A variants do not use the same current-setting datapoint:

* 16A charger: `DeviceMaxSetA = Max16A`, current setting uses `Set16A` / DP 114.
* 32A charger: `DeviceMaxSetA = Max32A`, current setting uses `Set32A` / DP 115.

Following maintainer feedback, DP 114 / `Set16A` is kept as the default lower-current datapoint, and DP 115 / `Set32A` is used via `value_redirect` when the charger reports `Max32A`.

## Implementation

* DP 113 is used as the charger-reported maximum current capability.
* DP 114 / `Set16A` is the default current-setting datapoint.
* DP 115 / `Set32A` is used through `value_redirect` when DP 113 reports `Max32A`.
* DP 116 / `Set40A` and DP 117 / `Set50A` are intentionally not used, as the Feyree Lion EV-Ultra manual only documents 16A and 32A variants for this model.

Expected result:

* 16A units: current slider remains limited to 16 A and writes to DP 114 / `Set16A`.
* 32A units: current slider allows up to 32 A and writes to DP 115 / `Set32A`.

## Testing

Tested locally with two real Feyree Lion EV-Ultra chargers using the same `feyree_lion_evcharger` profile:

* 16A single-phase unit:

  * Reports `DeviceMaxSetA = Max16A`.
  * Current entity writes to DP 114 / `Set16A`.
  * Current slider remains limited to 16 A.

* 32A single-phase unit:

  * Reports `DeviceMaxSetA = Max32A`.
  * Current entity writes to DP 115 / `Set32A`.
  * Current slider allows up to 32 A.

Home Assistant was restarted after modifying the profile, and both devices showed the expected behaviour.
