### PR TITLE
Update device name and details for LEDVANCE light

### DIFF
--- a/custom_components/tuya_local/devices/ledvance_smart_wifi_planon_magic.yaml
+++ b/custom_components/tuya_local/devices/ledvance_smart_wifi_planon_magic.yaml
@@ -1,0 +1,80 @@
+name: LEDVANCE SMART+ WiFi Planon Magic
+products:
+  - id: keyj3w8cmutjmwk5
+    manufacturer: LEDVANCE
+    model: SMART+ WiFi Planon Magic 36W
+entities:
+  - entity: light
+    icon: "mdi:ceiling-light"
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 21
+        type: string
+        name: color_mode
+        mapping:
+          - dps_val: white
+            value: color_temp
+          - dps_val: colour
+            value: hs
+          - dps_val: scene
+            value: scene
+          - dps_val: music
+            value: music
+      - id: 22
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+      - id: 23
+        type: integer
+        name: color_temp
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - target_range:
+              min: 2700
+              max: 6500
+      - id: 24
+        type: hex
+        name: rgbhsv
+        optional: true
+        format:
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+          - name: v
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+
+  - entity: time
+    translation_key: timer
+    category: config
+    dps:
+      - id: 26
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+
+  - entity: sensor
+    name: Light pixel count
+    icon: "mdi:led-strip-variant"
+    category: diagnostic
+    dps:
+      - id: 47
+        type: integer
+        name: sensor

--- a/custom_components/tuya_local/devices/ledvance_smartwifiplanonmagic_light.yaml
+++ b/custom_components/tuya_local/devices/ledvance_smartwifiplanonmagic_light.yaml
@@ -1,4 +1,4 @@
-name: LEDVANCE SMART+ WiFi Planon Magic
+name: Ceiling light
 products:
   - id: keyj3w8cmutjmwk5
     manufacturer: LEDVANCE


### PR DESCRIPTION
Add support for LEDVANCE SMART+ WiFi Planon Magic

Adds a device profile for the LEDVANCE SMART+ WiFi Planon Magic LED panel light.

Tested with local discovery productKey keyj3w8cmutjmwk5.

Working features:
- Switch
- Brightness
- Color temperature, 2700-6500K
- RGB/HSV color
- Countdown timer
- Light pixel count diagnostic sensor

The device is paired through the LEDVANCE SMART+ app, so the product identifier comes from local Tuya discovery productKey instead of Tuya Cloud.

- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Please describe in simple terms what you are submitting. Do not paste a multi-page AI generated rambling story here, as the maintainers do not have time to read that.
