### PR TITLE
Add Airwoods fresh air heat pump

### DIFF
--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -1,0 +1,259 @@
+name: Fresh air heat pump
+
+entities:
+  - entity: climate
+    name: Fresh air heat pump
+    dps:
+      - id: 101
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "3"
+                value: auto
+              - dps_val: "5"
+                value: cool
+              - dps_val: "6"
+                value: heat
+              - dps_val: "8"
+                value: dry
+              - dps_val: "10"
+                value: fan_only
+
+      - id: 115
+        type: string
+        name: mode
+        hidden: true
+
+      - id: 106
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 10
+          max: 40
+        mapping:
+          - step: 1
+
+      - id: 130
+        type: integer
+        name: current_temperature
+        unit: C
+
+  - entity: number
+    name: Supply air speed
+    icon: "mdi:fan-chevron-up"
+    dps:
+      - id: 102
+        type: string
+        name: value
+        mapping:
+          - dps_val: "0"
+            value: 1
+          - dps_val: "1"
+            value: 2
+          - dps_val: "2"
+            value: 3
+          - dps_val: "3"
+            value: 4
+          - dps_val: "4"
+            value: 5
+          - dps_val: "5"
+            value: 6
+          - dps_val: "6"
+            value: 7
+          - dps_val: "7"
+            value: 8
+          - dps_val: "8"
+            value: 9
+          - dps_val: "9"
+            value: 10
+        range:
+          min: 1
+          max: 10
+
+  - entity: number
+    name: Exhaust air speed
+    icon: "mdi:fan-chevron-down"
+    dps:
+      - id: 103
+        type: string
+        name: value
+        mapping:
+          - dps_val: "0"
+            value: 1
+          - dps_val: "1"
+            value: 2
+          - dps_val: "2"
+            value: 3
+          - dps_val: "3"
+            value: 4
+          - dps_val: "4"
+            value: 5
+          - dps_val: "5"
+            value: 6
+          - dps_val: "6"
+            value: 7
+          - dps_val: "7"
+            value: 8
+          - dps_val: "8"
+            value: 9
+          - dps_val: "9"
+            value: 10
+        range:
+          min: 1
+          max: 10
+
+  - entity: number
+    name: Bypass lower limit temperature
+    category: config
+    icon: "mdi:valve"
+    dps:
+      - id: 107
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 5
+          max: 30
+        mapping:
+          - step: 1
+
+  - entity: number
+    name: Bypass temperature range
+    category: config
+    icon: "mdi:delta"
+    dps:
+      - id: 108
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 2
+          max: 15
+        mapping:
+          - step: 1
+
+  - entity: sensor
+    name: Indoor temperature
+    class: temperature
+    dps:
+      - id: 117
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Outdoor temperature
+    class: temperature
+    dps:
+      - id: 118
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Supply air temperature
+    class: temperature
+    dps:
+      - id: 130
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Exhaust air temperature
+    class: temperature
+    dps:
+      - id: 131
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Stop code
+    category: diagnostic
+    icon: "mdi:alert-octagon-outline"
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+
+  - entity: binary_sensor
+    name: Alarm
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 119
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 119
+        type: bitfield
+        name: fault_code
+
+  - entity: binary_sensor
+    name: Filter clean
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 123
+        type: boolean
+        name: sensor
+
+  - entity: binary_sensor
+    name: Fan switch
+    category: diagnostic
+    icon: "mdi:fan"
+    dps:
+      - id: 125
+        type: boolean
+        name: sensor
+
+  - entity: sensor
+    name: Expansion valve pulse
+    category: diagnostic
+    icon: "mdi:valve"
+    dps:
+      - id: 124
+        type: integer
+        name: sensor
+
+  - entity: sensor
+    name: Filter left time
+    class: duration
+    category: diagnostic
+    icon: "mdi:air-filter"
+    dps:
+      - id: 126
+        type: integer
+        name: sensor
+        unit: d
+
+  - entity: sensor
+    name: Compressor frequency
+    category: diagnostic
+    icon: "mdi:sine-wave"
+    dps:
+      - id: 116
+        type: integer
+        name: sensor
+        unit: Hz
+
+  - entity: binary_sensor
+    name: Defrost
+    category: diagnostic
+    icon: "mdi:snowflake-melt"
+    dps:
+      - id: 122
+        type: boolean
+        name: sensor

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -155,6 +155,7 @@ entities:
 
   - entity: sensor
     name: VOC level
