### PR TITLE
Add ACIQ EX-150 pool heat pump

### DIFF
--- a/custom_components/tuya_local/devices/aciq_ex150_pool_heatpump.yaml
+++ b/custom_components/tuya_local/devices/aciq_ex150_pool_heatpump.yaml
@@ -1,0 +1,140 @@
+name: Pool heat pump
+products:
+  - id: yrjx6kq77vapja8a
+    manufacturer: ACIQ
+    model: EX-150
+entities:
+  - entity: climate
+    translation_key: pool_heatpump
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: work_mode
+            conditions:
+              - dps_val: smart
+                value: auto
+              - dps_val: warm
+                value: heat
+              - dps_val: cool
+                value: cool
+      - id: 2
+        type: integer
+        name: cooling_setpoint
+        unit: F
+        hidden: true
+        range:
+          min: 45
+          max: 95
+      - id: 3
+        type: integer
+        name: current_temperature
+        unit: F
+      - id: 4
+        type: string
+        name: work_mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: silence
+            value: low
+          - dps_val: smart
+            value: auto
+          - dps_val: booster
+            value: high
+      - id: 13
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 14
+        type: integer
+        name: temperature
+        unit: F
+        range:
+          min: 59
+          max: 104
+        mapping:
+          - constraint: work_mode
+            conditions:
+              - dps_val: cool
+                value_redirect: cooling_setpoint
+                range:
+                  min: 45
+                  max: 95
+      - id: 108
+        type: integer
+        name: min_temperature
+        unit: F
+        readonly: true
+      - id: 109
+        type: integer
+        name: max_temperature
+        unit: F
+        readonly: true
+
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 13
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+
+  - entity: sensor
+    name: Display water temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 15
+        type: integer
+        name: sensor
+        unit: F
+        class: measurement
+
+  - entity: sensor
+    name: Compressor load
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: integer
+        name: fault_code
+
+  - entity: sensor
+    name: Status flag
+    category: diagnostic
+    dps:
+      - id: 111
+        type: integer
+        name: sensor


### PR DESCRIPTION
## Summary
- Add a device profile for the ACIQ EX-150 pool heat pump
- Map heat/cool/auto HVAC modes, fan modes, Fahrenheit temperature setpoints, current temperature, and diagnostic sensors

## Validation
- .venv/bin/python -m pytest tests/test_device_config.py
- .venv/bin/yamllint custom_components/tuya_local/devices/aciq_ex150_pool_heatpump.yaml
- .venv/bin/ruff check .
- .venv/bin/ruff check --select I .
- .venv/bin/ruff format --check .
- .venv/bin/yamllint custom_components/tuya_local/devices