### PR TITLE
(feat) New Device Support - Hiniso 10L Smart Dehumidifier (Model RM10S)

### DIFF
--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -130,23 +130,3 @@ entities:
       - id: 16
         type: boolean
         name: switch
-
-  # SWING (Hidden)
-  - entity: switch
-    name: Swing
-    category: config
-    hidden: true
-    dps:
-      - id: 8
-        type: boolean
-        name: switch
-
-  # SECONDARY HUMIDITY ENUM (Hidden)
-  - entity: sensor
-    name: Secondary Humidity Enum
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 3
-        type: string
-        name: sensor

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -1,4 +1,4 @@
-name: Hiniso 10L Dehumidifier
+name: Hiniso 10L Smart Dehumidifier
 
 entities:
   # CORE HUMIDIFIER CONTROLS
@@ -21,11 +21,11 @@ entities:
         type: string
         mapping:
           - dps_val: dehumidify
-            value: normal
+            value: manual # Dehumidify mode, runs the compressor based on the set target humidity.
           - dps_val: auto
-            value: auto
+            value: comfort # Comfort mode (AU) as per the manual, relies on internal logic to turn on/off compressor based on ambient temperature
           - dps_val: continuous
-            value: continuous
+            value: boost # Continous mode (CO) or the drying mode, runs the compressor continuously
       - id: 6
         name: current_humidity
         type: integer
@@ -44,29 +44,20 @@ entities:
           - dps_val: "off"
             value: false
 
-  # FAN SPEED (Converted to a Select Dropdown)
-  - entity: select
-    name: Fan Speed
-    icon: mdi:fan
+  # FAN SPEED (slider UI)
+  - entity: switch
+    name: High Fan Speed
+    icon: mdi:fan-speed-3
     category: config
     dps:
       - id: 4
-        name: option
         type: string
+        name: switch
         mapping:
-          - dps_val: low
-            value: low
           - dps_val: high
-            value: high
-
-# CHILD LOCK
-  - entity: lock
-    translation_key: child_lock
-    category: config
-    dps:
-      - id: 16
-        type: boolean
-        name: lock
+            value: true
+          - dps_val: low
+            value: false
 
   # TIMER
   - entity: select
@@ -127,3 +118,35 @@ entities:
             value: 23h
           - dps_val: "24hrs"
             value: 24h
+
+  # --- HIDDEN DPS - Features Not Supported/Available for this Specific Unit ---
+
+  # CHILD LOCK (Hidden because physical unit lacks support)
+  - entity: switch
+    translation_key: child_lock
+    category: config
+    hidden: true
+    dps:
+      - id: 16
+        type: boolean
+        name: switch
+
+  # SWING (Hidden)
+  - entity: switch
+    name: Swing
+    category: config
+    hidden: true
+    dps:
+      - id: 8
+        type: boolean
+        name: switch
+
+  # SECONDARY HUMIDITY ENUM (Hidden)
+  - entity: sensor
+    name: Secondary Humidity Enum
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 3
+        type: string
+        name: sensor

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -44,20 +44,18 @@ entities:
           - dps_val: "off"
             value: false
 
-  # FAN SPEED (slider UI)
-  - entity: switch
-    name: High Fan Speed
-    icon: mdi:fan-speed-3
-    category: config
+  # FAN SPEED (Slider UI)
+  - entity: fan
+    translation_key: dehumidifier
     dps:
       - id: 4
+        name: speed
         type: string
-        name: switch
         mapping:
-          - dps_val: high
-            value: true
           - dps_val: low
-            value: false
+            value: low
+          - dps_val: high
+            value: high
 
   # TIMER
   - entity: select
@@ -122,11 +120,11 @@ entities:
   # --- HIDDEN DPS - Features Not Supported/Available for this Specific Unit ---
 
   # CHILD LOCK (Hidden because physical unit lacks support)
-  - entity: switch
+  - entity: lock
     translation_key: child_lock
     category: config
     hidden: true
     dps:
       - id: 16
         type: boolean
-        name: switch
+        name: lock

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -22,7 +22,7 @@ entities:
         type: string
         mapping:
           - dps_val: dehumidify
-            value: manual # Dehumidify mode, runs the compressor based on the set target humidity.
+            value: normal # Dehumidify mode, runs the compressor based on the set target humidity
           - dps_val: auto
             value: comfort # Comfort mode (AU) as per the manual, relies on internal logic to turn on/off compressor based on ambient temperature
           - dps_val: continuous

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -31,6 +31,17 @@ entities:
         name: current_humidity
         type: integer
 
+  # HUMIDITY SENSOR (Making this Sensor available for use in automations)
+  - entity: sensor
+    translation_key: relative_humidity
+    icon: mdi:water-percent
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
   # WATER TANK FULL
   - entity: binary_sensor
     translation_key: tank_full

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -44,15 +44,14 @@ entities:
           - dps_val: "off"
             value: false
 
