### PR TITLE
Add Hauslane IN-R110 range hood

### DIFF
--- a/custom_components/tuya_local/devices/hauslane_in_r110_rangehood.yaml
+++ b/custom_components/tuya_local/devices/hauslane_in_r110_rangehood.yaml
@@ -43,18 +43,18 @@ entities:
   - entity: sensor
     name: Baffle filter
     category: diagnostic
+    class: duration
     dps:
       - id: 102
         type: integer
         name: sensor
         unit: h
-        class: measurement
   - entity: sensor
     name: Charcoal filter
     category: diagnostic
+    class: duration
     dps:
       - id: 103
         type: integer
         name: sensor
         unit: h
-        class: measurement

--- a/custom_components/tuya_local/devices/hauslane_in_r110_rangehood.yaml
+++ b/custom_components/tuya_local/devices/hauslane_in_r110_rangehood.yaml
@@ -1,0 +1,60 @@
+name: Range hood
+products:
+  - id: tql6vskv9hlesoav
+    manufacturer: Hauslane
+    model: IN-R110
+entities:
+  - entity: fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 10
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "off"
+            value: 0
+          - dps_val: low
+            value: 25
+          - dps_val: middle
+            value: 50
+          - dps_val: high
+            value: 75
+          - dps_val: max
+            value: 100
+  - entity: light
+    dps:
+      - id: 4
+        type: boolean
+        name: switch
+  - entity: number
+    name: Delay shutoff
+    class: duration
+    category: config
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 5
+  - entity: sensor
+    name: Baffle filter
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: h
+        class: measurement
+  - entity: sensor
+    name: Charcoal filter
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: h
+        class: measurement


### PR DESCRIPTION
Adds a device config for the **Hauslane IN-R110** kitchen range hood (Tuya category `yyj`, product id `tql6vskv9hlesoav`).

Entities:
- **fan** — power (dp 1) + speed (dp 10: off/low/middle/high/max)
- **light** (dp 4)
- **number** delay shut-off timer (dp 101, minutes, max 5)
- **sensor** baffle filter life (dp 102, hours) and charcoal filter life (dp 103, hours)

Notes:
- dp 10 has a 5th speed `max`, and dp 101/102/103 are not present in the Tuya cloud datamodel — all confirmed by local testing on my own device.
- Tested working on real hardware through this integration.
- Ran locally before submitting: `yamllint`, `pytest tests/test_device_config.py`, and `untranslated_entities` all pass.