### PR TITLE
Add ezAIoT Lite Socket Thermostat (product id: lzfux5zela3cbpnd)

### DIFF
--- a/custom_components/tuya_local/devices/ezaiot_lite_socket_thermostat.yaml
+++ b/custom_components/tuya_local/devices/ezaiot_lite_socket_thermostat.yaml
@@ -1,0 +1,338 @@
+name: Socket thermostat
+products:
+  - id: lzfux5zela3cbpnd
+    manufacturer: ezAIoT
+    model: Lite
+entities:
+  - entity: climate
+    translation_key: thermostat
+    dps:
+      - id: 110
+        type: string
+        name: hvac_mode
+        mapping:
+          - dps_val: "plug"
+            value: "off"
+          - dps_val: "heat"
+            value: "heat"
+          - dps_val: "cool"
+            value: "cool"
+          - dps_val: "prg"
+            value: "auto"
+          - dps_val: "cycle"
+            value: "fan_only"
+      - id: 126
+        type: integer
+        name: current_temperature
+        mapping:
+          - scale: 10
+      - id: 135
+        type: integer
+        name: temperature
+        unit: C
+        mapping:
+          - scale: 10
+        range:
+          min: -500
+          max: 3000
+      - id: 127
+        type: integer
+        name: max_temperature
+        optional: true
+        mapping:
+          - scale: 10
+      - id: 130
+        type: integer
+        name: min_temperature
+        optional: true
+        mapping:
+          - scale: 10
+      - id: 114
+        type: integer
+        name: hvac_action
+        mapping:
+          - dps_val: 0
+            value: idle
+          - dps_val: 1
+            constraint: hvac_mode
+            conditions:
+              - dps_val: heat
+                value: heating
+              - dps_val: cool
+                value: cooling
+              - dps_val: auto
+                value: heating
+              - dps_val: fan_only
+                value: heating
+              - dps_val: "off"
+                value: idle
+
+  # Direct relay switch (used in plug mode)
+  - entity: switch
+    translation_key: manual_socket
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+
+  # Countdown timer as dropdown (minutes)
+  - entity: select
+    translation_key: manual_socket_countdown
+    icon: "mdi:timer"
+    dps:
+      - id: 9
+        type: integer
+        name: option
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: "0"
+          - dps_val: 60
+            value: "1"
+          - dps_val: 120
+            value: "2"
+          - dps_val: 180
+            value: "3"
+          - dps_val: 240
+            value: "4"
+          - dps_val: 300
+            value: "5"
+          - dps_val: 600
+            value: "10"
+          - dps_val: 900
+            value: "15"
+          - dps_val: 1800
+            value: "30"
+          - dps_val: 2700
+            value: "45"
+          - dps_val: 3600
+            value: "60"
+
+  # Display on button
+  - entity: button
+    translation_key: display_on
+    dps:
+      - id: 118
+        name: button
+        optional: true
+        type: boolean
+
+  # Operating mode select
+  - entity: select
+    translation_key: work_mode
+    dps:
+      - id: 110
+        type: string
+        name: option
+        mapping:
+          - dps_val: "plug"
+            value: "plug"
+          - dps_val: "heat"
+            value: "heat"
+          - dps_val: "cool"
+            value: "cool"
+          - dps_val: "prg"
+            value: "prg"
+          - dps_val: "cycle"
+            value: "cycle"
+
+  # Diagnostics: relay state
+  - entity: binary_sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 1
+            value: true
+
+  # Diagnostics: fault
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 26
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+
+  # Child lock
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 40
+        name: lock
+        type: boolean
+
+  # Frost protection
+  - entity: switch
+    category: config
+    translation_key: protection_frost
+    dps:
+      - id: 113
+        name: switch
+        type: boolean
+
+  # Cooling delay enable
+  - entity: switch
+    category: config
+    translation_key: protection_cooling_delay
+    icon: "mdi:pump"
+    dps:
+      - id: 133
+        name: switch
+        optional: true
+        type: boolean
+
+  # Cooling delay time
+  - entity: number
+    translation_key: protection_cooling_delay_time
+    category: config
+    icon: "mdi:pump"
+    dps:
+      - id: 134
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        range:
+          min: 0
+          max: 10
+
+  # Upper temperature alarm enable + threshold
+  - entity: switch
+    category: config
+    translation_key: high_temp_alarm_limit
+    icon: "mdi:thermometer-chevron-up"
+    dps:
+      - id: 128
+        name: switch
+        optional: true
+        type: boolean
+
+  - entity: number
+    translation_key: high_temp_alarm
+    category: config
+    icon: "mdi:thermometer-alert"
+    dps:
+      - id: 129
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - scale: 10
+        range:
+          min: -500
+          max: 3000
+
+  # Lower temperature alarm enable + threshold
+  - entity: switch
+    category: config
+    translation_key: low_temp_alarm_limit
+    icon: "mdi:thermometer-chevron-down"
+    dps:
+      - id: 131
+        name: switch
+        optional: true
+        type: boolean
+
+  - entity: number
+    translation_key: low_temp_alarm
+    category: config
+    icon: "mdi:thermometer-alert"
+    dps:
+      - id: 132
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        mapping:
+          - scale: 10
+        range:
+          min: -500
+          max: 3000
+
+  # Temperature hysteresis
+  - entity: number
+    translation_key: temp_differential
+    class: temperature_delta
+    category: config
+    icon: "mdi:thermometer"
+    mode: "box"
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        optional: true
+        mapping:
+          - scale: 10
+        unit: C
+        range:
+          min: 1
+          max: 300
+
+  # Temperature calibration
+  - entity: number
+    translation_key: temperature_calibration
+    class: temperature_delta
+    category: config
+    dps:
+      - id: 136
+        type: integer
+        name: value
+        optional: true
+        mapping:
+          - scale: 10
+        unit: C
+        range:
+          min: -150
+          max: 150
+
+  # Display brightness
+  - entity: select
+    translation_key: display_brightness
+    icon: "mdi:brightness-6"
+    category: config
+    dps:
+      - id: 115
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "Low"
+            value: "low"
+          - dps_val: "Middle"
+            value: "medium"
+          - dps_val: "High"
+            value: "high"
+
+  # Display timeout
+  - entity: select
+    translation_key: display_timeout
+    icon: "mdi:timer-cog-outline"
+    category: config
+    dps:
+      - id: 117
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "15s"
+            value: "15s"
+          - dps_val: "30s"
+            value: "30s"
+          - dps_val: "60s"
+            value: "60s"
+          - dps_val: "120s"
+            value: "120s"
+          - dps_val: "never"
+            value: "never"

