### PR TITLE
feat(devices): add Meaco Cirro Air Conditioners

### DIFF
--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -4,13 +4,15 @@ products:
     manufacturer: Meaco
     model: Meaco Cirro+ 14000 BTU Inverter & Heater
     model_id: CIRRO14000CHPRO
+  - id: sijcdtk46wa9uews
+    manufacturer: Meaco
+    model: Meaco Cirro+ 14000 BTU Inverter
+    model_id: CIRRO14000PRO
   # The following product IDs are unconfirmed but should work:
   # - model: Meaco Cirro 12000 BTU
   #   model_id: CIRRO12000PRO (cooling only)
   # - model: Meaco Cirro 12000 BTU & Heater
   #   model_id: CIRRO12000CHPRO (cooling + heating)
-  # - model: Meaco Cirro+ 14000 BTU Inverter
-  #   model_id: CIRRO14000PRO (cooling only)
   # - model: Meaco Cirro+ 16000 BTU Inverter
   #   model_id: CIRRO16000PRO (cooling only)
   # - model: Meaco Cirro+ 16000 BTU Inverter & Heater

--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -2,7 +2,14 @@ name: Air conditioner
 products:
   - id: smu5pc1ruzadfnuk
     manufacturer: Meaco
-    model: MeacoCool Cirro+ 14000 BTU Inverter
+    model: Meaco Cirro+ 14000 BTU Inverter
+    model_id: CIRRO14000CHPRO
+  # The following product IDs are unconfirmed but should work:
+  # - Meaco Cirro 12000 BTU CIRRO12000PRO (cooling only)
+  # - Meaco Cirro 12000 BTU CIRRO12000CHPRO (cooling + heating)
+  # - Meaco Cirro+ 14000 BTU Inverter CIRRO14000PRO (cooling only)
+  # - Meaco Cirro+ 16000 BTU Inverter CIRRO16000PRO (cooling only)
+  # - Meaco Cirro+ 16000 BTU Inverter CIRRO16000CHPRO (cooling + heating)
 entities:
   - entity: climate
     dps:
@@ -137,12 +144,14 @@ entities:
       - id: 14
         type: boolean
         name: lock
+        optional: true
   - entity: switch
     translation_key: ionizer
     dps:
       - id: 104
         type: boolean
         name: switch
+        optional: true
   - entity: select
     translation_key: temperature_unit
     category: config

--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -1,0 +1,157 @@
+name: Air conditioner
+products:
+  - id: smu5pc1ruzadfnuk
+    manufacturer: Meaco
+    model: MeacoCool Cirro+ 14000 BTU Inverter
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: Cool
+                value: cool
+              - dps_val: Dry
+                value: dry
+              - dps_val: Fan
+                value: fan_only
+              - dps_val: Heat
+                available: support_heat
+                value: heat
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 16
+          max: 32
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 61
+                  max: 90
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_current_f
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: Low
+            value: low
+          - dps_val: Mid
+            value: medium
+          - dps_val: High
+            value: high
+      - id: 15
+        type: string
+        name: swing_mode
+        mapping:
+          - dps_val: "OFF"
+            value: "off"
+          - dps_val: "ON"
+            value: "on"
+      - id: 19
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 23
+        type: integer
+        name: temp_set_f
+        optional: true
+        range:
+          min: 61
+          max: 90
+      - id: 24
+        type: integer
+        name: temp_current_f
+        optional: true
+      - id: 101
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: sleep
+          - dps_val: false
+            value: comfort
+      - id: 103
+        type: string
+        name: support_heat
+        hidden: true
+        mapping:
+          - dps_val: C_H
+            value: true
+          - value: false
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 4
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 14
+        type: boolean
+        name: lock
+  - entity: switch
+    translation_key: ionizer
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit

--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -145,13 +145,6 @@ entities:
         type: boolean
         name: lock
         optional: true
-  - entity: switch
-    translation_key: ionizer
-    dps:
-      - id: 104
-        type: boolean
-        name: switch
-        optional: true
   - entity: select
     translation_key: temperature_unit
     category: config

--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -2,14 +2,19 @@ name: Air conditioner
 products:
   - id: smu5pc1ruzadfnuk
     manufacturer: Meaco
-    model: Meaco Cirro+ 14000 BTU Inverter
+    model: Meaco Cirro+ 14000 BTU Inverter & Heater
     model_id: CIRRO14000CHPRO
   # The following product IDs are unconfirmed but should work:
