### PR TITLE
Add Varin VA-E002 ceiling fan light

### DIFF
--- a/custom_components/tuya_local/devices/varin_va_e002_fan_light.yaml
+++ b/custom_components/tuya_local/devices/varin_va_e002_fan_light.yaml
@@ -1,0 +1,62 @@
+name: Fan light
+entities:
+  - entity: light
+    name: Main Light
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 22
+        type: integer
+        name: brightness
+        optional: true
+        range:
+          min: 10
+          max: 1000
+      - id: 23
+        type: integer
+        name: color_temp
+        optional: true
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - target_range:
+              min: 3000
+              max: 5000
+            step: 500
+  - entity: fan
+    dps:
+      - id: 60
+        type: boolean
+        name: switch
+      - id: 62
+        type: integer
+        name: speed
+        optional: true
+        range:
+          min: 1
+          max: 6
+      - id: 63
+        type: string
+        name: direction
+        optional: true
+        mapping:
+          - dps_val: forward
+            value: forward
+          - dps_val: reverse
+            value: reverse
+  - entity: number
+    name: Fan timer
+    translation_key: timer
+    category: config
+    icon: "mdi:fan-clock"
+    dps:
+      - id: 64
+        type: integer
+        name: value
+        optional: true
+        unit: min
+        range:
+          min: 0
+          max: 540

--- a/custom_components/tuya_local/devices/varin_va_e002_fan_light.yaml
+++ b/custom_components/tuya_local/devices/varin_va_e002_fan_light.yaml
@@ -1,4 +1,8 @@
 name: Fan light
+products:
+  - id: vfqiwthdnlkynebk
+    manufacturer: Varin
+    model: VA-E002
 entities:
   - entity: light
     name: Main Light


### PR DESCRIPTION
### Device
Varin® VA-E002 , CCT-only ceiling fan with light (no RGB), 6-speed fan.
Tuya WiFi, protocol 3.5, product category `fsd`.
Product id: vfqiwthdnlkynebk

### Why a new config rather than reusing amari_ceiling_fanlight
The DP family matches Amari (which is auto-selected), but three mappings
are wrong for this device:

| DP | Amari | VA-E002 | Fix |
|----|-------|---------|-----|
| 23 color_temp | `invert: true` | warm = low K natively | invert removed |
| 62 fan speed | range 1–100 | 6 discrete levels | range 1–6 |
| 61 preset_mode | WakeUp/Natural/Normal/Sleep | sends raw `fresh`, no app modes | omitted |

The VA-E002 also does not report dp 26 (timer) or dp 28 (light control),
so those entities are dropped to avoid permanently-unavailable entities.
