### PR TITLE
feat(laresar_l6_nex_vacuum): add Laresar L6 NEX robot vacuum and mop

### DIFF
--- a/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
+++ b/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
@@ -63,36 +63,8 @@ entities:
       - id: 1
         type: boolean
         name: activate
-        optional: true
-        mapping:
-          - dps_val: false
-            constraint: pause
-            conditions:
-              - dps_val: true
-                value: false
-              - dps_val: false
-                value: false
-                hidden: true
-              - dps_val: null
-                value: false
-                hidden: true
-          - dps_val: true
-            constraint: pause
-            conditions:
-              - dps_val: false
-                value: true
-              - dps_val: true
-                value: true
-                hidden: true
-              - dps_val: null
-                value: true
-                hidden: true
-          - dps_val: null
-            value: false
-            hidden: true
       - id: 2
         type: boolean
-        optional: true
         name: pause
         hidden: true
 

--- a/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
+++ b/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
@@ -126,9 +126,8 @@ entities:
         name: button
 
   - entity: select
-    name: Cleaning mode
+    translation_key: cleaning_mode
     category: config
-    icon: "mdi:robot-vacuum"
     dps:
       - id: 4
         type: string
@@ -314,7 +313,6 @@ entities:
           max: 100
 
   - entity: sensor
