### PR TITLE
Add mask_base support and RGBIC CCTIC DP61 LED strip profile

### DIFF
--- a/custom_components/tuya_local/devices/device_config_schema.json
+++ b/custom_components/tuya_local/devices/device_config_schema.json
@@ -218,6 +218,10 @@
                                     "pattern": "^[0-9a-fA-F]+$",
                                     "description": "A hexadecimal mask to extract an integer from a base64 or hex DP value."
                                 },
+                                "mask_base": {
+                                    "type": ["integer", "string"],
+                                    "description": "Raw DP value to use as the base only when writing a masked value and the current DP value is unavailable."
+                                },
                                 "mask_signed": {
                                     "type": "boolean",
                                     "description": "true if the masked integer is signed. Default is false, which should not be specified explicitly to avoid clutter."

--- a/custom_components/tuya_local/devices/tuya_rgbic_cctic_led_strip_dp61.yaml
+++ b/custom_components/tuya_local/devices/tuya_rgbic_cctic_led_strip_dp61.yaml
@@ -43,7 +43,7 @@ entities:
         mask_base: "AAAAFABQMg=="
         mask: "0000000000FF00"
         range:
-          min: 0
+          min: 3
           max: 100
       - id: 61
         name: color_temp

--- a/custom_components/tuya_local/devices/tuya_rgbic_cctic_led_strip_dp61.yaml
+++ b/custom_components/tuya_local/devices/tuya_rgbic_cctic_led_strip_dp61.yaml
@@ -1,0 +1,89 @@
+name: RGBIC CCTIC light strip
+entities:
+  - entity: light
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 21
+        type: string
+        name: color_mode
+        mapping:
+          - dps_val: white
+            value: color_temp
+          - dps_val: colour
+            value: hs
+          - dps_val: scene
+            value: Scene
+          - dps_val: music
+            value: Music
+      - id: 24
+        name: rgbhsv
+        type: hex
+        format:
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+          - name: v
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+      - id: 61
+        name: brightness
+        type: base64
+        optional: true
+        mask_base: "AAAAFABQMg=="
+        mask: "0000000000FF00"
+        range:
+          min: 0
+          max: 100
+      - id: 61
+        name: color_temp
+        type: base64
+        optional: true
+        mask_base: "AAAAFABQMg=="
+        mask: "000000000000FF"
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - target_range:
+              min: 2700
+              max: 6500
+  - entity: time
+    translation_key: timer
+    category: config
+    dps:
+      - id: 26
+        name: second
+        type: integer
+        optional: true
+        range:
+          min: 0
+          max: 86400
+  - entity: sensor
+    name: DP 47
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 47
+        type: integer
+        name: sensor
+        optional: true
+  - entity: sensor
+    name: DP 53
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 53
+        type: integer
+        name: sensor
+        optional: true

--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -552,7 +552,7 @@ class TuyaDpsConfig:
         if self.rawtype == "bitfield" and matchdata:
             try:
                 return (int(value) & int(matchdata)) != 0
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 return False
         else:
             return str(value) == str(matchdata)
@@ -1115,10 +1115,12 @@ class TuyaDpsConfig:
             mask_scale = mask & (1 + ~mask)
 
             # Get raw current value directly (avoids scaling being auto applied as it causes issues)
-            raw_current = device.get_property(self.id)
             if self.id in pending_map:
                 decoded_value = self.decode_value(pending_map[self.id], device)
             else:
+                raw_current = device.get_property(self.id)
+                if raw_current is None:
+                    raw_current = self._config.get("mask_base")
                 decoded_value = self.decode_value(raw_current, device)
 
             if decoded_value is None:

--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -1122,6 +1122,13 @@ class TuyaDpsConfig:
                 if raw_current is None:
                     raw_current = self._config.get("mask_base")
                 decoded_value = self.decode_value(raw_current, device)
+            mask_base = self._config.get("mask_base")
+            if (
+                mask_base is not None
+                and isinstance(decoded_value, bytes)
+                and len(decoded_value) != length
+            ):
+                decoded_value = self.decode_value(mask_base, device)
 
             if decoded_value is None:
                 raise ValueError("Cannot mask unknown current value")

--- a/custom_components/tuya_local/helpers/device_config.py
+++ b/custom_components/tuya_local/helpers/device_config.py
@@ -552,7 +552,9 @@ class TuyaDpsConfig:
         if self.rawtype == "bitfield" and matchdata:
             try:
                 return (int(value) & int(matchdata)) != 0
-            except (TypeError, ValueError):
+            except TypeError:
+                return False
+            except ValueError:
                 return False
         else:
             return str(value) == str(matchdata)

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -120,6 +120,7 @@ DP_SCHEMA = vol.Schema(
         vol.Optional("mapping"): [MAPPING_SCHEMA],
         vol.Optional("format"): [FORMAT_SCHEMA],
         vol.Optional("mask"): str,
+        vol.Optional("mask_base"): vol.Any(str, int),
         vol.Optional("endianness"): vol.In(["little"]),
         vol.Optional("mask_signed"): True,
     }
@@ -838,6 +839,72 @@ def test_setting_masked_b64_with_special_case_mapping(mocker):
     mock_device.get_property.return_value = "AAA="
     cfg = TuyaDpsConfig(mock_entity, mock_config)
     assert cfg.get_values_to_set(mock_device, "special_case") == {"1": "AQA="}
+
+
+def test_setting_masked_b64_uses_mask_base_when_current_missing(mocker):
+    """Test that mask_base seeds masked writes when the current DP is missing."""
+    mock_entity = mocker.MagicMock()
+    mock_config = {
+        "id": "1",
+        "name": "test",
+        "type": "base64",
+        "mask": "0000000000ff00",
+        "mask_base": "AAAAFABQZA==",
+    }
+    mock_device = mocker.MagicMock()
+    mock_device.get_property.return_value = None
+    cfg = TuyaDpsConfig(mock_entity, mock_config)
+
+    assert cfg.get_values_to_set(mock_device, 0x32) == {"1": "AAAAFAAyZA=="}
+
+
+def test_setting_masked_b64_with_mask_base_merges_pending_writes(mocker):
+    """Test that same-DP masked writes merge after mask_base seeds the first write."""
+    mock_entity = mocker.MagicMock()
+    mock_device = mocker.MagicMock()
+    mock_device.get_property.return_value = None
+    brightness = TuyaDpsConfig(
+        mock_entity,
+        {
+            "id": "1",
+            "name": "brightness",
+            "type": "base64",
+            "mask": "0000000000ff00",
+            "mask_base": "AAAAFABQZA==",
+        },
+    )
+    color_temp = TuyaDpsConfig(
+        mock_entity,
+        {
+            "id": "1",
+            "name": "color_temp",
+            "type": "base64",
+            "mask": "000000000000ff",
+            "mask_base": "AAAAFABQZA==",
+        },
+    )
+    pending = {}
+    pending.update(color_temp.get_values_to_set(mock_device, 0x3A, pending))
+    pending.update(brightness.get_values_to_set(mock_device, 0x32, pending))
+
+    assert pending == {"1": "AAAAFAAyOg=="}
+
+
+def test_getting_masked_b64_ignores_mask_base_when_current_missing(mocker):
+    """Test that mask_base does not fabricate a current value."""
+    mock_entity = mocker.MagicMock()
+    mock_config = {
+        "id": "1",
+        "name": "test",
+        "type": "base64",
+        "mask": "0000000000ff00",
+        "mask_base": "AAAAFABQZA==",
+    }
+    mock_device = mocker.MagicMock()
+    mock_device.get_property.return_value = None
+    cfg = TuyaDpsConfig(mock_entity, mock_config)
+
+    assert cfg.get_value(mock_device) is None
 
 
 def test_default_without_mapping(mocker):

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -849,13 +849,47 @@ def test_setting_masked_b64_uses_mask_base_when_current_missing(mocker):
         "name": "test",
         "type": "base64",
         "mask": "0000000000ff00",
-        "mask_base": "AAAAFABQZA==",
+        "mask_base": "AAAAFABQMg==",
     }
     mock_device = mocker.MagicMock()
     mock_device.get_property.return_value = None
     cfg = TuyaDpsConfig(mock_entity, mock_config)
 
