### PR TITLE
feat(devices): add MeacoCool MC Series 12000 PRO CH air conditioner

### DIFF
--- a/custom_components/tuya_local/devices/meacocool_mc12000pro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meacocool_mc12000pro_airconditioner.yaml
@@ -73,10 +73,9 @@ entities:
         type: string
         name: temperature_unit
         mapping:
-          - dps_val: c
-            value: C
           - dps_val: f
             value: F
+          - value: C
       - id: 23
         type: integer
         name: temp_set_f

--- a/custom_components/tuya_local/devices/meacocool_mc12000pro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meacocool_mc12000pro_airconditioner.yaml
@@ -1,0 +1,145 @@
+name: Air conditioner
+products:
+  - id: anelna1pjt7avtye
+    manufacturer: Meaco
+    model: MeacoCool MC Series 12000 PRO CH
+    model_id: MC12000CHRPRO
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: Cool
+                value: cool
+              - dps_val: Dyr
+                value: dry
+              - dps_val: Fan
+                value: fan_only
+              - dps_val: Heat
+                available: support_heat
+                value: heat
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 16
+          max: 32
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 61
+                  max: 90
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_current_f
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: Low
+            value: low
+          - dps_val: Mid
+            value: medium
+          - dps_val: High
+            value: high
+      - id: 15
+        type: string
+        name: swing_mode
+        mapping:
+          - dps_val: "OFF"
+            value: "off"
+          - dps_val: "ON"
+            value: "on"
+      - id: 19
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 23
+        type: integer
+        name: temp_set_f
+        optional: true
+        range:
+          min: 61
+          max: 90
+      - id: 24
+        type: integer
+        name: temp_current_f
+        optional: true
+      - id: 101
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: sleep
+          - dps_val: false
+            value: comfort
+      - id: 103
+        type: string
+        name: support_heat
+        hidden: true
+        mapping:
+          - dps_val: C_H
+            value: true
+          - value: false
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 4
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit


### PR DESCRIPTION
Closes #5424

Adds `meacocool_mc12000pro_airconditioner` covering both variants of the MeacoCool MC Series 12000 PRO:
- `C` - cooling only (product ID: TBC)
- `C_H` - cooling + heating (product ID: anelna1pjt7avtye, tested)

DP 103 (`Model_ID`) is used as a `support_heat` constraint so that Heat mode is automatically hidden on cooling-only units.

Changes were not merged into the existing `meacocool_mcseries_airconditioner` as that config was written for the MC Series 10000 PRO CH and is missing several DPs present on the 12000 PRO:
- Mid fan speed (DP 5)
- Fahrenheit temperature redirect (DPs 23/24)
- Tank full diagnostic sensor (DP 22 bit 4)
- Swing is mapped as boolean rather than the correct string type

Adding the 12000 PRO to that file would result in those features not working for 12K owners.

The 12000 PRO CH matches the Suntec template at 100% quality, but the Suntec file lacks the `support_heat` constraint, meaning Heat mode would always appear even on cooling-only units.

Tested on a physical MC12000CHRPRO (C_H variant). All functions confirmed working:
- Cool / Dry / Fan / Heat modes
- Fan speeds Low / Mid / High
- Swing on/off
- Sleep preset mode
- Celsius/Fahrenheit switching with correct DP redirect
- Tank full diagnostic sensor