-    name: Battery
     class: battery
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
+++ b/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
@@ -1,0 +1,450 @@
+name: Robot vacuum and mop
+products:
+  - id: pi5tljdjcchcn0mr
+    name: L6 Nex
+    manufacturer: Laresar
+    model: L6 NEX
+
+entities:
+  - entity: vacuum
+    dps:
+      - id: 5
+        type: string
+        name: status
+        readonly: true
+        mapping:
+          - dps_val: "charge_done"
+            value: "docked"
+          - dps_val: "charging"
+            value: "docked"
+          - dps_val: "standby"
+            value: "idle"
+          - dps_val: "smart"
+            value: "cleaning"
+          - dps_val: "zone_clean"
+            value: "cleaning"
+          - dps_val: "part_clean"
+            value: "cleaning"
+          - dps_val: "cleaning"
+            value: "cleaning"
+          - dps_val: "paused"
+            value: "paused"
+          - dps_val: "goto_pos"
+            value: "returning"
+          - dps_val: "goto_charge"
+            value: "returning"
+          - dps_val: "pos_arrived"
+            value: "idle"
+          - dps_val: "sleep"
+            value: "idle"
+          - dps_val: "pos_unarrive"
+            value: "error"
+      - id: 8
+        type: integer
+        name: battery_level
+        readonly: true
+        unit: "%"
+
+  - entity: button
+    name: Start cleaning
+    category: config
+    icon: "mdi:play"
+    dps:
+      - id: 1
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Pause
+    category: config
+    icon: "mdi:pause"
+    dps:
+      - id: 2
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Return to dock
+    category: config
+    icon: "mdi:home"
+    dps:
+      - id: 3
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Find robot
+    category: config
+    icon: "mdi:map-marker"
+    dps:
+      - id: 11
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Collect dust now
+    category: config
+    icon: "mdi:vacuum"
+    dps:
+      - id: 38
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Reset edge brush
+    category: config
+    icon: "mdi:brush"
+    dps:
+      - id: 18
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Reset roll brush
+    category: config
+    icon: "mdi:brush"
+    dps:
+      - id: 20
+        type: boolean
+        name: button
+
+  - entity: button
+    translation_key: filter_reset
+    category: config
+    dps:
+      - id: 22
+        type: boolean
+        name: button
+
+  - entity: button
+    name: Reset map
+    category: config
+    icon: "mdi:map-outline"
+    dps:
+      - id: 13
+        type: boolean
+        name: button
+
+  - entity: select
+    name: Cleaning mode
+    category: config
+    icon: "mdi:robot-vacuum"
+    dps:
+      - id: 4
+        type: string
+        name: option
+        mapping:
+          - dps_val: "smart"
+            value: "Auto"
+          - dps_val: "chargego"
+            value: "Return to charge"
+          - dps_val: "zone"
+            value: "Zone clean"
+          - dps_val: "pose"
+            value: "Spot clean"
+          - dps_val: "part"
+            value: "Room clean"
+
+  - entity: select
+    name: Suction power
+    category: config
+    icon: "mdi:fan"
+    dps:
+      - id: 9
+        type: string
+        name: option
+        mapping:
+          - dps_val: "Close"
+            value: "Off"
+          - dps_val: "gentle"
+            value: "Eco"
+          - dps_val: "normal"
+            value: "Standard"
+          - dps_val: "strong"
+            value: "Strong"
+
+  - entity: select
+    name: Water tank level
+    category: config
+    icon: "mdi:water"
+    dps:
+      - id: 10
+        type: string
+        name: option
+        mapping:
+          - dps_val: "low"
+            value: "Low"
+          - dps_val: "middle"
+            value: "Medium"
+          - dps_val: "high"
+            value: "High"
+          - dps_val: "closed"
+            value: "Closed"
+
+  - entity: select
+    name: Work mode
+    category: config
+    icon: "mdi:cog"
+    dps:
+      - id: 41
+        type: string
+        name: option
+        mapping:
+          - dps_val: "both_work"
+            value: "Vacuum & mop"
+          - dps_val: "only_sweep"
+            value: "Vacuum only"
+          - dps_val: "only_mop"
+            value: "Mop only"
+
+  - entity: select
+    name: Carpet clean preference
+    category: config
+    icon: "mdi:rug"
+    dps:
+      - id: 44
+        type: string
+        name: option
+        mapping:
+          - dps_val: "adaptive"
+            value: "Zig zag cleaning"
+          - dps_val: "evade"
+            value: "Y shaped cleaning"
+          - dps_val: "ignore"
+            value: "Edge clean only"
+
+  - entity: select
+    name: Dust collection frequency
+    category: config
+    icon: "mdi:vacuum"
+    dps:
+      - id: 37
+        type: integer
+        name: option
+        mapping:
+          - dps_val: 0
+            value: "Never"
+          - dps_val: 1
+            value: "Once per clean"
+          - dps_val: 2
+            value: "Twice per clean"
+          - dps_val: 3
+            value: "3 times per clean"
+          - dps_val: 4
+            value: "4 times per clean"
+
+  - entity: select
+    translation_key: language
+    category: config
+    dps:
+      - id: 36
+        type: string
+        name: option
+        mapping:
+          - dps_val: "chinese_simplified"
+            value: "chinese"
+          - dps_val: "chinese_traditional"
+            value: "chinese_traditional"
+          - dps_val: "english"
+            value: "english"
+          - dps_val: "german"
+            value: "german"
+          - dps_val: "french"
+            value: "french"
+          - dps_val: "russian"
+            value: "russian"
+          - dps_val: "spanish"
+            value: "spanish"
+          - dps_val: "korean"
+            value: "korean"
+          - dps_val: "latin"
+            value: "latin"
+          - dps_val: "portuguese"
+            value: "portuguese"
+          - dps_val: "japanese"
+            value: "japanese"
+          - dps_val: "italian"
+            value: "italian"
+
+  - entity: switch
+    translation_key: do_not_disturb
+    category: config
+    dps:
+      - id: 25
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Resume cleaning
+    category: config
+    icon: "mdi:backup-restore"
+    dps:
+      - id: 27
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Customize mode
+    category: config
+    icon: "mdi:cog"
+    dps:
+      - id: 39
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Auto boost
+    category: config
+    icon: "mdi:rocket-launch"
+    dps:
+      - id: 45
+        type: boolean
+        name: switch
+
+  - entity: number
+    translation_key: volume
+    category: config
+    dps:
+      - id: 26
+        type: integer
+        name: value
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+
+  - entity: sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 8
+        type: integer
+        name: sensor
+        readonly: true
+        unit: "%"
+
+  - entity: sensor
+    name: Clean time
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 6
+        type: integer
+        name: sensor
+        unit: "min"
+        readonly: true
+
+  - entity: sensor
+    name: Clean area
+    class: area
+    category: diagnostic
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: "m²"
+        readonly: true
+
+  - entity: sensor
+    name: Edge brush life
+    category: diagnostic
+    icon: "mdi:brush"
+    dps:
+      - id: 17
+        type: integer
+        name: sensor
+        unit: "h"
+        readonly: true
+
+  - entity: sensor
+    name: Roll brush life
+    category: diagnostic
+    icon: "mdi:brush"
+    dps:
+      - id: 19
+        type: integer
+        name: sensor
+        unit: "h"
+        readonly: true
+
+  - entity: sensor
+    translation_key: filter_life
+    category: diagnostic
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        unit: "h"
+        readonly: true
+
+  - entity: sensor
+    name: Mop life
+    category: diagnostic
+    icon: "mdi:broom"
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: "min"
+        readonly: true
+
+  - entity: sensor
+    name: Total clean area
+    class: area
+    category: diagnostic
+    dps:
+      - id: 29
+        type: integer
+        name: sensor
+        unit: "m²"
+        readonly: true
+
+  - entity: sensor
+    name: Total clean count
+    category: diagnostic
+    dps:
+      - id: 30
+        type: integer
+        name: sensor
+        readonly: true
+
+  - entity: sensor
+    name: Total clean time
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 31
+        type: integer
+        name: sensor
+        unit: "min"
+        readonly: true
+
+  - entity: sensor
+    name: Mop state
+    class: enum
+    category: diagnostic
+    icon: "mdi:broom"
+    dps:
+      - id: 40
+        type: string
+        name: sensor
+        readonly: true
+        mapping:
+          - dps_val: "installed"
+            value: "Installed"
+          - dps_val: "none"
+            value: "Not installed"
+
+  - entity: binary_sensor
+    name: Fault status
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 28
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true