-  # - Meaco Cirro 12000 BTU CIRRO12000PRO (cooling only)
-  # - Meaco Cirro 12000 BTU CIRRO12000CHPRO (cooling + heating)
-  # - Meaco Cirro+ 14000 BTU Inverter CIRRO14000PRO (cooling only)
-  # - Meaco Cirro+ 16000 BTU Inverter CIRRO16000PRO (cooling only)
-  # - Meaco Cirro+ 16000 BTU Inverter CIRRO16000CHPRO (cooling + heating)
+  # - model: Meaco Cirro 12000 BTU
+  #   model_id: CIRRO12000PRO (cooling only)
+  # - model: Meaco Cirro 12000 BTU & Heater
+  #   model_id: CIRRO12000CHPRO (cooling + heating)
+  # - model: Meaco Cirro+ 14000 BTU Inverter
+  #   model_id: CIRRO14000PRO (cooling only)
+  # - model: Meaco Cirro+ 16000 BTU Inverter
+  #   model_id: CIRRO16000PRO (cooling only)
+  # - model: Meaco Cirro+ 16000 BTU Inverter & Heater
+  #   model_id: CIRRO16000CHPRO (cooling + heating)
 entities:
   - entity: climate
     dps:

--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -2,20 +2,20 @@ name: Air conditioner
 products:
   - id: smu5pc1ruzadfnuk
     manufacturer: Meaco
-    model: Meaco Cirro+ 14000 BTU Inverter & Heater
+    model: Cirro+ 14000 BTU Inverter & Heater
     model_id: CIRRO14000CHPRO
   - id: sijcdtk46wa9uews
     manufacturer: Meaco
-    model: Meaco Cirro+ 14000 BTU Inverter
+    model: Cirro+ 14000 BTU Inverter
     model_id: CIRRO14000PRO
   # The following product IDs are unconfirmed but should work:
-  # - model: Meaco Cirro 12000 BTU
+  # - model: Cirro 12000 BTU
   #   model_id: CIRRO12000PRO (cooling only)
-  # - model: Meaco Cirro 12000 BTU & Heater
+  # - model: Cirro 12000 BTU & Heater
   #   model_id: CIRRO12000CHPRO (cooling + heating)
-  # - model: Meaco Cirro+ 16000 BTU Inverter
+  # - model: Cirro+ 16000 BTU Inverter
   #   model_id: CIRRO16000PRO (cooling only)
-  # - model: Meaco Cirro+ 16000 BTU Inverter & Heater
+  # - model: Cirro+ 16000 BTU Inverter & Heater
   #   model_id: CIRRO16000CHPRO (cooling + heating)
 entities:
   - entity: climate
@@ -86,10 +86,9 @@ entities:
         type: string
         name: temperature_unit
         mapping:
-          - dps_val: c
-            value: C
           - dps_val: f
             value: F
+          - value: C
       - id: 23
         type: integer
         name: temp_set_f


### PR DESCRIPTION
Closes #5382

Adds a new device config covering all six models in the Meaco Cirro range across 12K, 14K and 16K BTU sizes, in both cooling-only (C) and cooling+heating (C_H) variants:

| Model | BTU | Variant | Product ID |
|---|---|---|---|
| CIRRO14000PRO | 14000 | C | sijcdtk46wa9uews |
| CIRRO14000CHPRO | 14000 | C_H | smu5pc1ruzadfnuk |
| CIRRO12000PRO | 12000 | C | TBC |
| CIRRO12000CHPRO | 12000 | C_H | TBC |
| CIRRO16000PRO | 16000 | C | TBC |
| CIRRO16000CHPRO | 16000 | C_H | TBC |

DP 103 (`Model_ID`) is used as a `support_heat` constraint so that Heat mode is automatically hidden on cooling-only units.

The 14K and 16K Cirro+ models are inverter variants; the 12K Cirro is a non-inverter model on different hardware. The DP structure is expected to be the same across the range based on available data models, but the 12K has not been personally verified. DPs 14 (child_lock) is marked `optional: true` to handle any variance between hardware platforms gracefully.

Note on DP 104 (ionizer): this DP is present in the 14K data model but is not listed as a feature on any Meaco Cirro product pages and has been [confirmed to not do anything by a user](https://github.com/make-all/tuya-local/issues/5382#issuecomment-4821405757). It has therefore been omitted from this config.

This config was derived from the Things Data Model provided in #5382 and has been confirmed working by a `CIRRO12000PRO` owner.