### PR TITLE
fix: add 'far' movement state value to ZG-205W mmWave presence sensor

### DIFF
--- a/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
@@ -297,6 +297,8 @@ entities:
             value: Breathe
           - dps_val: none
             value: None
+          - dps_val: far
+            value: Far
   - entity: switch
     name: Small motion self-test
     category: config


### PR DESCRIPTION
## Summary

The ZG-205W (and ZG-205Z, which uses the same DPS mapping) mmWave presence sensor occasionally emits `far` as the DPS 116 value in addition to the already-mapped `large_move`, `small_move`, `breathe`, and `none`.

## Problem

Without a mapping for `far`, tuya-local passes the raw string through to Home Assistant's enum sensor. HA then raises a `ValueError` on every update that sends this value:

```
ValueError: Sensor sensor.presence_sensor_office_pc_movement_state provides state value 'far',
which is not in the list of options provided
```

This produces repeated errors in the HA log and leaves the sensor in an unavailable/unknown state whenever the device reports `far`.

## Fix

Add `far` → `Far` to the DPS 116 mapping. Based on the sensor's near/far detection zones, this value appears to represent stationary presence detected at far range (beyond the active motion zone).

## Testing

Observed on ZG-205Z sensors (same DPS layout as ZG-205W) running current firmware. After adding this mapping, the `ValueError` no longer appears in HA logs and the sensor reports `Far` correctly.