--- a/custom_components/tuya_local/devices/ezaiot_thermostat_smartplug.yaml
+++ b/custom_components/tuya_local/devices/ezaiot_thermostat_smartplug.yaml
@@ -67,7 +67,7 @@ entities:
         type: boolean
   # Turn on the display on press for timeout time
   - entity: button
-    name: Display on
+    translation_key: display_on
     dps:
       - id: 118
         name: button
@@ -100,7 +100,7 @@ entities:
 
   # Display Timeout
   - entity: select
-    name: Display timeout
+    translation_key: display_timeout
     icon: "mdi:timer-cog-outline"
     category: config
     dps:

--- a/custom_components/tuya_local/translations/bg.json
+++ b/custom_components/tuya_local/translations/bg.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Радио стоп"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Продължителност на отлагане"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -688,7 +703,6 @@
                     "spanish": "Español",
                     "thai": "ภาษาไทย",
                     "turkish": "Türkçe",
-                    "polish": "Polski",
                     "vietnamese": "Tiếng Việt"
                 }
             },
@@ -1089,7 +1103,10 @@
                     "night": "Нощ",
                     "dim": "Приглушено",
                     "bright": "Ярко",
-                    "auto": "Автоматично"
+                    "auto": "Автоматично",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1144,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 часа",
                     "24_hour": "24 часа"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1460,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Воден знак"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/ca.json
+++ b/custom_components/tuya_local/translations/ca.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Aturar ràdio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Durada de l'ajornament"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Nit",
                     "dim": "Atenuat",
                     "bright": "Brillant",
