### PR TITLE
added Djive ARC Portable Fan

### DIFF
--- a/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
+++ b/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
@@ -47,14 +47,14 @@ entities:
           - value: true
 
   - entity: switch
-    name: UV Sterilization
+    translation_key: uv_sterilization
     dps:
       - id: 102
         type: boolean
         name: switch
 
   - entity: switch
-    name: Sound
+    translation_key: sound
     dps:
       - id: 13
         type: boolean
@@ -86,7 +86,7 @@ entities:
         name: sensor
 
   - entity: sensor
-    name: Filter life
+    translation_key: filter_life
     category: diagnostic
     dps:
       - id: 103
@@ -94,11 +94,11 @@ entities:
         name: sensor
         unit: "%"
 
-#  - entity: button
-#    name: Reset filter
-#    class: restart
-#    category: config
-#    dps:
-#      - id: 104
-#        type: boolean
-#        name: button
+  - entity: button
+    translation_key: filter_reset
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        optional: true
+        name: button

--- a/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
+++ b/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
@@ -1,6 +1,6 @@
 name: ARC Portable fan
 products:
-  - id: bffbd63dd60876f9e6fnay
+  - id: 4srsoiozpa7wd9ha
     manufacturer: djive
     model: ARC Portable
 entities:

--- a/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
+++ b/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
@@ -1,10 +1,11 @@
-name: ARC Portable fan
+name: Portable fan
 products:
   - id: 4srsoiozpa7wd9ha
     manufacturer: djive
     model: ARC Portable
 entities:
   - entity: fan
+    translation_key: fan_with_presets
     dps:
       - id: 1
         name: switch
@@ -45,7 +46,9 @@ entities:
           - dps_val: 0
             value: false
           - value: true
-
+      - id: 24
+        type: bitfield
+        name: fault_code
   - entity: switch
     translation_key: uv_sterilization
     dps:

--- a/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
+++ b/custom_components/tuya_local/devices/djive_arc_portable_fan.yaml
@@ -1,0 +1,104 @@
+name: ARC Portable fan
+products:
+  - id: bffbd63dd60876f9e6fnay
+    manufacturer: djive
+    model: ARC Portable
+entities:
+  - entity: fan
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 2
+        name: preset_mode
+        type: string
+        optional: true
+        mapping:
+          - dps_val: close
+            value: normal
+          - dps_val: auto
+            value: smart
+          - dps_val: strong
+            value: strong
+          - dps_val: fresh
+            value: fresh
+          - dps_val: sleep
+            value: sleep
+      - id: 3
+        name: speed
+        type: integer
+        range:
+          min: 1
+          max: 9
+      - id: 5
+        type: boolean
+        name: oscillate
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 24
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+
+  - entity: switch
+    name: UV Sterilization
+    dps:
+      - id: 102
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Sound
+    dps:
+      - id: 13
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    class: pm25
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: "μg/m³"
+
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+
+  - entity: binary_sensor
+    class: battery_charging
+    category: diagnostic
+    dps:
+      - id: 106
+        type: boolean
+        name: sensor
+
+  - entity: sensor
+    name: Filter life
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: "%"
+
+#  - entity: button
+#    name: Reset filter
+#    class: restart
+#    category: config
+#    dps:
+#      - id: 104
+#        type: boolean
+#        name: button


### PR DESCRIPTION
added support for Djive ARC Portable Fan

### Command:
- fan (speed, oscillate, preset mode)
- sound
- UV Sterilization

### Sensor:
- PM2.5

### Diagnostic:
- battery
- Filter life
- battery charging
- problem

### Configuration:
- filter reset

DP mapping check with Tuya Developer Platform and confirmed on my own device.

