### PR TITLE
Add TC700_Pro_Wifi air quality monitor

### DIFF
--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -26,10 +26,10 @@ entities:
     class: battery
     dps:
       - id: 4
-        type: string
-        optional: true
+        type: integer
         name: sensor
         unit: "%"
+        class: measurement
   - entity: sensor
     class: carbon_dioxide
     dps:
@@ -86,6 +86,7 @@ entities:
       - id: 107
         type: integer
         name: second
+        readonly: true
         range:
           min: 0
           max: 50000

--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -79,7 +79,8 @@ entities:
         unit: ugm3
         class: measurement
   - entity: sensor
-    name: Recordings count
+    name: Record count
+    category: diagnostic
     dps:
       - id: 107
         type: integer

--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -78,13 +78,9 @@ entities:
         name: sensor
         unit: ugm3
         class: measurement
-  - entity: number
+  - entity: sensor
     name: Recordings count
     dps:
       - id: 107
         type: integer
-        name: value
-        readonly: true
-        range:
-          min: 0
-          max: 50000
+        name: sensor

--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -71,7 +71,6 @@ entities:
         unit: ugm3
         class: measurement
   - entity: sensor
-    name: TVOC
     class: volatile_organic_compounds
     dps:
       - id: 106

--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -1,0 +1,91 @@
+name: TC700 Air Quality Monitor
+products:
+  - id: rvkhlmxnhytxua4a
+    model: TC700_Pro_Wifi
+entities:
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: sensor
+    name: Battery
+    class: battery
+    dps:
+      - id: 4
+        type: string
+        optional: true
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    class: carbon_dioxide
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: ppm
+        class: measurement
+  - entity: sensor
+    class: pm1
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: ugm3
+        class: measurement
+  - entity: sensor
+    class: pm25
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: ugm3
+        class: measurement
+  - entity: sensor
+    class: pm10
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: ugm3
+        class: measurement
+  - entity: sensor
+    name: HCHO
+    class: volatile_organic_compounds
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: ugm3
+        class: measurement
+  - entity: sensor
+    name: TVOC
+    class: volatile_organic_compounds
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        unit: ugm3
+        class: measurement
+  - entity: time
+    name: Recording time
+    dps:
+      - id: 107
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 50000

--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -80,12 +80,12 @@ entities:
         name: sensor
         unit: ugm3
         class: measurement
-  - entity: time
-    name: Recording time
+  - entity: number
+    name: Recordings count
     dps:
       - id: 107
         type: integer
-        name: second
+        name: value
         readonly: true
         range:
           min: 0

--- a/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
+++ b/custom_components/tuya_local/devices/tc700_airquality_nonitor.yaml
@@ -22,14 +22,13 @@ entities:
         unit: "%"
         class: measurement
   - entity: sensor
-    name: Battery
     class: battery
+    category: diagnostic
     dps:
       - id: 4
         type: integer
         name: sensor
         unit: "%"
-        class: measurement
   - entity: sensor
     class: carbon_dioxide
     dps:


### PR DESCRIPTION
This PR adds support for the TC700 Pro Wifi airquality monitor. It has a 18650 battery bay but it can also be powered from USB.
id : `rvkhlmxnhytxua4a`
DPs:
- 1: temp
- 2: humidity
- 4: battery charge percent
- 101: CO2 value
- 102: PM1.0 ug/m3
- 103: PM2.5 ug/m3
- 104: PM10.0 ug/m3
- 105: HCHO mg/m3 at scale 3
- 106: TVOC mg/m3 at scale 3
- 107: the count of recordings (the device can make fixed length recordings of its measurements and save them onto an SD card, this DP returns the count of such recordings)

<details>
  <summary>tuya iot DP descriptions</summary>
  
  ```json
  {
  "modelId": "exvekk",
  "services": [
    {
      "actions": [],
      "code": "",
      "description": "",
      "events": [],
      "name": "默认服务",
      "properties": [
        {
          "abilityId": 1,
          "accessMode": "ro",
          "code": "temp_current",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_temp",
            "attribute": "1666"
          },
          "name": "温度",
          "typeSpec": {
            "type": "value",
            "max": 900,
            "min": -200,
            "scale": 1,
            "step": 1,
            "unit": "℃"
          }
        },
        {
          "abilityId": 2,
          "accessMode": "ro",
          "code": "humidity_value",
          "description": "",
          "extensions": {
            "iconName": "icon-shidu",
            "attribute": "1666"
          },
          "name": "湿度数值",
          "typeSpec": {
            "type": "value",
            "max": 100,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "%"
          }
        },
        {
          "abilityId": 4,
          "accessMode": "ro",
          "code": "battery_percentage",
          "description": "",
          "extensions": {
            "iconName": "icon-dp_battery",
            "attribute": "1154"
          },
          "name": "电池电量",
          "typeSpec": {
            "type": "value",
            "max": 100,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "%"
          }
        },
        {
          "abilityId": 101,
          "accessMode": "ro",
          "code": "co2_val",
          "description": "",
          "extensions": {
            "scope": ""
          },
          "name": "二氧化碳",
          "typeSpec": {
            "type": "value",
            "max": 25000,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "PPM"
          }
        },
        {
          "abilityId": 102,
          "accessMode": "ro",
          "code": "pm1_0_val",
          "description": "",
          "name": "PM1.0",
          "typeSpec": {
            "type": "value",
            "max": 9999,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "ug/m³"
          }
        },
        {
          "abilityId": 103,
          "accessMode": "ro",
          "code": "pm2_5_val",
          "description": "",
          "name": "PM2.5",
          "typeSpec": {
            "type": "value",
            "max": 9999,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "ug/m³"
          }
        },
        {
          "abilityId": 104,
          "accessMode": "ro",
          "code": "pm10_val",
          "description": "",
          "name": "PM10",
          "typeSpec": {
            "type": "value",
            "max": 9999,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": "ug/m³"
          }
        },
        {
          "abilityId": 105,
          "accessMode": "ro",
          "code": "hcho_val",
          "description": "",
          "name": "HCHO",
          "typeSpec": {
            "type": "value",
            "max": 3000,
            "min": 0,
            "scale": 3,
            "step": 1,
            "unit": "mg/m³"
          }
        },
        {
          "abilityId": 106,
          "accessMode": "ro",
          "code": "tvoc_val",
          "description": "",
          "name": "TVOC",
          "typeSpec": {
            "type": "value",
            "max": 3000,
            "min": 0,
            "scale": 3,
            "step": 1,
            "unit": "mg/m³"
          }
        },
        {
          "abilityId": 107,
          "accessMode": "ro",
          "code": "rec_val",
          "description": "",
          "name": "REC",
          "typeSpec": {
            "type": "value",
            "max": 50000,
            "min": 0,
            "scale": 0,
            "step": 1,
            "unit": ""
          }
        }
      ]
    }
  ]
}
  ```
  
</details>

DPs 105 & 106 return values in mg/m3 but at x1000 scale, so I configured them to ug/m3 with no scaling.
Also I hope `pm1` is the correct class for PM1.0
