### PR TITLE
util: look up the integer range by string key, not the range builtin

### DIFF
--- a/util/common_funcs.py
+++ b/util/common_funcs.py
@@ -32,8 +32,9 @@ def representation(dp):
     if dp.type is bool:
         return True
     if dp.type is int:
-        if dp._config.get(range):
-            return dp._config.get(range)["min"]
+        range_spec = dp._config.get("range")
+        if isinstance(range_spec, dict) and "min" in range_spec:
+            return range_spec["min"]
         return 0
     if dp.type is str:
         return ""


### PR DESCRIPTION
## Summary
- `util/common_funcs.py`: `representation()` looked up the integer range by passing the built-in `range` function as a key. The config dict is loaded from YAML, so the actual key is the string `"range"` — the lookup always returned `None` and a sample DP value of `0` was used regardless of the configured `min`. The CLI utilities `duplicates` and `match_against` (which use `make_sample_dps`) silently produced wrong sample values, and a real device match could be turned into a false negative if the duplicate detection was matching against a `range: {min: 40, max: 70}` config.
- The fix uses the string key `"range"` and guards against a non-dict / missing `min` before subscripting, so the function returns the configured minimum when present and falls back to `0` otherwise.

## Verification
- Wrote a standalone script that constructed fake DPs with and without `range` config. Before the fix, both returned `0`. After the fix, the DP with `range.min: 5` returns `5` and the DP without a range returns `0`.