+    assert cfg.get_values_to_set(mock_device, 0x32) == {"1": "AAAAFAAyMg=="}
+
+
+def test_setting_masked_b64_uses_matching_current_value_over_mask_base(mocker):
+    """Test that a compatible current packed value is preferred over mask_base."""
+    mock_entity = mocker.MagicMock()
+    mock_config = {
+        "id": "1",
+        "name": "test",
+        "type": "base64",
+        "mask": "0000000000ff00",
+        "mask_base": "AAAAFABQMg==",
+    }
+    mock_device = mocker.MagicMock()
+    mock_device.get_property.return_value = "AAAAFABQZA=="
+    cfg = TuyaDpsConfig(mock_entity, mock_config)
+
     assert cfg.get_values_to_set(mock_device, 0x32) == {"1": "AAAAFAAyZA=="}
+
+
+def test_setting_masked_b64_uses_mask_base_when_current_length_mismatch(mocker):
+    """Test that incompatible packed payloads do not seed masked writes."""
+    mock_entity = mocker.MagicMock()
+    mock_config = {
+        "id": "1",
+        "name": "test",
+        "type": "base64",
+        "mask": "0000000000ff00",
+        "mask_base": "AAAAFABQMg==",
+    }
+    mock_device = mocker.MagicMock()
+    mock_device.get_property.return_value = "AAEAFAAAamQ0"
+    cfg = TuyaDpsConfig(mock_entity, mock_config)
+
+    assert cfg.get_values_to_set(mock_device, 0x32) == {"1": "AAAAFAAyMg=="}
 
 
 def test_setting_masked_b64_with_mask_base_merges_pending_writes(mocker):