-  # FAN SPEED
-  - entity: fan
-    translation_key: dehumidifier
+  # FAN SPEED (Converted to a Select Dropdown)
+  - entity: select
+    name: Fan Speed
+    icon: mdi:fan
+    category: config
     dps:
-      - id: 1
-        name: switch
-        type: boolean
       - id: 4
-        name: speed
+        name: option
         type: string
         mapping:
           - dps_val: low
@@ -60,7 +59,7 @@ entities:
           - dps_val: high
             value: high
 
-  # CHILD LOCK
+# CHILD LOCK
   - entity: lock
     translation_key: child_lock
     category: config
@@ -69,7 +68,7 @@ entities:
         type: boolean
         name: lock
 
-  # TIMER (Moved to DP 101)
+  # TIMER
   - entity: select
     translation_key: timer
     category: config
@@ -80,51 +79,51 @@ entities:
         mapping:
           - dps_val: "None"
             value: cancel
-          - dps_val: 1h
+          - dps_val: "1hr"
             value: 1h
-          - dps_val: 2h
+          - dps_val: "2hrs"
             value: 2h
-          - dps_val: 3h
+          - dps_val: "3hrs"
             value: 3h
-          - dps_val: 4h
+          - dps_val: "4hrs"
             value: 4h
-          - dps_val: 5h
+          - dps_val: "5hrs"
             value: 5h
-          - dps_val: 6h
+          - dps_val: "6hrs"
             value: 6h
-          - dps_val: 7h
+          - dps_val: "7hrs"
             value: 7h
-          - dps_val: 8h
+          - dps_val: "8hrs"
             value: 8h
-          - dps_val: 9h
+          - dps_val: "9hrs"
             value: 9h
-          - dps_val: 10h
+          - dps_val: "10hrs"
             value: 10h
-          - dps_val: 11h
+          - dps_val: "11hrs"
             value: 11h
-          - dps_val: 12h
+          - dps_val: "12hrs"
             value: 12h
-          - dps_val: 13h
+          - dps_val: "13hrs"
             value: 13h
-          - dps_val: 14h
+          - dps_val: "14hrs"
             value: 14h
-          - dps_val: 15h
+          - dps_val: "15hrs"
             value: 15h
-          - dps_val: 16h
+          - dps_val: "16hrs"
             value: 16h
-          - dps_val: 17h
+          - dps_val: "17hrs"
             value: 17h
-          - dps_val: 18h
+          - dps_val: "18hrs"
             value: 18h
-          - dps_val: 19h
+          - dps_val: "19hrs"
             value: 19h
-          - dps_val: 20h
+          - dps_val: "20hrs"
             value: 20h
-          - dps_val: 21h
+          - dps_val: "21hrs"
             value: 21h
-          - dps_val: 22h
+          - dps_val: "22hrs"
             value: 22h
-          - dps_val: 23h
+          - dps_val: "23hrs"
             value: 23h
-          - dps_val: 24h
+          - dps_val: "24hrs"
             value: 24h

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -1,0 +1,130 @@
+name: Hiniso 10L Dehumidifier
+
+entities:
+  # CORE HUMIDIFIER CONTROLS
+  - entity: humidifier
+    class: dehumidifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 2
+        name: humidity
+        type: integer
+        range:
+          min: 30
+          max: 90
+        mapping:
+          - step: 5
+      - id: 5
+        name: mode
+        type: string
+        mapping:
+          - dps_val: dehumidify
+            value: normal
+          - dps_val: auto
+            value: auto
+          - dps_val: continuous
+            value: continuous
+      - id: 6
+        name: current_humidity
+        type: integer
+
+  # WATER TANK FULL
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 25
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "on"
+            value: true
+          - dps_val: "off"
+            value: false
+
+  # FAN SPEED
+  - entity: fan
+    translation_key: dehumidifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 4
+        name: speed
+        type: string
+        mapping:
+          - dps_val: low
+            value: low
+          - dps_val: high
+            value: high
+
+  # CHILD LOCK
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 16
+        type: boolean
+        name: lock
+
+  # TIMER (Moved to DP 101)
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 101
+        type: string
+        name: option
+        mapping:
+          - dps_val: "None"
+            value: cancel
+          - dps_val: 1h
+            value: 1h
+          - dps_val: 2h
+            value: 2h
+          - dps_val: 3h
+            value: 3h
+          - dps_val: 4h
+            value: 4h
+          - dps_val: 5h
+            value: 5h
+          - dps_val: 6h
+            value: 6h
+          - dps_val: 7h
+            value: 7h
+          - dps_val: 8h
+            value: 8h
+          - dps_val: 9h
+            value: 9h
+          - dps_val: 10h
+            value: 10h
+          - dps_val: 11h
+            value: 11h
+          - dps_val: 12h
+            value: 12h
+          - dps_val: 13h
+            value: 13h
+          - dps_val: 14h
+            value: 14h
+          - dps_val: 15h
+            value: 15h
+          - dps_val: 16h
+            value: 16h
+          - dps_val: 17h
+            value: 17h
+          - dps_val: 18h
+            value: 18h
+          - dps_val: 19h
+            value: 19h
+          - dps_val: 20h
+            value: 20h
+          - dps_val: 21h
+            value: 21h
+          - dps_val: 22h
+            value: 22h
+          - dps_val: 23h
+            value: 23h
+          - dps_val: 24h
+            value: 24h

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -26,7 +26,7 @@ entities:
           - dps_val: auto
             value: comfort # Comfort mode (AU) as per the manual, relies on internal logic to turn on/off compressor based on ambient temperature
           - dps_val: continuous
