### PR TITLE
Ovlaim 809 ceiling fan: add sleep preset mode, make timer a read-only sensor

### DIFF
--- a/custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml
+++ b/custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml
@@ -65,5 +65,6 @@ entities:
     dps:
       - id: 64
         type: integer
+        optional: true
         name: sensor
         unit: min

--- a/custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml
+++ b/custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml
@@ -45,6 +45,8 @@ entities:
             value: fresh
           - dps_val: nature
             value: nature
+          - dps_val: sleep
+            value: sleep
       - id: 62
         name: speed
         type: integer
@@ -56,16 +58,12 @@ entities:
         name: direction
         type: string
         optional: true
-  - entity: number
-    translation_key: timer
+  - entity: sensor
+    translation_key: time_remaining
     class: duration
-    category: config
+    category: diagnostic
     dps:
       - id: 64
-        name: value
         type: integer
-        optional: true
+        name: sensor
         unit: min
-        range:
-          min: 0
-          max: 540


### PR DESCRIPTION
Resolves #5406

Follow-up to #5373. Two corrections to `ovlaim_809_ceiling_fanlight.yaml`, from the device's Tuya cloud specification (product `ftqsaibnb3insvp9`):

### 1. Add the `sleep` fan preset mode (dp61)
The device `fan_mode` enum is `[fresh, nature, sleep]`, but the config mapped only `fresh` and `nature`. This adds the missing `sleep` value so it can be selected from Home Assistant.

### 2. Make the fan timer a read-only sensor (dp64)
`countdown_left_fan` was exposed as a writable `number`. We ran several tests: the device accepts and stores whatever value is written to it, but it never starts a countdown or turns the fan off, so in practice it behaves as read-only. (Working out exactly how the app arms the timer would take deeper investigation that isn't worth the effort right now.) Changed from a writable number to a read-only `sensor` (`time_remaining`, duration, diagnostic).

### Verification
- Real hardware: the sensor reflects the value the device reports; `sleep` is selectable and accepted by the device.
- `uv run yamllint custom_components/tuya_local/devices/ovlaim_809_ceiling_fanlight.yaml` clean
- `uv run pytest tests/test_device_config.py` 32 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