-                    "auto": "Automàtic"
+                    "auto": "Automàtic",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 hores",
                     "24_hour": "24 hores"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Marca de agua"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/cz.json
+++ b/custom_components/tuya_local/translations/cz.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Rádio zastavení"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Doba odložení"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Noc",
                     "dim": "Tlumené",
                     "bright": "Jasné",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 hodin",
                     "24_hour": "24 hodin"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Vodotisk"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/de.json
+++ b/custom_components/tuya_local/translations/de.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Radio stopp"
+            },
+            "display_on": {
+                "name": "Display an"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Schlummerdauer"
+            },
+            "high_temp_alarm": {
+                "name": "Hoher Temperaturalarm"
+            },
+            "low_temp_alarm": {
+                "name": "Niedriger Temperaturalarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Schutzoption - Kühlverzögerung Zeit"
+            },
+            "temp_differential": {
+                "name": "Temperatur - Differenz"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Nacht",
                     "dim": "Gedimmt",
                     "bright": "Hell",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Niedrig",
+                    "medium": "Mittel",
+                    "high": "Hoch"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 Stunden",
                     "24_hour": "24 Stunden"
+                }
+            },
+            "display_timeout": {
+                "name": "Bildschirm - Timeout",
+                "state": {
+                    "15s": "15 Sek",
+                    "30s": "30 Sek",
+                    "60s": "60 Sek",
+                    "120s": "120 Sek",
+                    "never": "Nie"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Steckdose manuell - Countdown",
+                "state": {
+                    "0": "Aus",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Betriebsmodus",
+                "state": {
+                    "plug": "Steckdose",
+                    "heat": "Heizen",
+                    "cool": "Kühlen",
+                    "prg": "Wochenprogramm",
+                    "cycle": "Zyklustimer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Wasserzeichen"
+            },
+            "high_temp_alarm_limit": {
+                "name": "Hoher Temperaturalarm Limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Niedriger Temperaturalarm Limit"
+            },
+            "manual_socket": {
+                "name": "Steckdose manuell"
+            },
+            "protection_cooling_delay": {
+                "name": "Schutzoption - Kühlverzögerung"
+            },
+            "protection_frost": {
+                "name": "Schutzoption - Frostschutz"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/el.json
+++ b/custom_components/tuya_local/translations/el.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Ραδιόφωνο διακοπή"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Διάρκεια αναβολής"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Νύχτα",
                     "dim": "Χαμηλό",
                     "bright": "Φωτεινό",
-                    "auto": "Αυτόματο"
+                    "auto": "Αυτόματο",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 ωρών",
                     "24_hour": "24 ωρών"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Υδατογράφημα"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/en.json
+++ b/custom_components/tuya_local/translations/en.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Radio stop"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Snooze duration"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Night",
                     "dim": "Dim",
                     "bright": "Bright",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 hour",
                     "24_hour": "24 hour"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Watermark"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/es.json
+++ b/custom_components/tuya_local/translations/es.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Detener radio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Duración de repetición"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Noche",
                     "dim": "Tenue",
                     "bright": "Brillante",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 horas",
                     "24_hour": "24 horas"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Marca de agua"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/fr.json
+++ b/custom_components/tuya_local/translations/fr.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Arrêt radio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Durée de répétition"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Nuit",
                     "dim": "Faible",
                     "bright": "Lumineuse",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12h",
                     "24_hour": "24h"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Filigrane"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/hu.json
+++ b/custom_components/tuya_local/translations/hu.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Rádió leállítás"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Szundi időtartam"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Éjszakai",
                     "dim": "Halvány",
                     "bright": "Fényes",
-                    "auto": "Automatikus"
+                    "auto": "Automatikus",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 órás",
                     "24_hour": "24 órás"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Vízjel"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/id.json
+++ b/custom_components/tuya_local/translations/id.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Radio berhenti"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Durasi tunda"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Malam",
                     "dim": "Redup",
                     "bright": "Terang",
-                    "auto": "Otomatis"
+                    "auto": "Otomatis",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 jam",
                     "24_hour": "24 jam"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Tanda air"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/it.json
+++ b/custom_components/tuya_local/translations/it.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Arresta radio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Durata posticipo"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Notte",
                     "dim": "Tenue",
                     "bright": "Luminoso",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 ore",
                     "24_hour": "24 ore"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Filigrana"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/ja.json
+++ b/custom_components/tuya_local/translations/ja.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "ラジオ停止"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "スヌーズ時間"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "夜間",
                     "dim": "暗い",
                     "bright": "明るい",
-                    "auto": "自動"
+                    "auto": "自動",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12時間",
                     "24_hour": "24時間"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "ウォーターマーク"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/no-NB.json
+++ b/custom_components/tuya_local/translations/no-NB.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Radiostopp"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Slumringsvarighet"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Natt",
                     "dim": "Dempet",
                     "bright": "Lyst",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 timer",
                     "24_hour": "24 timer"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Vannmerke"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/pl.json
+++ b/custom_components/tuya_local/translations/pl.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Odłącz radio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Czas drzemki"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Noc",
                     "dim": "Przyciemniony",
                     "bright": "Jasny",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12-godzinny",
                     "24_hour": "24-godzinny"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Znak wodny"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/pt-BR.json
+++ b/custom_components/tuya_local/translations/pt-BR.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Parar rádio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Duração da soneca"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Noite",
                     "dim": "Fraco",
                     "bright": "Forte",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 horas",
                     "24_hour": "24 horas"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Marca d'água"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/pt-PT.json
+++ b/custom_components/tuya_local/translations/pt-PT.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Parar rádio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Duração da soneca"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Noite",
                     "dim": "Fraco",
                     "bright": "Forte",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 horas",
                     "24_hour": "24 horas"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Marca d'água"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/ro.json
+++ b/custom_components/tuya_local/translations/ro.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Oprire radio"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Durată amânare"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Noapte",
                     "dim": "Slab",
                     "bright": "Puternic",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1144,7 +1162,43 @@
                     "12_hour": "12 ore",
                     "24_hour": "24 ore"
                 }
-            }            
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
+                }
+            }
         },
         "sensor": {
             "ambient_temperature": {
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Filigran"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {
@@ -1539,4 +1608,3 @@
         }
     }
 }