-            value: boost # Continous mode (CO) or the drying mode, runs the compressor continuously
+            value: boost # Continuous mode (CO) or the drying mode, runs the compressor continuously
       - id: 6
         name: current_humidity
         type: integer
@@ -34,6 +34,7 @@ entities:
   # WATER TANK FULL
   - entity: binary_sensor
     translation_key: tank_full
+    icon: mdi:water-alert-outline
     category: diagnostic
     dps:
       - id: 25
@@ -47,7 +48,7 @@ entities:
 
   # FAN SPEED
   - entity: select
-    translation_key: fan_speed
+    name: Fan Speed
     icon: mdi:fan
     category: config
     dps:
@@ -56,9 +57,9 @@ entities:
         name: option
         mapping:
           - dps_val: low
-            value: low
+            value: Low
           - dps_val: high
-            value: high
+            value: High
 
   # TIMER
   - entity: select

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -23,12 +23,16 @@ entities:
         name: mode
         type: string
         mapping:
+          # Dehumidify mode, runs the compressor based on set target humidity
           - dps_val: dehumidify
-            value: normal # Dehumidify mode, runs the compressor based on the set target humidity
+            value: normal
+          # Comfort mode (AU) as per the manual, relies on internal logic.
+          # it controls the compressor based on ambient temperature.
           - dps_val: auto
-            value: comfort # Comfort mode (AU) as per the manual, relies on internal logic to turn on/off compressor based on ambient temperature
+            value: comfort
+          # Continuous mode (CO) runs the compressor continuously
           - dps_val: continuous
-            value: boost # Continuous mode (CO) or the drying mode, runs the compressor continuously
+            value: boost
       - id: 6
         name: current_humidity
         type: integer

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -1,3 +1,4 @@
+# HINISO Model: RM10S (10L Smart Dehumidifier)
 name: Hiniso 10L Smart Dehumidifier
 
 entities:
@@ -44,13 +45,15 @@ entities:
           - dps_val: "off"
             value: false
 
-  # FAN SPEED (Slider UI)
-  - entity: fan
-    translation_key: dehumidifier
+  # FAN SPEED
+  - entity: select
+    translation_key: fan_speed
+    icon: mdi:fan
+    category: config
     dps:
       - id: 4
-        name: speed
         type: string
+        name: option
         mapping:
           - dps_val: low
             value: low

--- a/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_10L_dehumidifier.yaml
@@ -1,4 +1,6 @@
 # HINISO Model: RM10S (10L Smart Dehumidifier)
+# Device ID: d7696cfb645eb04673gobl
+
 name: Hiniso 10L Smart Dehumidifier
 
 entities:
@@ -33,7 +35,7 @@ entities:
 
   # HUMIDITY SENSOR (Making this Sensor available for use in automations)
   - entity: sensor
-    translation_key: relative_humidity
+    name: Relative Humidity
     icon: mdi:water-percent
     dps:
       - id: 6

--- a/custom_components/tuya_local/devices/hiniso_rm10s_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/hiniso_rm10s_dehumidifier.yaml
@@ -1,12 +1,12 @@
 # HINISO Model: RM10S (10L Smart Dehumidifier)
-# Device ID: d7696cfb645eb04673gobl
 
-name: Hiniso 10L Smart Dehumidifier
+name: Dehumidifier
 
 entities:
   # CORE HUMIDIFIER CONTROLS
   - entity: humidifier
     class: dehumidifier
+    translation_key: extended
     dps:
       - id: 1
         name: switch
@@ -32,27 +32,14 @@ entities:
             value: comfort
           # Continuous mode (CO) runs the compressor continuously
           - dps_val: continuous
-            value: boost
+            value: continuous
       - id: 6
         name: current_humidity
         type: integer
 
