### PR TITLE
Fix inverted direction mapping for Fanco Eco Silent Deluxe

### DIFF
--- a/custom_components/tuya_local/devices/fanco_ecosilentdeluxe.yaml
+++ b/custom_components/tuya_local/devices/fanco_ecosilentdeluxe.yaml
@@ -28,6 +28,11 @@ entities:
       - id: 8
         name: direction
         type: string
+        mapping:
+          - dps_val: forward
+            value: reverse
+          - dps_val: reverse
+            value: forward
   - entity: light
     dps:
       - id: 15


### PR DESCRIPTION
Fixes the reversed direction mapping for the Fanco Eco Silent Deluxe ceiling fan `fanco_ecosilentdeluxe.yaml`

The existing config exposes DP `8` directly as `direction`, but on this device the raw Tuya `forward` and `reverse` values are physically inverted in Home Assistant.

This PR adds an explicit mapping so that Home Assistant’s `forward` and `reverse` options match the actual fan direction.

Tested locally on 4 Fanco Eco Silent Deluxe fans.

This PR fixes #5409 