### PR TITLE
Improve user handling klarstein_iceblock_airconditioner

### DIFF
--- a/custom_components/tuya_local/devices/klarstein_iceblock_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/klarstein_iceblock_airconditioner.yaml
@@ -9,6 +9,21 @@ products:
 entities:
   - entity: climate
     dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "1"
+                value: cool
+              - dps_val: "3"
+                value: dry
+              - dps_val: "5"
+                value: fan_only
       - id: 2
         type: integer
         name: temperature
@@ -32,21 +47,14 @@ entities:
               - dps_val: true
                 value_redirect: temp_current_f
       - id: 101
-        name: hvac_mode
+        name: mode
         type: string
-        mapping:
-          - dps_val: "1"
-            value: cool
-          - dps_val: "3"
-            value: dry
-          - dps_val: "5"
-            value: fan_only
       - id: 103
         name: preset_mode
         type: boolean
         mapping:
           - dps_val: false
-            value: none
+            value: comfort
           - dps_val: true
             value: sleep
       - id: 104


### PR DESCRIPTION
This will add Mode "off" to the hvac_mode, so that you are able to turn the AC off via the climate card. 
Some minor rename of the normal mode: use "comfort" instead of "none"

Otherwise you don't have the possibility to turn it off:

<img width="380" height="339" alt="image" src="https://github.com/user-attachments/assets/2d5da13d-bb91-4b69-b54e-f4e0e7056cdb" />