+    class: enum
     category: diagnostic
     icon: "mdi:molecule"
     dps:

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -5,7 +5,6 @@ name: Fresh air heat pump
 
 entities:
   - entity: climate
-    name: Fresh air heat pump
     dps:
       - id: 101
         type: boolean
@@ -42,7 +41,7 @@ entities:
         mapping:
           - step: 1
 
-      - id: 130
+      - id: 117
         type: integer
         name: current_temperature
         unit: C
@@ -142,13 +141,63 @@ entities:
           - step: 1
 
   - entity: sensor
-    name: Indoor temperature
-    class: temperature
+    name: CO2
+    category: diagnostic
+    class: carbon_dioxide
     dps:
-      - id: 117
+      - id: 111
         type: integer
         name: sensor
-        unit: C
+        unit: ppm
+        mapping:
+          - dps_val: 0
+            value: null
+
+  - entity: sensor
+    name: VOC level
+    category: diagnostic
+    icon: "mdi:molecule"
+    dps:
+      - id: 112
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "0"
+            value: null
+          - dps_val: "1"
+            value: excellent
+          - dps_val: "2"
+            value: good
+          - dps_val: "3"
+            value: medium
+          - dps_val: "4"
+            value: poor
+
+  - entity: sensor
+    name: Humidity
+    category: diagnostic
+    class: humidity
+    dps:
+      - id: 113
+        type: integer
+        name: sensor
+        unit: "%"
+        mapping:
+          - dps_val: 0
+            value: null
+
+  - entity: sensor
+    name: PM2.5
+    category: diagnostic
+    class: pm25
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        unit: µg/m³
+        mapping:
+          - dps_val: 0
+            value: null
 
   - entity: sensor
     name: Outdoor temperature
@@ -177,17 +226,7 @@ entities:
         name: sensor
         unit: C
 
-  - entity: sensor
-    name: Stop code
-    category: diagnostic
-    icon: "mdi:alert-octagon-outline"
-    dps:
-      - id: 109
-        type: integer
-        name: sensor
-
   - entity: binary_sensor
-    name: Alarm
     class: problem
     category: diagnostic
     dps:
@@ -203,6 +242,9 @@ entities:
       - id: 119
         type: bitfield
         name: fault_code
+      - id: 109
+        type: integer
+        name: stop_code
 
   - entity: binary_sensor
     name: Filter clean
@@ -214,16 +256,16 @@ entities:
         name: sensor
 
   - entity: binary_sensor
-    name: Fan switch
+    name: 10 speed fan mode
     category: diagnostic
-    icon: "mdi:fan"
+    icon: "mdi:fan-cog"
     dps:
       - id: 125
         type: boolean
         name: sensor
 
   - entity: sensor
-    name: Expansion valve pulse
+    name: Expansion valve opening
     category: diagnostic
     icon: "mdi:valve"
     dps:
@@ -232,10 +274,9 @@ entities:
         name: sensor
 
   - entity: sensor
-    name: Filter left time
+    translation_key: filter_life
     class: duration
     category: diagnostic
-    icon: "mdi:air-filter"
     dps:
       - id: 126
         type: integer
@@ -252,10 +293,59 @@ entities:
         name: sensor
         unit: Hz
 
+  - entity: sensor
+    name: Compressor discharge temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 120
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Compressor suction temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 121
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Evaporator temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 127
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Condenser temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 128
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Radiator temperature
+    category: diagnostic
+    class: temperature
+    dps:
+      - id: 129
+        type: integer
+        name: sensor
+        unit: C
+
   - entity: binary_sensor
     translation_key: defrost
     category: diagnostic
