### PR TITLE
Add support for YAMAZEN Livinf Fan/AHX-ALD30

### DIFF
--- a/custom_components/tuya_local/devices/yamazen_fan.yaml
+++ b/custom_components/tuya_local/devices/yamazen_fan.yaml
@@ -1,4 +1,4 @@
-name: Yamazen Living Fan
+name: Fan
 products:
   - id: yjxegyhiawfedgah
     manufacturer: Yamazen
@@ -44,25 +44,36 @@ entities:
         type: string
         name: oscillate
         mapping:
-          # --- Write to Device: Map HA boolean to DPS value (Angle) ---
-          # Uncomment the lines below to enable the toggle function.
-          # This example sends "120" (Can be changed to 30/60/90 as desired).
-          #   - value: true
-          #     dps_val: "120"
-          #   - value: false
-          #     dps_val: "OFF"
-
-          # --- Read from Device: Map DPS to HA boolean (oscillating: True) ---
           - dps_val: "OFF"
             value: false
           - dps_val: "120"
             value: true
           - dps_val: "30"
             value: true
+            hidden: true
           - dps_val: "60"
             value: true
+            hidden: true
           - dps_val: "90"
             value: true
+            hidden: true
+  - entity: select
+    name: Fan swing
+    dps:
+      - id: 4
+        type: string
+        name: option
+        mapping:
+          - dps_val: "OFF"
+            value: "Off"
+          - dps_val: "30"
+            value: "30°"
+          - dps_val: "60"
+            value: "60°"
+          - dps_val: "90"
+            value: "90°"
+          - dps_val: "120"
+            value: "120°"
   - entity: number
     translation_key: timer
     class: duration

--- a/custom_components/tuya_local/devices/yamazen_fan.yaml
+++ b/custom_components/tuya_local/devices/yamazen_fan.yaml
@@ -52,7 +52,7 @@ entities:
           #   - value: false
           #     dps_val: "OFF"
 
-          # --- Read from Device: Map existing DPS value to HA boolean (oscillating: True) ---
+          # --- Read from Device: Map DPS to HA boolean (oscillating: True) ---
           - dps_val: "OFF"
             value: false
           - dps_val: "120"

--- a/custom_components/tuya_local/devices/yamazen_fan.yaml
+++ b/custom_components/tuya_local/devices/yamazen_fan.yaml
@@ -1,6 +1,7 @@
 name: Yamazen Living Fan
 products:
-  - manufacturer: Yamazen
+  - id: yjxegyhiawfedgah
+    manufacturer: Yamazen
     model: AHX-ALD30
 entities:
   - entity: fan
@@ -43,13 +44,15 @@ entities:
         type: string
         name: oscillate
         mapping:
-          # --- 書き込み：HA の boolean → DPS値（角度） ---
-          # トグル ON 時は既定で 120° を送る（好みに応じて 30/60/90 へ変更可）
-        #   - value: true
-        #     dps_val: "120"
-        #   - value: false
-        #     dps_val: "OFF"
-          # --- 読み取り：DPS値 → HA の boolean（oscillating） ---
+          # --- Write to Device: Map HA boolean to DPS value (Angle) ---
+          # Uncomment the lines below to enable the toggle function.
+          # This example sends "120" (Can be changed to 30/60/90 as desired).
+          #   - value: true
+          #     dps_val: "120"
+          #   - value: false
+          #     dps_val: "OFF"
+
+          # --- Read from Device: Map existing DPS value to HA boolean (oscillating: True) ---
           - dps_val: "OFF"
             value: false
           - dps_val: "120"
@@ -60,9 +63,6 @@ entities:
             value: true
           - dps_val: "90"
             value: true
-
-
-
   - entity: number
     translation_key: timer
     class: duration

--- a/custom_components/tuya_local/devices/yamazen_fan.yaml
+++ b/custom_components/tuya_local/devices/yamazen_fan.yaml
@@ -1,0 +1,77 @@
+name: Yamazen Living Fan
+products:
+  - manufacturer: Yamazen
+    model: AHX-ALD30
+entities:
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: normal
+            value: normal
+          - dps_val: nature
+            value: nature
+          - dps_val: sleep
+            value: sleep
+      - id: 3
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "1"
+            value: 13
+          - dps_val: "2"
+            value: 25
+          - dps_val: "3"
+            value: 37
+          - dps_val: "4"
+            value: 50
+          - dps_val: "5"
+            value: 63
+          - dps_val: "6"
+            value: 75
+          - dps_val: "7"
+            value: 87
+          - dps_val: "8"
+            value: 100
+      - id: 4
+        type: string
+        name: oscillate
+        mapping:
+          # --- 書き込み：HA の boolean → DPS値（角度） ---
+          # トグル ON 時は既定で 120° を送る（好みに応じて 30/60/90 へ変更可）
+        #   - value: true
+        #     dps_val: "120"
+        #   - value: false
+        #     dps_val: "OFF"
+          # --- 読み取り：DPS値 → HA の boolean（oscillating） ---
+          - dps_val: "OFF"
+            value: false
+          - dps_val: "120"
+            value: true
+          - dps_val: "30"
+            value: true
+          - dps_val: "60"
+            value: true
+          - dps_val: "90"
+            value: true
+
+
+
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 6
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 8


### PR DESCRIPTION
Add support for YAMAZEN Livinf Fan/AHX-ALD30

Note: I couldn't retrieve the Product ID, so it is left blank. The device has been tested and works with this configuration.