### PR TITLE
Add Poolsana InverPRESTIGE PRO pool heat pump

### DIFF
--- a/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
@@ -298,4 +298,3 @@ entities:
         optional: true
         unit: rpm
         class: measurement
-

--- a/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
@@ -125,10 +125,11 @@ entities:
         type: bitfield
         name: sensor
 
-  # DP15 is a legacy duplicate of the water inlet temperature (same physical sensor as DP3
-  # and DP101). On most other Tuya pool heat pumps DP15 is the fault bitmap, but on this
-  # firmware the fault moved to DP21 and DP15 was repurposed. Kept here for documentation;
-  # use DP101 (Water inlet temperature) as the authoritative sensor.
+  # DP15 is a legacy duplicate of the water inlet temperature (same
+  # physical sensor as DP3 and DP101). On most other Tuya pool heat
+  # pumps DP15 is the fault bitmap, but on this firmware fault moved
+  # to DP21 and DP15 was repurposed. Use DP101 as the authoritative
+  # inlet sensor.
   - entity: sensor
     name: Pool temperature (legacy)
     class: temperature
@@ -168,7 +169,7 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Ambient temperature
+    translation_key: ambient_temperature
     class: temperature
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
@@ -119,7 +119,7 @@ entities:
   # to DP21 and DP15 was repurposed. Use DP101 as the authoritative
   # inlet sensor.
   - entity: sensor
-    name: Pool temperature (legacy)
+    name: Pool temperature
     class: temperature
     category: diagnostic
     hidden: true

--- a/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
@@ -290,7 +290,7 @@ entities:
   - entity: sensor
     name: DC fan speed
     category: diagnostic
-    icon: mdi:fan
+    icon: "mdi:fan"
     dps:
       - id: 114
         type: integer

--- a/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
@@ -1,0 +1,320 @@
+name: Poolsana InverPRESTIGE PRO pool heat pump
+
+products:
+  - id: qmht2j30hapasy87
+    manufacturer: Tuya
+    model: Swimming Pool Heat Pump
+
+entities:
+  - entity: climate
+    translation_key: pool_heatpump
+    icon: mdi:heat-pump
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: preset_mode
+            conditions:
+              - dps_val: heat
+                value: heat
+              - dps_val: h_powerful
+                value: heat
+              - dps_val: h_silent
+                value: heat
+              - dps_val: cool
+                value: cool
+              - dps_val: c_powerful
+                value: cool
+              - dps_val: c_silent
+                value: cool
+              - dps_val: auto
+                value: auto
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 5
+          max: 40
+      - id: 3
+        type: integer
+        name: current_temperature
+        unit: C
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: heat
+            value: Smart heating
+          - dps_val: h_powerful
+            value: Powerful heating
+          - dps_val: h_silent
+            value: Silent heating
+          - dps_val: cool
+            value: Smart cooling
+          - dps_val: c_powerful
+            value: Powerful cooling
+          - dps_val: c_silent
+            value: Silent cooling
+          - dps_val: auto
+            value: Auto
+      - id: 13
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+          - value: C
+
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+      - id: 21
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: OK
+          - dps_val: 1
+            value: compressor_overcurrent
+          - dps_val: 2
+            value: compressor_out_of_sync
+          - dps_val: 8
+            value: compressor_phase_loss
+          - dps_val: 16
+            value: dc_voltage_low
+          - dps_val: 32
+            value: dc_voltage_high
+          - dps_val: 257
+            value: communication_error
+          - dps_val: 258
+            value: ac_phase_loss
+          - dps_val: 260
+            value: ac_overcurrent
+          - dps_val: 288
+            value: ipm_overheat
+          - dps_val: 320
+            value: compressor_current_protection
+          - dps_val: 384
+            value: pfc_overheat
+
+  - entity: sensor
+    name: Fault code
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+
+  # DP15 is a legacy duplicate of the water inlet temperature (same physical sensor as DP3
+  # and DP101). On most other Tuya pool heat pumps DP15 is the fault bitmap, but on this
+  # firmware the fault moved to DP21 and DP15 was repurposed. Kept here for documentation;
+  # use DP101 (Water inlet temperature) as the authoritative sensor.
+  - entity: sensor
+    name: Pool temperature (legacy)
+    class: temperature
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 15
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  # Query list mapping from the Smart Life app screenshots:
+  - entity: sensor
+    name: Water inlet temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Water outlet temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Ambient temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Exhaust temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Suction temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Heating coil temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Cooling coil temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Steps of main EEV
+    category: diagnostic
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        optional: true
+        unit: step
+        class: measurement
+
+  - entity: sensor
+    name: Not available steps
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        optional: true
+        unit: step
+        class: measurement
+
+  - entity: sensor
+    name: Compressor current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 110
+        type: integer
+        name: sensor
+        optional: true
+        unit: A
+        class: measurement
+
+  - entity: sensor
+    name: Heat sink temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 111
+        type: integer
+        name: sensor
+        optional: true
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: DC bus voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+        optional: true
+        unit: V
+        class: measurement
+
+  - entity: sensor
+    name: Compressor frequency
+    class: frequency
+    category: diagnostic
+    dps:
+      - id: 113
+        type: integer
+        name: sensor
+        optional: true
+        unit: Hz
+        class: measurement
+
+  - entity: sensor
+    name: DC fan speed
+    category: diagnostic
+    icon: mdi:fan
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        optional: true
+        unit: rpm
+        class: measurement
+
+  - entity: sensor
+    name: PCB version
+    category: diagnostic
+    dps:
+      - id: 115
+        type: integer
+        name: sensor
+        optional: true

