### PR TITLE
Fix mypin_6l_videopetfeeder, added various compatible models

### DIFF
--- a/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
+++ b/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
@@ -3,15 +3,6 @@ products:
   - id: 8zrzjldq07tlxnlv
     manufacturer: Mypin
     model: 6L
-  - id: 8zrzjldq07tlxnlv
-    manufacturer: Pretty Paws
-    model: PP003
-  - id: 8zrzjldq07tlxnlv
-    manufacturer: Petrust
-    model: PP003
-  - id: 8zrzjldq07tlxnlv
-    manufacturer: Lexmart
-    model: PP003
 entities:
   - entity: switch
     name: Camera record
@@ -209,7 +200,7 @@ entities:
         optional: true
         name: backup_log
   - entity: text
-    name: Meal plan
+    translation_key: Meal plan
     icon: "mdi:calendar-clock"
     dps:
       - id: 237

--- a/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
+++ b/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
@@ -3,6 +3,15 @@ products:
   - id: 8zrzjldq07tlxnlv
     manufacturer: Mypin
     model: 6L
+  - id: 8zrzjldq07tlxnlv
+    manufacturer: Pretty Paws
+    model: PP003
+  - id: 8zrzjldq07tlxnlv
+    manufacturer: Petrust
+    model: PP003
+  - id: 8zrzjldq07tlxnlv
+    manufacturer: Lexmart
+    model: PP003
 entities:
   - entity: switch
     name: Camera record
@@ -202,7 +211,6 @@ entities:
   - entity: text
     name: Meal plan
     icon: "mdi:calendar-clock"
-    hidden: false
     dps:
       - id: 237
         type: string

--- a/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
+++ b/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
@@ -200,8 +200,7 @@ entities:
         optional: true
         name: backup_log
   - entity: text
-    name: Meal plan
-    icon: "mdi:calendar-clock"
+    translation_key: meal_plan
     dps:
       - id: 237
         type: string

--- a/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
+++ b/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
@@ -195,14 +195,19 @@ entities:
         range:
           min: 0
           max: 255
-      - id: 237
-        type: string
-        optional: true
-        name: schedule
       - id: 247
         type: string
         optional: true
         name: backup_log
+  - entity: text
+    name: Meal plan
+    icon: "mdi:calendar-clock"
+    hidden: false
+    dps:
+      - id: 237
+        type: string
+        name: value
+        optional: true
   - entity: sensor
     class: battery
     category: diagnostic
@@ -306,18 +311,22 @@ entities:
         mapping:
           - scale: 10
   - entity: number
-    name: Log offline feed
-    category: config
+    name: Manual feed
     icon: "mdi:food-drumstick"
     dps:
       - id: 245
         type: integer
-        optional: true
         name: value
+        optional: true
+        persist: false
         unit: portions
         range:
-          min: 0
-          max: 99
+          min: 1
+          max: 10
+        mapping:
+          - dps_val: -2000
+            hidden: true
+            value: 0
   - entity: event
     name: Feed
     icon: "mdi:food-drumstick"

--- a/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
+++ b/custom_components/tuya_local/devices/mypin_6l_videopetfeeder.yaml
@@ -200,7 +200,7 @@ entities:
         optional: true
         name: backup_log
   - entity: text
-    translation_key: Meal plan
+    name: Meal plan
     icon: "mdi:calendar-clock"
     dps:
       - id: 237
@@ -310,7 +310,7 @@ entities:
         mapping:
           - scale: 10
   - entity: number
-    name: Manual feed
+    translation_key: manual_feed
     icon: "mdi:food-drumstick"
     dps:
       - id: 245


### PR DESCRIPTION
## Changes to mypin_6l_videopetfeeder.yaml

### Fixes
- DP 245 (feed_publish): renamed from "Log offline feed" to "Manual feed"
- DP 245: added `persist: false` (device does not echo DP back after feeding)
- DP 245: corrected range (min: 1, max: 10) and added hidden mapping for idle value -2000

### New entities
- DP 237: added separate `text` entity "Meal plan" for mealplan-card compatibility

### Device info
- Tested on Pretty Paws PP003 / Petrust PP003 / Lexmart PP003
- Same hardware as Mypin 6L (product id: 8zrzjldq07tlxnlv)
- DP 237 uses hex encoding (not base64)
- Cached state example: {"237": "7f1400011000000"} = all days, 14:00, 1 portion, enabled

### Notes
- `persist: false` on DP 245 is essential: the device does not echo the value
  back after dispensing food, causing HA to wait indefinitely without it