### PR TITLE
fix: add 'near' movement state value to ZG-205W mmWave presence sensor

### DIFF
--- a/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
+++ b/custom_components/tuya_local/devices/zg205w_mmWave_presence_sensor.yaml
@@ -299,6 +299,8 @@ entities:
             value: None
           - dps_val: far
             value: Far
+          - dps_val: near
+            value: Near
   - entity: switch
     name: Small motion self-test
     category: config


### PR DESCRIPTION
## Summary

Companion fix to #5411. DPS 116 (Movement state) on the ZG-205Z sensor also emits `near` as a real device value, but this was not included in the previous PR.

Without this mapping, HA logs a continuous error:

```
Entity sensor.presence_sensor_office_pc_movement_state provides state value 'near',
which is not in the list of options ['Large', 'Small', 'Breathe', 'None', 'Far']
```

## Evidence

Observed in production over a 2-hour window with a subject present in the room:

| State | Count |
|-------|-------|
| Far | 453 |
| Near | 320 |
| Breathe | 215 |
| Large | 215 |

The sensor cycles through `Far → Near → Large → Breathe` as the subject moves, confirming `near` is a genuine device-emitted value representing presence detection in the near zone.

## Change

Added `dps_val: near` / `value: Near` to the DPS 116 mapping, immediately following the `far` entry added in #5411.