--- a/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
+++ b/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
@@ -39,6 +39,12 @@ entities:
             value: "idle"
           - dps_val: "pos_unarrive"
             value: "error"
+      - id: 4
+        type: string
+        name: command
+        mapping:
+          - dps_val: "chargego"
+            value: "return_to_base"
       - id: 9
         type: string
         name: fan_speed
@@ -54,33 +60,41 @@ entities:
       - id: 11
         type: boolean
         name: locate
-
-  - entity: button
-    name: Start cleaning
-    category: config
-    icon: "mdi:play"
-    dps:
       - id: 1
         type: boolean
-        name: button
-
-  - entity: button
-    name: Pause
-    category: config
-    icon: "mdi:pause"
-    dps:
+        name: activate
+        optional: true
+        mapping:
+          - dps_val: false
+            constraint: pause
+            conditions:
+              - dps_val: true
+                value: false
+              - dps_val: false
+                value: false
+                hidden: true
+              - dps_val: null
+                value: false
+                hidden: true
+          - dps_val: true
+            constraint: pause
+            conditions:
+              - dps_val: false
+                value: true
+              - dps_val: true
+                value: true
+                hidden: true
+              - dps_val: null
+                value: true
+                hidden: true
+          - dps_val: null
+            value: false
+            hidden: true
       - id: 2
         type: boolean
-        name: button
-
-  - entity: button
-    name: Return to dock
-    category: config
-    icon: "mdi:home"
-    dps:
-      - id: 3
-        type: boolean
-        name: button
+        optional: true
+        name: pause
+        hidden: true
 
   - entity: button
     name: Collect dust now

--- a/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
+++ b/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
@@ -150,6 +150,14 @@ entities:
     translation_key: mopping
     category: config
     dps:
+      - id: 40
+        type: string
+        name: available
+        mapping:
+          - dps_val: "installed"
+            value: true
+          - dps_val: "none"
+            value: false
       - id: 10
         type: string
         name: option
@@ -357,6 +365,14 @@ entities:
     category: diagnostic
     icon: "mdi:broom"
     dps:
+      - id: 40
+        type: string
+        name: available
+        mapping:
+          - dps_val: "installed"
+            value: true
+          - dps_val: "none"
+            value: false
       - id: 23
         type: integer
         name: sensor

--- a/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
+++ b/custom_components/tuya_local/devices/l6_nex_robot_vacuum.yaml
@@ -39,11 +39,21 @@ entities:
             value: "idle"
           - dps_val: "pos_unarrive"
             value: "error"
-      - id: 8
-        type: integer
-        name: battery_level
-        readonly: true
-        unit: "%"
+      - id: 9
+        type: string
+        name: fan_speed
+        mapping:
+          - dps_val: "Close"
+            value: "off"
+          - dps_val: "gentle"
+            value: "gentle"
+          - dps_val: "normal"
+            value: "normal"
+          - dps_val: "strong"
+            value: "strong"
+      - id: 11
+        type: boolean
+        name: locate
 
   - entity: button
     name: Start cleaning
@@ -69,15 +79,6 @@ entities:
     icon: "mdi:home"
     dps:
       - id: 3
-        type: boolean
-        name: button
-
-  - entity: button
-    name: Find robot
-    category: config
-    icon: "mdi:map-marker"
-    dps:
-      - id: 11
         type: boolean
         name: button
 
@@ -126,8 +127,9 @@ entities:
         name: button
 
   - entity: select
-    translation_key: cleaning_mode
+    name: Cleaning pattern
     category: config
+    icon: "mdi:robot-vacuum"
     dps:
       - id: 4
         type: string
@@ -145,56 +147,36 @@ entities:
             value: "Room clean"
 
   - entity: select
-    name: Suction power
+    translation_key: mopping
     category: config
