### PR TITLE
Add bp20v4_smartplug configuration

### DIFF
--- a/custom_components/tuya_local/devices/bp20v4_smartplug.yaml
+++ b/custom_components/tuya_local/devices/bp20v4_smartplug.yaml
@@ -1,0 +1,168 @@
+name: BP20 V4 Smart Plug
+entities:
+  - entity: switch
+    class: outlet
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 21
+        type: integer
+        optional: true
+        name: test_bit
+      - id: 44
+        type: string
+        name: inching
+        optional: true
+  - entity: time
+    category: config
+    translation_key: timer
+    dps:
+      - id: 9
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+      - id: 42
+        type: string
+        name: cycle_timer
+        optional: true
+      - id: 43
+        type: string
+        name: random_timer
+        optional: true
+  - entity: sensor
+    category: diagnostic
+    class: current
+    dps:
+      - id: 18
+        name: sensor
+        type: integer
+        class: measurement
+        unit: mA
+      - id: 23
+        type: integer
+        name: calibration
+        optional: true
+  - entity: sensor
+    category: diagnostic
+    class: power
+    dps:
+      - id: 19
+        name: sensor
+        type: integer
+        class: measurement
+        unit: W
+        mapping:
+          - scale: 10
+      - id: 24
+        type: integer
+        name: calibration
+        optional: true
+  - entity: sensor
+    category: diagnostic
+    class: voltage
+    dps:
+      - id: 20
+        name: sensor
+        type: integer
+        class: measurement
+        unit: V
+        mapping:
+          - scale: 10
+      - id: 22
+        type: integer
+        name: calibration
+        optional: true
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 26
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 26
+        type: bitfield
+        name: fault_code
+  - entity: select
+    category: config
+    translation_key: initial_state
+    dps:
+      - id: 38
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "on"
+            value: "on"
+          - dps_val: "off"
+            value: "off"
+          - dps_val: memory
+            value: memory
+  - entity: switch
+    name: Overcharge protection
+    category: config
+    hidden: unavailable
+    dps:
+      - id: 39
+        type: boolean
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 39
+        type: boolean
+        name: switch
+        optional: true
+  - entity: select
+    translation_key: light_mode
+    category: config
+    hidden: unavailable
+    dps:
+      - id: 40
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: relay
+            value: state
+          - dps_val: pos
+            value: locator
+          - dps_val: none
+            value: "off"
+          - dps_val: "on"
+            value: "on"
+          - dps_val: "off"
+            value: "off"
+      - id: 40
+        type: string
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    hidden: unavailable
+    dps:
+      - id: 41
+        type: boolean
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 41
+        type: boolean
+        name: lock
+        optional: true


### PR DESCRIPTION
Add device configuration for BP20 V4 smart plug (generic Tuya 20A plug).

DPs verified by live device probe (protocol 3.4):
- Switch: DP1
- Timer: DP9 (countdown), DP42 (cycle), DP43 (random), DP44 (inching)
- Current: DP18, calibration DP23
- Power: DP19 (scale 10), calibration DP24
- Voltage: DP20 (scale 10), calibration DP22
- Fault: DP26 (bitfield)
- Power-on state: DP38 (on/off/memory)
- Overcharge protection: DP39 (boolean)
- Indicator light mode: DP40 (on/off/relay/pos)
- Child lock: DP41 (boolean)