### PR TITLE
Fix unload KeyError for failed device setup

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -1003,9 +1003,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    _LOGGER.debug("Unloading entry for device: %s", get_device_id(entry.data))
+    device_id = get_device_id(entry.data)
+    _LOGGER.debug("Unloading entry for device: %s", device_id)
     config = entry.data
-    data = hass.data[DOMAIN][get_device_id(config)]
+    domain_data = hass.data.get(DOMAIN, {})
+    data = domain_data.get(device_id)
+    if data is None:
+        await async_delete_device(hass, config)
+        return True
+
     device_conf = await hass.async_add_executor_job(
         get_config,
         config[CONF_TYPE],
@@ -1023,7 +1029,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         await hass.config_entries.async_forward_entry_unload(entry, e)
 
     await async_delete_device(hass, config)
-    del hass.data[DOMAIN][get_device_id(config)]
+    domain_data.pop(device_id, None)
 
     return True
 

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -813,7 +813,16 @@ def setup_device(hass: HomeAssistant, config: dict):
 async def async_delete_device(hass: HomeAssistant, config: dict):
     device_id = get_device_id(config)
     _LOGGER.info("Deleting device: %s", device_id)
-    await hass.data[DOMAIN][device_id]["device"].async_stop()
-    del hass.data[DOMAIN][device_id]["device"]
-    del hass.data[DOMAIN][device_id]["tuyadevice"]
-    del hass.data[DOMAIN][device_id]["tuyadevicelock"]
+    domain_data = hass.data.get(DOMAIN, {})
+    device_entry = domain_data.get(device_id)
+    if device_entry is None:
+        return
+
+    device = device_entry.get("device")
+    if device is not None:
+        await device.async_stop()
+        device_entry.pop("device", None)
+    device_entry.pop("tuyadevice", None)
+    device_entry.pop("tuyadevicelock", None)
+    if not device_entry:
+        domain_data.pop(device_id, None)

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -824,5 +824,8 @@ async def async_delete_device(hass: HomeAssistant, config: dict):
         device_entry.pop("device", None)
     device_entry.pop("tuyadevice", None)
     device_entry.pop("tuyadevicelock", None)
+    # Platform setup may cache entity instances in this bucket by config_id.
+    # Only drop empty buckets here; async_unload_entry removes the whole bucket
+    # after forwarded platform unloads complete.
     if not device_entry:
         domain_data.pop(device_id, None)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,6 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.tuya_local import (
     async_migrate_entry,
     async_setup_entry,
+    async_unload_entry,
     config_flow,
     get_device_unique_id,
 )
@@ -125,6 +126,30 @@ async def test_async_setup_entry_cleans_up_failed_device(hass, mocker, refresh_e
 
     assert "deviceid" not in hass.data.get(DOMAIN, {})
     mock_device._api.set_socketPersistent.assert_called_with(False)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_ignores_missing_device_data(hass):
+    """Unload should tolerate entries that failed before device data was cached."""
+
+    hass.data[DOMAIN] = {}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=13,
+        minor_version=18,
+        title="test",
+        data={
+            CONF_DEVICE_ID: "deviceid",
+            CONF_HOST: "hostname",
+            CONF_LOCAL_KEY: TESTKEY,
+            CONF_POLL_ONLY: False,
+            CONF_PROTOCOL_VERSION: 3.4,
+            CONF_TYPE: "kogan_kahtp_heater",
+        },
+        options={},
+    )
+
+    assert await async_unload_entry(hass, entry)
 
 
 @pytest.mark.asyncio

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,8 @@ from time import time
 import pytest
 
 # from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
-from custom_components.tuya_local.device import TuyaLocalDevice
+from custom_components.tuya_local.const import CONF_DEVICE_ID, DOMAIN
+from custom_components.tuya_local.device import TuyaLocalDevice, async_delete_device
 
 from .const import EUROM_600_HEATER_PAYLOAD
 
@@ -66,6 +67,25 @@ def test_device_info(subject, mock_api):
         "name": "Some name",
         "manufacturer": "Tuya",
     }
+
+
+@pytest.mark.asyncio
+async def test_delete_keeps_device_entry_when_stop_fails(hass, mocker):
+    """Device cache should not be removed before stop succeeds."""
+    device = mocker.MagicMock()
+    device.async_stop = mocker.AsyncMock(side_effect=RuntimeError("stop failed"))
+    hass.data[DOMAIN] = {
+        "deviceid": {
+            "device": device,
+            "tuyadevice": mocker.MagicMock(),
+            "tuyadevicelock": mocker.MagicMock(),
+        }
+    }
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await async_delete_device(hass, {CONF_DEVICE_ID: "deviceid"})
+
+    assert hass.data[DOMAIN]["deviceid"]["device"] is device
 
 
 def test_has_returned_state(subject):


### PR DESCRIPTION
## Summary

This fixes an unload crash that can happen when a Tuya device is offline during Home Assistant startup. In that state Home Assistant may leave the config entry in `setup_retry`, while `tuya-local` never finishes creating the usual cached device data under `hass.data`.

Later, when Home Assistant reloads, updates, or shuts down that entry, the integration still runs its unload path. Before this change, that path assumed the cached device entry and all of its internal keys existed, so it could raise a `KeyError` instead of completing the unload.

This PR makes that cleanup path defensive for setup-failed entries:

- `async_unload_entry` now tolerates a missing `hass.data[DOMAIN][device_id]` entry and treats it as already unloaded.
- `async_delete_device` now tolerates missing or partially initialized cached handles.
- Device cleanup still awaits `async_stop()` before removing the cached `device` object, so a stop failure does not silently discard the device reference first.

The intent is to keep normal unload behavior unchanged for devices that completed setup, while preventing failed setup or `setup_retry` entries from crashing later reload/update/shutdown flows.

## Reported traceback

    Traceback (most recent call last):
      File "/config/custom_components/tuya_local/__init__.py", line 1001, in async_update_entry
        await async_unload_entry(hass, entry)
      File "/config/custom_components/tuya_local/__init__.py", line 993, in async_unload_entry
        await async_delete_device(hass, config)
      File "/config/custom_components/tuya_local/device.py", line 822, in async_delete_device
        del hass.data[DOMAIN][device_id]["device"]
    KeyError: '<device_id>'

## Device context

- Device: Venta AH550 humidifier, detected as type `venta_ah510_humidifier`.
- Setup state: offline during Home Assistant boot, leaving the entry in `setup_retry`.
- Entry reason: `tuya-local device offline`.
- Related issues: #3824, #3174.

## Scope notes

This PR is intentionally narrow. It addresses unload cleanup for setup-failed or partially initialized entries, but does not try to redesign broader cache recovery behavior. In particular, it does not add new handling for unrelated cases where platform entities were already forwarded and the device cache is later externally corrupted.

## Testing

- `uv run pytest tests/test_config_flow.py::test_async_unload_entry_ignores_missing_device_data -q`
- `uv run pytest tests/test_device.py::test_delete_keeps_device_entry_when_stop_fails -q`
- `uv run pytest tests/test_device.py tests/test_config_flow.py -q`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff check --select I .`
- `uv run ruff format --check .`
- `uv run yamllint custom_components/tuya_local/devices`
