### PR TITLE
Awesafe ac 11k us evcharger

### DIFF
--- a/custom_components/tuya_local/devices/awesafe_ac_11k_us_evcharger.yaml
+++ b/custom_components/tuya_local/devices/awesafe_ac_11k_us_evcharger.yaml
@@ -54,19 +54,6 @@ entities:
       type: string
       optional: true
       name: system_version
-  # - entity: number
-  #   name: Charging current
-  #   category: config
-  #   class: current
-  #   icon: "mdi:ev-plug-type2"
-  #   dps:
-  #     - id: 4
-  #       type: integer
-  #       name: value
-  #       unit: A
-  #       range:
-  #         min: 8
-  #         max: 50
   - entity: select
     name: Set current
     category: config

--- a/custom_components/tuya_local/devices/awesafe_ac_11k_us_evcharger.yaml
+++ b/custom_components/tuya_local/devices/awesafe_ac_11k_us_evcharger.yaml
@@ -1,0 +1,357 @@
+name: EV charger
+products:
+  - id: gkues3igkup3nlpz
+    manufacturer: AWESAFE
+    model: "AC-11K-US"
+entities:
+  - entity: sensor
+    class: enum
+    translation_key: status
+    icon: "mdi:ev-station"
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: charger_free
+            value: available
+          - dps_val: charger_insert
+            value: plugged_in
+          - dps_val: charger_free_fault
+            value: fault_unplugged
+          - dps_val: charger_charging
+            value: charging
+          - dps_val: charger_wait
+            value: waiting
+          - dps_val: charger_end
+            value: charged
+          - dps_val: charger_fault
+            value: fault
+          - dps_val: charger_pause
+            value: paused
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        optional: true
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    category: diagnostic
+    dps:
+      - id: 22
+        type: string
+        optional: true
+        name: meter_id
+  - entity: sensor
+    category: diagnostic
+    dps:
+    - id: 23
+      type: string
+      optional: true
+      name: system_version
+  # - entity: number
+  #   name: Charging current
+  #   category: config
+  #   class: current
+  #   icon: "mdi:ev-plug-type2"
+  #   dps:
+  #     - id: 4
+  #       type: integer
+  #       name: value
+  #       unit: A
+  #       range:
+  #         min: 8
+  #         max: 50
+  - entity: select
+    name: Set current
+    category: config
+    icon: "mdi:ev-plug-type2"
+    dps:
+      - id: 4
+        type: integer
+        name: option
+        # Valid values: 8, 10, 13, 16, 32, 40, 50
+        mapping:
+          - dps_val: 8
+            value: "8A"
+          - dps_val: 10
+            value: "10A"
+          - dps_val: 13
+            value: "13A"
+          - dps_val: 16
+            value: "16A"
+          - dps_val: 32
+            value: "32A"
+          - dps_val: 40
+            value: "40A"
+          - dps_val: 50
+            value: "50A"
+# Does not make sense for US level 2 which is two-phase, but included for potential others
+  - entity: sensor
+    name: Single phase power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        optional: true
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Total power
+    class: power
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: kW
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 10
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 10
+        type: bitfield
+        name: fault_code
+      - id: 10
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: null
+            value: "No data"
+          - dps_val: 0
+            value: "Ready"
+          - dps_val: 1
+            value: "Ov2 Cr Fault"
+          - dps_val: 2
+            value: "OV Vol"
+          - dps_val: 4
+            value: "Undervoltage alarm"
+          - dps_val: 8
+            value: "Contactor adhesion"
+          - dps_val: 16
+            value: "Contactor fault"
+          - dps_val: 32
+            value: "Earth fault"
+          - dps_val: 64
+            value: "Meter Hardware alarm"
+          - dps_val: 128
+            value: "Scram fault"
+          - dps_val: 256
+            value: "CP fault"
+          - dps_val: 512
+            value: "Meter Commu fault"
+          - dps_val: 1024
+            value: "Card reader fault"
+          - dps_val: 2048
+            value: "Cir short fault"
+          - dps_val: 4096
+            value: "Adhesion fault"
+          - dps_val: 8192
+            value: "Self test alarm"
+          - dps_val: 16384
+            value: "Leakage current fault"
+  - entity: select
+    translation_key: charging_mode
+    icon: "mdi:ev-station"
+    dps:
+      - id: 14
+        type: string
+        name: option
+        mapping:
+          - dps_val: charge_now
+            value: Immediate charge
+          - dps_val: charge_pct
+            value: Charge to %
+          - dps_val: charge_energy
+            value: Charge to kWh
+          - dps_val: charge_schedule
+            value: Scheduled charge
+          - dps_val: charge_delay
+            value: Delayed charge
+  - entity: switch
+    icon: "mdi:ev-station"
+    dps:
+      - id: 18
+        type: boolean
+        name: switch
+  - entity: sensor
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Last charge
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
+        unit: kWh
+        class: measurement
+        optional: true
+        mapping:
+          - scale: 100
+  - entity: binary_sensor
+    class: connectivity
+    category: diagnostic
+    dps:
+      - id: 27
+        type: string
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: offline
+            value: false
+          - dps_val: online
+            value: true
+  - entity: number
+    translation_key: timer
+    class: duration
+    mode: box
+    dps:
+      - id: 28
+        type: integer
+        name: value
+        unit: h
+        optional: true
+        range:
+          min: 0
+          max: 12
+  - entity: number
+    name: Scheduled charge start hour
+    category: config
+    mode: box
+    dps:
+      - id: 19
+        type: base64
+        name: value
+        optional: true
+        unit: h
+        mask: "FF00"
+        range:
+          min: 0
+          max: 23
+  - entity: number
+    name: Scheduled charge stop hour
+    category: config
+    mode: box
+    dps:
+      - id: 19
+        type: base64
+        name: value
+        optional: true
+        unit: h
+        mask: "00FF"
+        range:
+          min: 0
+          max: 23
+  - entity: sensor
+    class: voltage
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        mask: "FFFF000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: current
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        mask: "0000FFFFFF000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: power
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: kW
+        mask: "0000000000FFFFFF"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    category: diagnostic
+    dps:
+      - id: 33
+        type: base64
+        optional: true
+        name: supports_immediate_charging
+        mask: "FF00000000000000"
+  - entity: sensor
+    category: diagnostic
+    dps:
+      - id: 33
+        type: base64
+        optional: true
+        name: supports_percentage_charging
+        mask: "00FF000000000000"
+  - entity: sensor
+    category: diagnostic
+    dps:
+      - id: 33
+        type: base64
+        optional: true
+        name: supports_energy_charging
+        mask: "0000FF0000000000"
+  - entity: sensor
+    category: diagnostic
+    dps:
+      - id: 33
+        type: base64
+        optional: true
+        name: supports_timed_charging
+        mask: "000000FF00000000"
+  - entity: sensor
+    category: diagnostic
+    dps:
+      - id: 33
+        type: base64
+        optional: true
+        name: supports_delayed_charging
+        mask: "00000000FF000000"
+  - entity: number
+    name: Charge time
+    category: config
+    class: duration
+    icon: "mdi:clock"
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        unit: min
+        optional: true
+        range:
+          min: 0
+          max: 1440


### PR DESCRIPTION
- Added device description for AWESAFE Level 2 EV charger.  Specific model tested (and working) is https://www.amazon.com/dp/B0DQCP9KSD?ref=ppx_yo2ov_dt_b_fed_asin_title
- DP descriptions pulled from Tuya API and include all DPs possible for this and other variants, although not all are supported by mine
- This was tested against the above model.  Tested model does not include all DPs configured in Tuya cloud and only the following DPs have been tested to work: 3, 4, 6, 9, 10, 14, 18, 24, 27, 28
- There is also a slight mismatch in behavior of my charger for items in DP 4. They appear to be slightly translated, at least for the US Tesla model.  For instance, choosing 16A will result in a 15A charge limit, a 13A results in a 12.5A charge, and 50A results in a 48A charge.  The values included are tested for this model.  Any other values than this list result in the charger ignoring the update.  There may be valid values for other similar chargers for different power systems.