-    icon: "mdi:snowflake-melt"
     dps:
       - id: 122
         type: boolean

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -244,7 +244,7 @@ entities:
         name: stop_code
 
   - entity: binary_sensor
-    translation_key: filter_clean
+    name: Filter clean
     class: problem
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -38,21 +38,17 @@ entities:
         range:
           min: 10
           max: 40
-        mapping:
-          - step: 1
 
       - id: 117
         type: integer
         name: current_temperature
-        unit: C
 
-  - entity: number
-    name: Supply air speed
-    icon: "mdi:fan-chevron-up"
+  - entity: fan
+    name: Supply air fan
     dps:
       - id: 102
         type: string
-        name: value
+        name: speed
         mapping:
           - dps_val: "0"
             value: 1
@@ -78,13 +74,12 @@ entities:
           min: 1
           max: 10
 
-  - entity: number
-    name: Exhaust air speed
-    icon: "mdi:fan-chevron-down"
+  - entity: fan
+    name: Exhaust air fan
     dps:
       - id: 103
         type: string
-        name: value
+        name: speed
         mapping:
           - dps_val: "0"
             value: 1
@@ -113,7 +108,7 @@ entities:
   - entity: number
     name: Bypass lower limit temperature
     category: config
-    icon: "mdi:valve"
+    class: temperature
     dps:
       - id: 107
         type: integer
@@ -122,13 +117,11 @@ entities:
         range:
           min: 5
           max: 30
-        mapping:
-          - step: 1
 
   - entity: number
     name: Bypass temperature range
     category: config
-    icon: "mdi:delta"
+    class: temperature_delta
     dps:
       - id: 108
         type: integer
@@ -137,11 +130,8 @@ entities:
         range:
           min: 2
           max: 15
-        mapping:
-          - step: 1
 
   - entity: sensor
-    category: diagnostic
     class: carbon_dioxide
     dps:
       - id: 111
@@ -153,9 +143,8 @@ entities:
             value: null
 
   - entity: sensor
-    name: VOC level
+    translation_key: air_quality
     class: enum
-    category: diagnostic
     dps:
       - id: 112
         type: string
@@ -173,7 +162,6 @@ entities:
             value: poor
 
   - entity: sensor
-    category: diagnostic
     class: humidity
     dps:
       - id: 113
@@ -185,7 +173,6 @@ entities:
             value: null
 
   - entity: sensor
-    category: diagnostic
     class: pm25
     dps:
       - id: 114
@@ -252,15 +239,6 @@ entities:
         type: boolean
         name: sensor
 
-  - entity: binary_sensor
-    name: 10 speed fan mode
-    category: diagnostic
-    icon: "mdi:fan-cog"
-    dps:
-      - id: 125
-        type: boolean
-        name: sensor
-
   - entity: sensor
     name: Expansion valve opening
     category: diagnostic
@@ -283,7 +261,7 @@ entities:
   - entity: sensor
     name: Compressor frequency
     category: diagnostic
-    icon: "mdi:sine-wave"
+    class: frequency
     dps:
       - id: 116
         type: integer

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -51,28 +51,28 @@ entities:
         name: speed
         mapping:
           - dps_val: "0"
-            value: 1
-          - dps_val: "1"
-            value: 2
-          - dps_val: "2"
-            value: 3
-          - dps_val: "3"
-            value: 4
-          - dps_val: "4"
-            value: 5
-          - dps_val: "5"
-            value: 6
-          - dps_val: "6"
-            value: 7
-          - dps_val: "7"
-            value: 8
-          - dps_val: "8"
-            value: 9
-          - dps_val: "9"
             value: 10
+          - dps_val: "1"
+            value: 20
+          - dps_val: "2"
+            value: 30
+          - dps_val: "3"
+            value: 40
+          - dps_val: "4"
+            value: 50
+          - dps_val: "5"
+            value: 60
+          - dps_val: "6"
+            value: 70
+          - dps_val: "7"
+            value: 80
+          - dps_val: "8"
+            value: 90
+          - dps_val: "9"
+            value: 100
         range:
-          min: 1
-          max: 10
+          min: 10
+          max: 100
 
   - entity: fan
     name: Exhaust air fan
@@ -82,28 +82,28 @@ entities:
         name: speed
         mapping:
           - dps_val: "0"
-            value: 1
-          - dps_val: "1"
-            value: 2
-          - dps_val: "2"
-            value: 3
-          - dps_val: "3"
-            value: 4
-          - dps_val: "4"
-            value: 5
-          - dps_val: "5"
-            value: 6
-          - dps_val: "6"
-            value: 7
-          - dps_val: "7"
-            value: 8
-          - dps_val: "8"
-            value: 9
-          - dps_val: "9"
             value: 10
+          - dps_val: "1"
+            value: 20
+          - dps_val: "2"
+            value: 30
+          - dps_val: "3"
+            value: 40
+          - dps_val: "4"
+            value: 50
+          - dps_val: "5"
+            value: 60
+          - dps_val: "6"
+            value: 70
+          - dps_val: "7"
+            value: 80
+          - dps_val: "8"
+            value: 90
+          - dps_val: "9"
+            value: 100
         range:
-          min: 1
-          max: 10
+          min: 10
+          max: 100
 
   - entity: number
     name: Bypass lower limit temperature

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -70,9 +70,6 @@ entities:
             value: 90
           - dps_val: "9"
             value: 100
-        range:
-          min: 10
-          max: 100
 
   - entity: fan
     name: Exhaust air fan
@@ -101,9 +98,6 @@ entities:
             value: 90
           - dps_val: "9"
             value: 100
-        range:
-          min: 10
-          max: 100
 
   - entity: number
     name: Bypass lower limit temperature
@@ -157,7 +151,7 @@ entities:
           - dps_val: "2"
             value: good
           - dps_val: "3"
-            value: medium
+            value: moderate
           - dps_val: "4"
             value: poor
 

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -141,7 +141,6 @@ entities:
           - step: 1
 
   - entity: sensor
-    name: CO2
     category: diagnostic
     class: carbon_dioxide
     dps:
@@ -157,7 +156,6 @@ entities:
     name: VOC level
     class: enum
     category: diagnostic
-    icon: "mdi:molecule"
     dps:
       - id: 112
         type: string
@@ -175,7 +173,6 @@ entities:
             value: poor
 
   - entity: sensor
-    name: Humidity
     category: diagnostic
     class: humidity
     dps:
@@ -188,7 +185,6 @@ entities:
             value: null
 
   - entity: sensor
-    name: PM2.5
     category: diagnostic
     class: pm25
     dps:
@@ -248,7 +244,7 @@ entities:
         name: stop_code
 
   - entity: binary_sensor
-    name: Filter clean
+    translation_key: filter_clean
     class: problem
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -1,5 +1,8 @@
 name: Fresh air heat pump
 
+#     manufacturer: Airwoods
+#     model: AV-HTPF35 / AV-HTPF60 / AV-HTPF90
+
 entities:
   - entity: climate
     name: Fresh air heat pump
@@ -250,7 +253,7 @@ entities:
         unit: Hz
 
   - entity: binary_sensor
-    name: Defrost
+    translation_key: defrost
     category: diagnostic
     icon: "mdi:snowflake-melt"
     dps:


### PR DESCRIPTION
Adds a device config for an Airwoods AV-HTPF fresh air heat pump / ventilation heat pump.

The device was successfully tested by manual selection in tuya-local.

Product ID/productKey is currently unknown, so the products block is omitted.

Tested functions:

* Power on/off via DP101
* HVAC modes via DP115
* Target temperature via DP106
* Current/supply air temperature via DP130
* Supply and exhaust air speed via DP102/DP103
* Diagnostic sensors via DP109, DP116, DP119, DP122, DP123, DP124, DP126