-

--- a/custom_components/tuya_local/translations/ru.json
+++ b/custom_components/tuya_local/translations/ru.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Остановить радио"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Длительность отсрочки"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Ночь",
                     "dim": "Тусклый",
                     "bright": "Яркий",
-                    "auto": "Авто"
+                    "auto": "Авто",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12-часовой",
                     "24_hour": "24-часовой"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Водяной знак"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/sv.json
+++ b/custom_components/tuya_local/translations/sv.json
@@ -121,7 +121,7 @@
                 },
                 "device": {
                     "name": "Enhet",
-                    "description": "Den IR-enhet som kommandot ska skickas till. Detta är valfritt och endast nödvändigt om kommandot sparades med en enhet." 
+                    "description": "Den IR-enhet som kommandot ska skickas till. Detta är valfritt och endast nödvändigt om kommandot sparades med en enhet."
                 }
             }
         }
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Radiostopp"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Slummerlängd"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Natt",
                     "dim": "Dämpad",
                     "bright": "Ljus",
-                    "auto": "Auto"
+                    "auto": "Auto",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 timmar",
                     "24_hour": "24 timmar"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Vattenstämpel"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/uk.json
+++ b/custom_components/tuya_local/translations/uk.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "Радіо зупинка"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "Тривалість відкладення"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "Ніч",
                     "dim": "Тьмяний",
                     "bright": "Яскравий",
-                    "auto": "Авто"
+                    "auto": "Авто",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 годин",
                     "24_hour": "24 години"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "Водяной знак"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/ur.json
+++ b/custom_components/tuya_local/translations/ur.json
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "ریڈیو بند"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "سنوز دورانیہ"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "رات",
                     "dim": "مدھم",
                     "bright": "روشن",
-                    "auto": "خود کار"
+                    "auto": "خود کار",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12 گھنٹے",
                     "24_hour": "24 گھنٹے"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "واٹر مارک"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/zh-Hans.json
