### PR TITLE
Update Funai ERW-150 damper labels

### DIFF
--- a/custom_components/tuya_local/devices/funai_erw150_ventilation.yaml
+++ b/custom_components/tuya_local/devices/funai_erw150_ventilation.yaml
@@ -39,9 +39,9 @@ entities:
           - dps_val: "Manual"
             value: "Manual"
           - dps_val: "Auto_1"
-            value: "Auto 1"
+            value: "+16 °C"
           - dps_val: "Auto_2"
-            value: "Auto 2"
+            value: "+20 °C"
 
   - entity: number
     name: Damper position


### PR DESCRIPTION
Follow-up to #4074.

This updates the Funai ERW-150 DP 102 damper select labels to match the device UI:

- `Auto_1` -> `+16 °C`
- `Auto_2` -> `+20 °C`
- `Manual` remains `Manual`

The raw DP values are unchanged, only the Home Assistant select labels are adjusted.

Validation:
- Parsed `custom_components/tuya_local/devices/funai_erw150_ventilation.yaml` with PyYAML and confirmed the DP 102 mapping.
- Full pytest suite was not run locally because this checkout does not have pytest/uv installed.