### PR TITLE
Add Kibernetik 12K portable split air conditioner

### DIFF
--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
@@ -22,6 +22,8 @@ entities:
                 value: fan_only
               - dps_val: DRY
                 value: dry
+              - dps_val: HEAT
+                value: heat
       - id: 2
         name: temperature
         type: integer
@@ -68,9 +70,6 @@ entities:
             value: sleep
           - dps_val: false
             value: comfort
-      - id: 102
-        name: unknown_102
-        type: boolean
       - id: 104
         name: swing_mode
         type: boolean
@@ -79,15 +78,9 @@ entities:
             value: "vertical"
           - dps_val: false
             value: "off"
-      - id: 106
-        name: unknown_106
-        type: integer
-      - id: 109
-        name: unknown_109
-        type: boolean
       - id: 110
         name: unknown_110
-        type: integer
+        type: string
   - entity: select
     translation_key: temperature_unit
     category: config
@@ -100,6 +93,13 @@ entities:
             value: celsius
           - dps_val: F
             value: fahrenheit
+  - entity: switch
+    translation_key: auto_dry
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
   - entity: number
     translation_key: timer
     category: config
@@ -121,3 +121,21 @@ entities:
         type: integer
         name: sensor
         unit: min
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 102
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 106
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true

--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
@@ -20,10 +20,10 @@ entities:
                 value: cool
               - dps_val: FAN
                 value: fan_only
+              # dp4 also lists HEAT, but this is a cool-only model (see dp110).
+              # Left out until a heat-capable model can confirm it.
               - dps_val: DRY
                 value: dry
-              - dps_val: HEAT
-                value: heat
       - id: 2
         name: temperature
         type: integer
@@ -79,7 +79,10 @@ entities:
           - dps_val: false
             value: "off"
       - id: 110
-        name: unknown_110
+        # "model" per Tuya data model; meaning of values unconfirmed.
+        # This cool-only 5-speed unit reports "0" - a heat-capable or
+        # 3-speed model may report differently (may gate heat/fan speeds).
+        name: model
         type: string
   - entity: select
     translation_key: temperature_unit

--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
@@ -1,0 +1,123 @@
+name: Air conditioner
+products:
+  - id: deedvplnx2yvge08
+    manufacturer: Kibernetik
+    model: 12K portable split
+entities:
+  - entity: climate
+    translation_only_key: aircon_extra
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: COOL
+                value: cool
+              - dps_val: FAN
+                value: fan_only
+              - dps_val: DRY
+                value: dry
+      - id: 2
+        name: temperature
+        type: integer
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: C
+                range:
+                  min: 16
+                  max: 32
+              - dps_val: F
+                range:
+                  min: 60
+                  max: 90
+      - id: 3
+        name: current_temperature
+        type: integer
+      - id: 4
+        name: mode
+        type: string
+        hidden: true
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: quiet
+          - dps_val: "2"
+            value: low
+          - dps_val: "3"
+            value: medium
+          - dps_val: "4"
+            value: high
+          - dps_val: "5"
+            value: strong
+      - id: 19
+        name: temperature_unit
+        type: string
+      - id: 101
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: sleep
+          - dps_val: false
+            value: comfort
+      - id: 102
+        name: unknown_102
+        type: boolean
+      - id: 104
+        name: swing_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            value: "vertical"
+          - dps_val: false
+            value: "off"
+      - id: 106
+        name: unknown_106
+        type: integer
+      - id: 109
+        name: unknown_109
+        type: boolean
+      - id: 110
+        name: unknown_110
+        type: integer
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: C
+            value: celsius
+          - dps_val: F
+            value: fahrenheit
+  - entity: number
+    translation_key: timer
+    category: config
+    class: duration
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 24
+  - entity: sensor
+    translation_key: time_remaining
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: min


### PR DESCRIPTION
## Summary

Adds a device config for the **Kibernetik 12K BTU portable split air conditioner** (Tuya product id `deedvplnx2yvge08`, category `kt`, product name "Portable Split Air Conditioner"). Sold in Switzerland via Fust (art. 111235), controlled through the Smart Life app.

## Why a new config

This device was being matched (by dps fallback, no product-id match) to the existing `kogan_kawfpac12ya` config, which maps the fan (dps 5) as a **3-speed** device (low/medium/high). The Kibernetik is a **5-speed** unit — the Tuya cloud schema reports dps 5 enum range `['1','2','3','4','5']`, and on the 3-speed config steps 4/5 showed up as raw values instead of named fan modes.

## Fan steps verified on real hardware

Selected each level in the Smart Life app and read back the raw dps 5 value via Home Assistant:

| Smart Life | dps 5 | fan_mode |
|------------|:-----:|----------|
| Silent | `1` | `silent` |
| Low    | `2` | `low` |
| Mid    | `3` | `medium` |
| High   | `4` | `high` |
| Turbo  | `5` | `turbo` |

Remaining datapoints mirror the Kogan PAC_Y12 config, on which this device operates correctly (hvac off/cool/fan_only/dry, target/current temp, preset sleep/comfort, vertical swing, °C/°F select).

## Note on the Kogan Y12

The Kogan Y12 appears to be the same PAC_Y12 hardware and may also be a 5-speed unit with the same fan mislabel, but I could not verify that on a Kogan device, so I left its config unchanged rather than risk breaking it.

## Tests

- `uv run yamllint custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml` — clean
- `uv run pytest tests/test_device_config.py` — 32 passed