### PR TITLE
Add Ovlaim 809 ceiling fan light

### DIFF
--- a/custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml
+++ b/custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml
@@ -1,0 +1,71 @@
+name: Ceiling fan
+products:
+  - id: ftqsaibnb3insvp9
+    manufacturer: Ovlaim
+    model: "809"
+entities:
+  - entity: light
+    dps:
+      - id: 20
+        name: switch
+        type: boolean
+      - id: 21
+        name: work_mode
+        type: string
+        optional: true
+      - id: 22
+        name: brightness
+        type: integer
+        optional: true
+        range:
+          min: 10
+          max: 1000
+      - id: 23
+        name: color_temp
+        type: integer
+        optional: true
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - target_range:
+              min: 2700
+              max: 7000
+  - entity: fan
+    dps:
+      - id: 60
+        name: switch
+        type: boolean
+      - id: 61
+        name: preset_mode
+        type: string
+        optional: true
+        mapping:
+          - dps_val: fresh
+            value: fresh
+          - dps_val: nature
+            value: nature
+      - id: 62
+        name: speed
+        type: integer
+        optional: true
+        range:
+          min: 1
+          max: 6
+      - id: 63
+        name: direction
+        type: string
+        optional: true
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 64
+        name: value
+        type: integer
+        optional: true
+        unit: min
+        range:
+          min: 0
+          max: 540


### PR DESCRIPTION
Resolves #5374

## Summary

Adds a device config for the **Ovlaim 809** ceiling fan with CCT light (Tuya WiFi canopy, product id `ftqsaibnb3insvp9`, category `fsd`).

## Why a new config rather than reusing `yoevu_eos_fanlight`

This unit has the same datapoint layout as `yoevu_eos_fanlight` (light: 20/21/22/23, fan: 60/61/62/63, timer: 64), so without an explicit product entry it was being detection-matched to that config. But the ranges in `yoevu_eos_fanlight` do not fit this hardware:

| DP | `yoevu_eos_fanlight` | This device (Tuya cloud spec) |
|----|----------------------|-------------------------------|
| 22 `bright_value` | 10–100 | **10–1000** |
| 23 `temp_value` | direct kelvin 2700–7000 | **raw 0–1000**, mapped to 2700–7000 K |
| 62 `fan_speed` | 1–6 | 1–6 |

The result was brightness pegged at maximum (device reports values up to 1000, clamped against a max of 100) and color temperature effectively unusable. The ranges above were read from the device's Tuya cloud specification (`/v1.0/devices/{id}/specifications`).

The `yoevu_eos_fanlight` config (product `nwjrdttwaghkr6r4`) is left untouched, since I cannot verify whether that specific product really uses the 10–100 range.

## Verification

Tested on real hardware via tuya-local local control:
- Light on/off, brightness across the full range, color temperature 2700–7000 K with warm/cool in the correct direction (no `invert` needed)
- Fan on/off, speed 1–6, preset modes (fresh / nature), direction
- Timer (number)

## Checks run

- `uv run yamllint custom_components/tuya_local/devices` — clean
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pytest tests/test_device_config.py` — 32 passed

DEVICES.md not regenerated (auto-generated; left for the maintainer release process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)