@@ -870,7 +904,7 @@ def test_setting_masked_b64_with_mask_base_merges_pending_writes(mocker):
             "name": "brightness",
             "type": "base64",
             "mask": "0000000000ff00",
-            "mask_base": "AAAAFABQZA==",
+            "mask_base": "AAAAFABQMg==",
         },
     )
     color_temp = TuyaDpsConfig(
@@ -880,7 +914,7 @@ def test_setting_masked_b64_with_mask_base_merges_pending_writes(mocker):
             "name": "color_temp",
             "type": "base64",
             "mask": "000000000000ff",
-            "mask_base": "AAAAFABQZA==",
+            "mask_base": "AAAAFABQMg==",
         },
     )
     pending = {}
@@ -898,7 +932,7 @@ def test_getting_masked_b64_ignores_mask_base_when_current_missing(mocker):
         "name": "test",
         "type": "base64",
         "mask": "0000000000ff00",
-        "mask_base": "AAAAFABQZA==",
+        "mask_base": "AAAAFABQMg==",
     }
     mock_device = mocker.MagicMock()
     mock_device.get_property.return_value = None


### PR DESCRIPTION
## Summary

This PR adds support for a Tuya RGBIC+CCTIC Wi-Fi LED strip that uses packed DP61 raw/base64 data for white brightness and colour temperature.

It also adds a small generic `mask_base` option for masked packed DP writes. This is needed when a masked DP write has to preserve unmasked bytes, but the current packed DP value is either missing or incompatible with the mask shape.

Fixes / follows up: #5353

## What is supported

* On/off via DP20
* HS colour via DP24
* White brightness via DP61
* Colour temperature via DP61
* Switching between colour mode and white/CCT mode
* Safe masked writes when DP61 is missing at startup
* Safe masked writes when DP61 currently contains the RGB-mode 9-byte payload instead of the white-mode 7-byte payload

## What is intentionally not included

This does not attempt full Tuya app parity. It does not implement scene editing, per-segment painting, music/mic configuration, or the full Dreamlight protocol.

## Device details

Device name from Finnish user guide:

`Älykäs LED-valonauha RGBIC+CCTIC, 5M, Wifi`

Observed relevant DPs:

```text
20 switch_led
21 work_mode: white, colour, scene, music
24 colour_data / HSV colour
61 paint_colour_data / packed raw white+CCT payload
```

Observed white-mode DP61 shape:

```text
00 00 00 14 00 BB TT
```

Where:

* `BB` is white brightness, usable range 3–100 on this device
* `TT` is colour temperature, 0–100 mapped to 2700–6500 K

## Implementation notes

`mask_base` is only used in the masked write path. It is not used for reads, so Home Assistant does not report fabricated brightness or colour-temperature state before the device has actually reported the DP.

The fallback order for masked writes remains:

1. pending value for the same DP
2. current device value, if compatible with the mask width
3. `mask_base`, if configured

## Tested

Live tested on my own device with Home Assistant and Tuya Local:

* Turn on/off
* Set HS colour
* Set white brightness
* Set colour temperature
* Switch RGB/HS → white/CCT
* Low white brightness floor fixed at 3%

Local validation:

```text
uv run pytest
uv run pytest tests/test_device_config.py
uv run ruff check .
uv run ruff check --select I .
uv run ruff format --check .
uv run yamllint custom_components/tuya_local/devices
```