-  # HUMIDITY SENSOR (Making this Sensor available for use in automations)
-  - entity: sensor
-    name: Relative Humidity
-    icon: mdi:water-percent
-    dps:
-      - id: 6
-        type: integer
-        name: sensor
-        unit: "%"
-        class: measurement
-
   # WATER TANK FULL
   - entity: binary_sensor
     translation_key: tank_full
-    icon: mdi:water-alert-outline
-    category: diagnostic
     dps:
       - id: 25
         type: string
@@ -64,19 +51,19 @@ entities:
             value: false
 
   # FAN SPEED
-  - entity: select
-    name: Fan Speed
-    icon: mdi:fan
-    category: config
+  - entity: fan
     dps:
+      - id: 1
+        name: switch
+        type: boolean
       - id: 4
         type: string
-        name: option
+        name: speed
         mapping:
           - dps_val: low
-            value: Low
+            value: 50
           - dps_val: high
-            value: High
+            value: 100
 
   # TIMER
   - entity: select
@@ -90,53 +77,53 @@ entities:
           - dps_val: "None"
             value: cancel
           - dps_val: "1hr"
-            value: 1h
+            value: "1h"
           - dps_val: "2hrs"
-            value: 2h
+            value: "2h"
           - dps_val: "3hrs"
-            value: 3h
+            value: "3h"
           - dps_val: "4hrs"
-            value: 4h
+            value: "4h"
           - dps_val: "5hrs"
-            value: 5h
+            value: "5h"
           - dps_val: "6hrs"
-            value: 6h
+            value: "6h"
           - dps_val: "7hrs"
-            value: 7h
+            value: "7h"
           - dps_val: "8hrs"
-            value: 8h
+            value: "8h"
           - dps_val: "9hrs"
-            value: 9h
+            value: "9h"
           - dps_val: "10hrs"
-            value: 10h
+            value: "10h"
           - dps_val: "11hrs"
-            value: 11h
+            value: "11h"
           - dps_val: "12hrs"
-            value: 12h
+            value: "12h"
           - dps_val: "13hrs"
-            value: 13h
+            value: "13h"
           - dps_val: "14hrs"
-            value: 14h
+            value: "14h"
           - dps_val: "15hrs"
-            value: 15h
+            value: "15h"
           - dps_val: "16hrs"
-            value: 16h
+            value: "16h"
           - dps_val: "17hrs"
-            value: 17h
+            value: "17h"
           - dps_val: "18hrs"
-            value: 18h
+            value: "18h"
           - dps_val: "19hrs"
-            value: 19h
+            value: "19h"
           - dps_val: "20hrs"
-            value: 20h
+            value: "20h"
           - dps_val: "21hrs"
-            value: 21h
+            value: "21h"
           - dps_val: "22hrs"
-            value: 22h
+            value: "22h"
           - dps_val: "23hrs"
-            value: 23h
+            value: "23h"
           - dps_val: "24hrs"
-            value: 24h
+            value: "24h"
 
   # --- HIDDEN DPS - Features Not Supported/Available for this Specific Unit ---
 


### PR DESCRIPTION
## Description
Adds support for the Hiniso 10L Smart Dehumidifier (Model RM10S) 
The existing hiniso dehumidifier integration (hiniso_dehumidifier.yaml) didn't work probably becasue of a new firmware, as most of the DP IDs are different in this model, few are noted below.

Protocol Version: 3.5

### Mapping Notes:
* **Modes (DP 5):** 
  * `dehumidify` -> `Normal` (Compressor reacts to manual RH target)
  * `auto` -> (AU) `comfort` (Hardware ignores manual target in this mode and sets internal compressor logic based on ambient room temperature).
  * `continuous` -> (CO) `boost` (Hardware ignores humidity sensors and runs compressor 24/7).
  * *Note on DP 2:* When the unit enters `auto` mode, the Tuya Wi-Fi chip overrides DP 2 and hardcodes it to `30`. This is hardware-level behavior, but it's not eactly right, the compressor logic is internal it depends on the ambient temerature and follows a hardware level logic, which is this: temp>27 = humidity 50, 20<temp<27 = humidity 55, and 5<temp<20 = humidity 60%. temp<5 = compressor turns off. But DP-2 is set to 30% for whatever reason, this is a known hardware limitation.
* **Child Lock (DP 16):** This unit doesn't have that feature, but the Tuya chip broadcasts and accepts the command. Mapped as a hidden `config` entity as without this the Stage 2 of pairing fails (device doesn't show up).
* **Timer:** Moved to DP 101

## Device Signature
```
"cached_state": {
      "updated_at": 1782400067.400447,
      "1": true,
      "2": 50,
      "4": "high",
      "5": "dehumidify",
      "6": 59,
      "16": false,
      "25": "off",
      "101": "None"
    }
```