### PR TITLE
Fail fast on device offline to improve HA startup

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -7,6 +7,7 @@ investigation into Goldair's tuyapi statuses
 https://github.com/codetheweb/tuyapi/issues/31.
 """
 
+import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -973,6 +974,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         device = await hass.async_add_executor_job(setup_device, hass, config)
         await device.async_refresh()
+
+    except asyncio.CancelledError as e:
+        cleanup_failed_device(hass, device_id)
+        raise ConfigEntryNotReady("tuya-local setup cancelled (startup timeout)") from e
 
     except Exception as e:
         cleanup_failed_device(hass, device_id)

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -91,6 +91,7 @@ class TuyaLocalDevice(object):
                     )
                 else:
                     parent = tinytuya.Device(dev_id, address, local_key)
+                    parent.set_socketTimeout(2)
                     parent_lock = asyncio.Lock()
                     if name != "Test":
                         hass.data[DOMAIN][dev_id] = {
@@ -102,6 +103,7 @@ class TuyaLocalDevice(object):
                     cid=dev_cid,
                     parent=parent,
                 )
+                self._api.set_socketTimeout(2)
                 self._api_lock = parent_lock
             else:
                 if hass.data[DOMAIN].get(dev_id) and name != "Test":
@@ -111,6 +113,7 @@ class TuyaLocalDevice(object):
                     )
                 else:
                     self._api = tinytuya.Device(dev_id, address, local_key)
+                    self._api.set_socketTimeout(2)
                     self._api_lock = asyncio.Lock()
                     if name != "Test":
                         hass.data[DOMAIN][dev_id] = {
@@ -672,6 +675,24 @@ class TuyaLocalDevice(object):
                             # data so commands can still be sent.
                             self._cached_state["updated_at"] = time()
                             retval = None
+                        elif last_err_code in ("901", "905"):
+                            # Network Error: Unable to Connect (901) or Device
+                            # Unreachable (905). The device is unreachable;
+                            # retrying with a different protocol version will
+                            # not help, so fail fast.
+                            _LOGGER.debug(
+                                "Device unreachable (%s), giving up (%d/%d)",
+                                last_err_code,
+                                i,
+                                connections,
+                            )
+                            self._reset_cached_state()
+                            self._api_working_protocol_failures += 1
+                            if self._api_working_protocol_failures == 1:
+                                _LOGGER.error(error_message)
+                            else:
+                                _LOGGER.debug(error_message)
+                            break
                         else:
                             raise AttributeError(retval["Error"])
                     self._api_protocol_working = True

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -91,6 +91,7 @@ class TuyaLocalDevice(object):
                     )
                 else:
                     parent = tinytuya.Device(dev_id, address, local_key)
+                    parent.set_socketTimeout(2)
                     parent_lock = asyncio.Lock()
                     if name != "Test":
                         hass.data[DOMAIN][dev_id] = {
@@ -102,6 +103,7 @@ class TuyaLocalDevice(object):
                     cid=dev_cid,
                     parent=parent,
                 )
+                self._api.set_socketTimeout(2)
                 self._api_lock = parent_lock
             else:
                 if hass.data[DOMAIN].get(dev_id) and name != "Test":
@@ -111,6 +113,7 @@ class TuyaLocalDevice(object):
                     )
                 else:
                     self._api = tinytuya.Device(dev_id, address, local_key)
+                    self._api.set_socketTimeout(2)
                     self._api_lock = asyncio.Lock()
                     if name != "Test":
                         hass.data[DOMAIN][dev_id] = {
@@ -672,6 +675,22 @@ class TuyaLocalDevice(object):
                             # data so commands can still be sent.
                             self._cached_state["updated_at"] = time()
                             retval = None
+                        elif last_err_code == "901":
+                            # Network Error: Unable to Connect. The device is
+                            # unreachable; retrying with a different protocol
+                            # version will not help, so fail fast.
+                            _LOGGER.debug(
+                                "Device unreachable (901), giving up (%d/%d)",
+                                i,
+                                connections,
+                            )
+                            self._reset_cached_state()
+                            self._api_working_protocol_failures += 1
+                            if self._api_working_protocol_failures == 1:
+                                _LOGGER.error(error_message)
+                            else:
+                                _LOGGER.debug(error_message)
+                            break
                         else:
                             raise AttributeError(retval["Error"])
                     self._api_protocol_working = True

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -675,12 +675,14 @@ class TuyaLocalDevice(object):
                             # data so commands can still be sent.
                             self._cached_state["updated_at"] = time()
                             retval = None
-                        elif last_err_code == "901":
-                            # Network Error: Unable to Connect. The device is
-                            # unreachable; retrying with a different protocol
-                            # version will not help, so fail fast.
+                        elif last_err_code in ("901", "905"):
+                            # Network Error: Unable to Connect (901) or Device
+                            # Unreachable (905). The device is unreachable;
+                            # retrying with a different protocol version will
+                            # not help, so fail fast.
                             _LOGGER.debug(
-                                "Device unreachable (901), giving up (%d/%d)",
+                                "Device unreachable (%s), giving up (%d/%d)",
+                                last_err_code,
                                 i,
                                 connections,
                             )

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -677,6 +677,25 @@ class TuyaLocalDevice(object):
                     self._api_protocol_working = True
                     self._api_working_protocol_failures = 0
                     return retval
+            except (TimeoutError, OSError) as e:
+                _LOGGER.debug(
+                    "Retrying after exception %s %s (%d/%d)",
+                    type(e).__name__,
+                    e,
+                    i,
+                    connections,
+                )
+                self._api.set_socketPersistent(False)
+                if self._api.parent:
+                    self._api.parent.set_socketPersistent(False)
+
+                self._reset_cached_state()
+                self._api_working_protocol_failures += 1
+                if self._api_working_protocol_failures == 1:
+                    _LOGGER.error(error_message)
+                else:
+                    _LOGGER.debug(error_message)
+                break
             except Exception as e:
                 _LOGGER.debug(
                     "Retrying after exception %s %s (%d/%d)",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -220,10 +220,24 @@ async def test_api_protocol_version_is_stable_once_successful(
 
 
 @pytest.mark.asyncio
-async def test_refresh_stops_retrying_when_device_unreachable(subject, mock_api):
+async def test_refresh_stops_retrying_when_device_unreachable_901(subject, mock_api):
     subject._api_protocol_working = False
     mock_api().status.side_effect = [
         {"Error": "Network Error: Unable to Connect", "Err": "901"},
+        {"dps": {"1": False}},
+    ]
+
+    await subject.async_refresh()
+
+    assert mock_api().status.call_count == 1
+    assert subject._cached_state == {"updated_at": 0}
+
+
+@pytest.mark.asyncio
+async def test_refresh_stops_retrying_when_device_unreachable_905(subject, mock_api):
+    subject._api_protocol_working = False
+    mock_api().status.side_effect = [
+        {"Error": "Network Error: Device Unreachable", "Err": "905"},
         {"dps": {"1": False}},
     ]
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -244,7 +244,7 @@ async def test_refresh_does_not_rotate_protocol_on_timeout(subject, mock_api, mo
 
     await subject.async_refresh()
 
-    mock_api().set_version.assert_called_once_with(3.1)
+    assert mock_api().set_version.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -220,6 +220,34 @@ async def test_api_protocol_version_is_stable_once_successful(
 
 
 @pytest.mark.asyncio
+async def test_refresh_stops_retrying_when_device_unreachable_901(subject, mock_api):
+    subject._api_protocol_working = False
+    mock_api().status.side_effect = [
+        {"Error": "Network Error: Unable to Connect", "Err": "901"},
+        {"dps": {"1": False}},
+    ]
+
+    await subject.async_refresh()
+
+    assert mock_api().status.call_count == 1
+    assert subject._cached_state == {"updated_at": 0}
+
+
+@pytest.mark.asyncio
+async def test_refresh_stops_retrying_when_device_unreachable_905(subject, mock_api):
+    subject._api_protocol_working = False
+    mock_api().status.side_effect = [
+        {"Error": "Network Error: Device Unreachable", "Err": "905"},
+        {"dps": {"1": False}},
+    ]
+
+    await subject.async_refresh()
+
+    assert mock_api().status.call_count == 1
+    assert subject._cached_state == {"updated_at": 0}
+
+
+@pytest.mark.asyncio
 async def test_api_protocol_version_is_not_rotated_when_not_auto(subject, mock_api):
     # Set up preconditions for the test
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -220,6 +220,34 @@ async def test_api_protocol_version_is_stable_once_successful(
 
 
 @pytest.mark.asyncio
+async def test_refresh_stops_retrying_immediately_on_timeout(subject, mock_api):
+    subject._api_protocol_working = False
+    mock_api().status.side_effect = [
+        TimeoutError("timed out"),
+        {"dps": {"1": False}},
+    ]
+
+    await subject.async_refresh()
+
+    assert mock_api().status.call_count == 1
+    assert subject._cached_state == {"updated_at": 0}
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_rotate_protocol_on_timeout(subject, mock_api, mocker):
+    subject._api_protocol_version_index = None
+    subject._api_protocol_working = False
+    mock_api().status.side_effect = [
+        TimeoutError("timed out"),
+        {"dps": {"1": False}},
+    ]
+
+    await subject.async_refresh()
+
+    mock_api().set_version.assert_called_once_with(3.1)
+
+
+@pytest.mark.asyncio
 async def test_api_protocol_version_is_not_rotated_when_not_auto(subject, mock_api):
     # Set up preconditions for the test
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -220,10 +220,10 @@ async def test_api_protocol_version_is_stable_once_successful(
 
 
 @pytest.mark.asyncio
-async def test_refresh_stops_retrying_immediately_on_timeout(subject, mock_api):
+async def test_refresh_stops_retrying_when_device_unreachable(subject, mock_api):
     subject._api_protocol_working = False
     mock_api().status.side_effect = [
-        TimeoutError("timed out"),
+        {"Error": "Network Error: Unable to Connect", "Err": "901"},
         {"dps": {"1": False}},
     ]
 
@@ -231,20 +231,6 @@ async def test_refresh_stops_retrying_immediately_on_timeout(subject, mock_api):
 
     assert mock_api().status.call_count == 1
     assert subject._cached_state == {"updated_at": 0}
-
-
-@pytest.mark.asyncio
-async def test_refresh_does_not_rotate_protocol_on_timeout(subject, mock_api, mocker):
-    subject._api_protocol_version_index = None
-    subject._api_protocol_working = False
-    mock_api().status.side_effect = [
-        TimeoutError("timed out"),
-        {"dps": {"1": False}},
-    ]
-
-    await subject.async_refresh()
-
-    assert mock_api().set_version.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fail fast when tuya device is offline. This reduces HA startup time for me to 4 secs (up from multiple minutes). 

My use case is my floor heater: it's off fully in the summer. This is my only Tuya device. 

When the device protocol is set to 'auto', a loop would retry different protocols an HA startup would be delayed and error logs kept happening. 

It is AI generated code (please squash), but the comments wrt error codes and the importof asyncio make sense to me. 

 Tested by me using my fork as repo source in HACS using only one Tuya device.
