### PR TITLE
feat(devices): add configuration for Globmatic gate opener

### DIFF
--- a/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
+++ b/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
@@ -1,0 +1,76 @@
+name: Gate opener
+
+products:
+  - id: 4iispvj6a6vsavxl
+    manufacturer: Globmatic
+    model: Automatic sliding gate opener - Castor
+    model_id: bf6b6de074afba4988esep
+
+entities:
+  - entity: button
+    name: "Motor toggle"
+    dps:
+      - id: 101
+        name: button
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: true
+            icon: "mdi:gate-open"
+          - dps_val: 50
+            value: true
+            icon: "mdi:gate-arrow-left"
+          - dps_val: 100
+            value: true
+            icon: "mdi:gate"
+
+  - entity: cover
+    name: "Motor control"
+    class: gate
+    dps:
+      - id: 101
+        name: control
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: open
+          - dps_val: 100
+            value: close
+      - id: 101
+        name: action
+        type: integer
+        mapping:
+          - dps_val: 0
+            value: opened
+          - dps_val: 50
+            value: opening
+          - dps_val: 100
+            value: closed
+      - id: 101
+        name: position
+        type: integer
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - invert: true
+
+  - entity: sensor
+    name: "Gate position"
+    dps:
+      - id: 101
+        name: sensor
+        type: integer
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - invert: true
+
+  - entity: sensor
+    name: "Gate state"
+    dps:
+      - id: 10
+        name: sensor
+        type: string
+        optional: true

--- a/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
+++ b/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
@@ -7,23 +7,6 @@ products:
     model_id: bf6b6de074afba4988esep
 
 entities:
-  - entity: button
-    name: "Motor toggle"
-    dps:
-      - id: 101
-        name: button
-        type: integer
-        mapping:
-          - dps_val: 0
-            value: true
-            icon: "mdi:gate-open"
-          - dps_val: 50
-            value: true
-            icon: "mdi:gate-arrow-left"
-          - dps_val: 100
-            value: true
-            icon: "mdi:gate"
-
   - entity: cover
     name: "Motor control"
     class: gate
@@ -48,18 +31,6 @@ entities:
             value: closed
       - id: 101
         name: position
-        type: integer
-        range:
-          min: 0
-          max: 100
-        mapping:
-          - invert: true
-
-  - entity: sensor
-    name: "Gate position"
-    dps:
-      - id: 101
-        name: sensor
         type: integer
         range:
           min: 0

--- a/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
+++ b/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
@@ -7,7 +7,6 @@ products:
 
 entities:
   - entity: cover
-    name: "Motor control"
     class: gate
     dps:
       - id: 101
@@ -38,7 +37,6 @@ entities:
           - invert: true
 
   - entity: sensor
-    name: "Gate state"
     dps:
       - id: 10
         name: sensor

--- a/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
+++ b/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
@@ -10,25 +10,15 @@ entities:
     class: gate
     dps:
       - id: 101
-        name: control
-        type: integer
-        mapping:
-          - dps_val: 0
-            value: open
-          - dps_val: 100
-            value: close
-      - id: 101
-        name: action
-        type: integer
-        mapping:
-          - dps_val: 0
-            value: opened
-          - dps_val: 50
-            value: null
-          - dps_val: 100
-            value: closed
-      - id: 101
         name: position
+        type: integer
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - invert: true
+      - id: 101
+        name: current_position
         type: integer
         range:
           min: 0
@@ -37,6 +27,7 @@ entities:
           - invert: true
 
   - entity: sensor
+    translation_key: status
     dps:
       - id: 10
         name: sensor

--- a/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
+++ b/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
@@ -4,7 +4,6 @@ products:
   - id: 4iispvj6a6vsavxl
     manufacturer: Globmatic
     model: Automatic sliding gate opener - Castor
-    model_id: bf6b6de074afba4988esep
 
 entities:
   - entity: cover

--- a/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
+++ b/custom_components/tuya_local/devices/globmatic_gate_opener.yaml
@@ -24,7 +24,7 @@ entities:
           - dps_val: 0
             value: opened
           - dps_val: 50
-            value: opening
+            value: null
           - dps_val: 100
             value: closed
       - id: 101


### PR DESCRIPTION
Adds a device config for the Globmatic Automatic sliding gate opener - Castor.

Entities:
- button: `dp 101`, triggers the motor to toggle state (similar to the behaviour of a remote IR button), by setting the position to end states (0 or 100).
- cover: `dp 101`, allows to see buttons to toggle state and the state of the motor in a nice UI.
- sensor: `dp 101`, exposes the gate position, only values [0, 50, 100], it is a limitation of the physical sensor.
- sensor: `dp 10`, exposes the state the sensor reports.

Notes:
- physical sensor reports position reversed, hence the reversed mapping and the reversed icons


Tested working on real hardware through this config.
Ran locally before submitting: yamllint, pytest tests/test_device_config.py, all pass.