+++ b/custom_components/tuya_local/translations/zh-Hans.json
@@ -117,7 +117,7 @@
                 },
                 "command": {
                     "name": "命令",
-                    "description": "要发送的命令。必须是之前由此集成为此遥控器学习的命令。" 
+                    "description": "要发送的命令。必须是之前由此集成为此遥控器学习的命令。"
                 },
                 "device": {
                     "name": "设备",
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "电台停止"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "贪睡时长"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "夜间",
                     "dim": "暗",
                     "bright": "亮",
-                    "auto": "自动"
+                    "auto": "自动",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12小时",
                     "24_hour": "24小时"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "水印"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {

--- a/custom_components/tuya_local/translations/zh-Hant.json
+++ b/custom_components/tuya_local/translations/zh-Hant.json
@@ -121,7 +121,7 @@
                 },
                 "device": {
                     "name": "設備",
-                    "description": "要發送命令的紅外線設備。這是可選的，僅在命令保存時帶有設備时需要。" 
+                    "description": "要發送命令的紅外線設備。這是可選的，僅在命令保存時帶有設備时需要。"
                 }
             }
         }
@@ -236,6 +236,9 @@
             },
             "radio_stop": {
                 "name": "電台停止"
+            },
+            "display_on": {
+                "name": "Display on"
             }
         },
         "climate": {
@@ -606,6 +609,18 @@
             },
             "snooze_duration": {
                 "name": "貪睡時長"
+            },
+            "high_temp_alarm": {
+                "name": "High temperature alarm"
+            },
+            "low_temp_alarm": {
+                "name": "Low temperature alarm"
+            },
+            "protection_cooling_delay_time": {
+                "name": "Protection - Cooling delay time"
+            },
+            "temp_differential": {
+                "name": "Temperature - Differential"
             }
         },
         "select": {
@@ -1088,7 +1103,10 @@
                     "night": "夜間",
                     "dim": "暗",
                     "bright": "亮",
-                    "auto": "自動"
+                    "auto": "自動",
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
                 }
             },
             "seconds_dot": {
@@ -1143,6 +1161,42 @@
                 "state": {
                     "12_hour": "12小時",
                     "24_hour": "24小時"
+                }
+            },
+            "display_timeout": {
+                "name": "Display - Timeout",
+                "state": {
+                    "15s": "15s",
+                    "30s": "30s",
+                    "60s": "60s",
+                    "120s": "120s",
+                    "never": "Never"
+                }
+            },
+            "manual_socket_countdown": {
+                "name": "Manual socket - Countdown",
+                "state": {
+                    "0": "Off",
+                    "1": "1 min",
+                    "2": "2 min",
+                    "3": "3 min",
+                    "4": "4 min",
+                    "5": "5 min",
+                    "10": "10 min",
+                    "15": "15 min",
+                    "30": "30 min",
+                    "45": "45 min",
+                    "60": "60 min"
+                }
+            },
+            "work_mode": {
+                "name": "Operating mode",
+                "state": {
+                    "plug": "Socket",
+                    "heat": "Heating",
+                    "cool": "Cooling",
+                    "prg": "Weekly program",
+                    "cycle": "Cycle timer"
                 }
             }
         },
@@ -1459,6 +1513,21 @@
             },
             "watermark": {
                 "name": "水印"
+            },
+            "high_temp_alarm_limit": {
+                "name": "High temperature alarm limit"
+            },
+            "low_temp_alarm_limit": {
+                "name": "Low temperature alarm limit"
+            },
+            "manual_socket": {
+                "name": "Manual socket"
+            },
+            "protection_cooling_delay": {
+                "name": "Protection - Cooling delay"
+            },
+            "protection_frost": {
+                "name": "Protection - Frost protection"
             }
         },
         "text": {


### PR DESCRIPTION
New device config for the ezAIoT Socket Thermostat Lite (product id: lzfux5zela3cbpnd).

Maps DPs for climate control (heat/cool/auto/cycle timer/off via plug mode), relay switch, countdown timer dropdown, display brightness/timeout, high/low temperature alarms, cooling compressor delay, frost protection, temperature hysteresis, and calibration.

Adds translations to all 23 language files; German fully translated, all others use English fallback.