### PR TITLE
Add Create Windcalm S ceiling fan

### DIFF
--- a/custom_components/tuya_local/devices/create_windcalm_s_fan.yaml
+++ b/custom_components/tuya_local/devices/create_windcalm_s_fan.yaml
@@ -1,4 +1,8 @@
 name: Ceiling fan
+products:
+  - id: bf8a0d2c5527605aca0hdv
+    manufacturer: Create
+    model: Windcalm S
 entities:
   - entity: fan
     dps:

--- a/custom_components/tuya_local/devices/create_windcalm_s_fan.yaml
+++ b/custom_components/tuya_local/devices/create_windcalm_s_fan.yaml
@@ -1,7 +1,4 @@
 name: Ceiling fan
-products:
-  - manufacturer: Create
-    model: Windcalm S
 entities:
   - entity: fan
     dps:

--- a/custom_components/tuya_local/devices/create_windcalm_s_fan.yaml
+++ b/custom_components/tuya_local/devices/create_windcalm_s_fan.yaml
@@ -1,0 +1,41 @@
+name: Ceiling fan
+products:
+  - manufacturer: Create
+    model: Windcalm S
+entities:
+  - entity: fan
+    dps:
+      - id: 60
+        type: boolean
+        name: switch
+      - id: 62
+        type: integer
+        name: speed
+        mapping:
+          - dps_val: 1
+            value: 17
+          - dps_val: 2
+            value: 33
+          - dps_val: 3
+            value: 50
+          - dps_val: 4
+            value: 67
+          - dps_val: 5
+            value: 83
+          - dps_val: 6
+            value: 100
+      - id: 63
+        type: string
+        name: direction
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 64
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 0
+          max: 540


### PR DESCRIPTION
Adds configuration for the Create Windcalm S ceiling fan.

**Device:** Create Windcalm S ceiling fan
**Protocol:** Tuya local, protocol 3.5

**DPs:**
- DP 60 (boolean): power switch
- DP 62 (integer 1-6): fan speed, mapped to discrete percentage steps (17/33/50/67/83/100%)
- DP 63 (string): direction (forward/reverse)
- DP 64 (integer 0-540): countdown timer in minutes

Note: DP 62 uses explicit dps_val mappings rather than a ange, as the integer values 1-6 map to discrete speed steps and a linear range produces incorrect percentage values.