--- a/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
+++ b/custom_components/tuya_local/devices/poolsana_inverprestige_pro_heatpump.yaml
@@ -1,14 +1,13 @@
-name: Poolsana InverPRESTIGE PRO pool heat pump
+name: Pool heat pump
 
 products:
   - id: qmht2j30hapasy87
-    manufacturer: Tuya
-    model: Swimming Pool Heat Pump
+    manufacturer: Poolsana
+    model: InverPrestige Pro
 
 entities:
   - entity: climate
     translation_key: pool_heatpump
-    icon: mdi:heat-pump
     dps:
       - id: 1
         type: boolean
@@ -23,14 +22,18 @@ entities:
                 value: heat
               - dps_val: h_powerful
                 value: heat
+                hidden: true
               - dps_val: h_silent
                 value: heat
+                hidden: true
               - dps_val: cool
                 value: cool
               - dps_val: c_powerful
                 value: cool
+                hidden: true
               - dps_val: c_silent
                 value: cool
+                hidden: true
               - dps_val: auto
                 value: auto
       - id: 2
@@ -49,31 +52,21 @@ entities:
         name: preset_mode
         mapping:
           - dps_val: heat
-            value: Smart heating
+            value: smart_heat
           - dps_val: h_powerful
-            value: Powerful heating
+            value: quick_heat
           - dps_val: h_silent
-            value: Silent heating
+            value: quiet_heat
           - dps_val: cool
-            value: Smart cooling
+            value: smart_cool
           - dps_val: c_powerful
-            value: Powerful cooling
+            value: quick_cool
           - dps_val: c_silent
-            value: Silent cooling
+            value: quiet_cool
           - dps_val: auto
-            value: Auto
-      - id: 13
-        type: string
-        name: temperature_unit
-        mapping:
-          - dps_val: c
-            value: C
-          - dps_val: f
-            value: F
-          - value: C
+            value: auto
 
   - entity: binary_sensor
-    name: Fault
     class: problem
     category: diagnostic
     dps:
@@ -115,15 +108,10 @@ entities:
             value: compressor_current_protection
           - dps_val: 384
             value: pfc_overheat
-
-  - entity: sensor
-    name: Fault code
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 21
-        type: bitfield
-        name: sensor
+      - id: 115
+        type: integer
+        name: pcb_version
+        optional: true
 
   # DP15 is a legacy duplicate of the water inlet temperature (same
   # physical sensor as DP3 and DP101). On most other Tuya pool heat
@@ -311,11 +299,3 @@ entities:
         unit: rpm
         class: measurement
 
-  - entity: sensor
-    name: PCB version
-    category: diagnostic
-    dps:
-      - id: 115
-        type: integer
-        name: sensor
-        optional: true


### PR DESCRIPTION
## Device

**Poolsana InverPRESTIGE PRO** inverter pool heat pump, purchased 2025/2026.
- Tuya protocol 3.5
- Product ID: `qmht2j30hapasy87`
- [Product page](https://www.poolsana.de/pool-waermepumpe-poolsana-inverprestige-pro-full-inverter)

## Relationship to existing `poolsana_heatpump.yaml`

The existing file covers the **InverPower Next**. The InverPRESTIGE PRO uses a different DP layout — likely a newer firmware revision — and needs a separate profile:

| DP | InverPower Next | InverPRESTIGE PRO |
|----|----------------|-------------------|
| 15 | Fault bitmap | Legacy water inlet temp (duplicate of DP3/DP101) |
| 21 | — | Fault bitmap |
| 101–115 | — | Full diagnostic sensor set |

The `products` block with the specific product ID ensures auto-matching only applies to this exact hardware revision, not to older InverPRESTIGE PRO units that may have a different DP layout.

## Entities

- **Climate**: heat/cool/auto modes; preset_mode for Smart/Powerful/Silent variants (DPs 1+4)
- **Binary sensor**: Fault (DP21 bitfield) with description mapping for all known fault codes
- **Sensors (diagnostic)**: water inlet/outlet, ambient, exhaust, suction, heating/cooling coil temperatures, EEV steps, compressor current, heat sink temp, DC bus voltage, compressor frequency, DC fan speed, PCB version (DPs 101–115)
- **Sensor (hidden/optional)**: DP15 — confirmed via live monitoring to be a legacy duplicate of the water inlet temperature; documented but not surfaced by default

## Testing

Tested on a live device running HA 2026.6.x with tuya_local 2026.6.2. All climate controls, preset modes, and diagnostic sensors verified working.