-    icon: "mdi:fan"
-    dps:
-      - id: 9
-        type: string
-        name: option
-        mapping:
-          - dps_val: "Close"
-            value: "Off"
-          - dps_val: "gentle"
-            value: "Eco"
-          - dps_val: "normal"
-            value: "Standard"
-          - dps_val: "strong"
-            value: "Strong"
-
-  - entity: select
-    name: Water tank level
-    category: config
-    icon: "mdi:water"
     dps:
       - id: 10
         type: string
         name: option
         mapping:
-          - dps_val: "low"
-            value: "Low"
-          - dps_val: "middle"
-            value: "Medium"
-          - dps_val: "high"
-            value: "High"
           - dps_val: "closed"
-            value: "Closed"
+            value: "off"
+          - dps_val: "low"
+            value: "low"
+          - dps_val: "middle"
+            value: "medium"
+          - dps_val: "high"
+            value: "high"
 
   - entity: select
-    name: Work mode
+    translation_key: cleaning_mode
     category: config
-    icon: "mdi:cog"
     dps:
       - id: 41
         type: string
         name: option
         mapping:
           - dps_val: "both_work"
-            value: "Vacuum & mop"
+            value: "sweep_and_mop"
           - dps_val: "only_sweep"
-            value: "Vacuum only"
+            value: "sweep"
           - dps_val: "only_mop"
-            value: "Mop only"
+            value: "mop"
 
   - entity: select
     name: Carpet clean preference
@@ -319,7 +301,6 @@ entities:
       - id: 8
         type: integer
         name: sensor
-        readonly: true
         unit: "%"
 
   - entity: sensor
@@ -331,7 +312,6 @@ entities:
         type: integer
         name: sensor
         unit: "min"
-        readonly: true
 
   - entity: sensor
     name: Clean area
@@ -342,7 +322,6 @@ entities:
         type: integer
         name: sensor
         unit: "m²"
-        readonly: true
 
   - entity: sensor
     name: Edge brush life
@@ -353,7 +332,6 @@ entities:
         type: integer
         name: sensor
         unit: "h"
-        readonly: true
 
   - entity: sensor
     name: Roll brush life
@@ -364,7 +342,6 @@ entities:
         type: integer
         name: sensor
         unit: "h"
-        readonly: true
 
   - entity: sensor
     translation_key: filter_life
@@ -374,7 +351,6 @@ entities:
         type: integer
         name: sensor
         unit: "h"
-        readonly: true
 
   - entity: sensor
     name: Mop life
@@ -385,7 +361,6 @@ entities:
         type: integer
         name: sensor
         unit: "min"
-        readonly: true
 
   - entity: sensor
     name: Total clean area
@@ -396,7 +371,6 @@ entities:
         type: integer
         name: sensor
         unit: "m²"
-        readonly: true
 
   - entity: sensor
     name: Total clean count
@@ -405,7 +379,6 @@ entities:
       - id: 30
         type: integer
         name: sensor
-        readonly: true
 
   - entity: sensor
     name: Total clean time
@@ -416,7 +389,6 @@ entities:
         type: integer
         name: sensor
         unit: "min"
-        readonly: true
 
   - entity: sensor
     name: Mop state
@@ -427,7 +399,6 @@ entities:
       - id: 40
         type: string
         name: sensor
-        readonly: true
         mapping:
           - dps_val: "installed"
             value: "Installed"
@@ -435,7 +406,6 @@ entities:
             value: "Not installed"
 
   - entity: binary_sensor
-    name: Fault status
     class: problem
     category: diagnostic
     dps:
@@ -446,3 +416,6 @@ entities:
           - dps_val: 0
             value: false
           - value: true
+      - id: 28
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
## Summary

- Adds device config for the Laresar L6 NEX robot vacuum and mop (product ID `pi5tljdjcchcn0mr`)
- Tested locally against a real device running in Home Assistant

## Entities

- **Vacuum** — status and battery level (docked/cleaning/paused/returning/idle/error)
- **Buttons** — start cleaning, pause, return to dock, find robot, collect dust, reset edge brush, reset roll brush, reset filter, reset map
- **Selects** — cleaning mode, suction power, water tank level, work mode, carpet clean preference, dust collection frequency, language
- **Switches** — do not disturb, resume cleaning, customize mode, auto boost
- **Number** — volume (0–100%)
- **Sensors** — battery, clean time, clean area, edge brush life, roll brush life, filter life, mop life, total clean area, total clean count, total clean time, mop state
- **Binary sensor** — fault status (note: also shows as active when do not disturb mode is enabled)

## Notes

- Map/room selection features (DPs 14, 15, 16) are not supported locally; those require the cloud app
- DPS values confirmed against the Tuya IoT "Query Things Data Model" API