### PR TITLE
Add config for device EcoNour 42" tower fan HTS-F305A (new)

### DIFF
--- a/custom_components/tuya_local/devices/econour_htsf305a_towerfan.yaml
+++ b/custom_components/tuya_local/devices/econour_htsf305a_towerfan.yaml
@@ -69,7 +69,21 @@ entities:
         type: integer
         name: sensor
         class: measurement
-        unit: C
+        mapping:
+          - constraint: unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_f
+      - id: 101
+        type: integer
+        name: temp_f
+      - id: 28
+        type: string
+        name: unit
+        mapping:
+          - dps_val: f
+            value: F
+          - value: C
   - entity: select
     translation_key: timer
     category: config

--- a/custom_components/tuya_local/devices/econour_towerfan_hts-f305a.yaml
+++ b/custom_components/tuya_local/devices/econour_towerfan_hts-f305a.yaml
@@ -116,12 +116,3 @@ entities:
             value: celsius
           - dps_val: f
             value: fahrenheit
-  - entity: sensor
-    name: Temperature F
-    class: temperature
-    dps:
-      - id: 101
-        type: integer
-        name: sensor
-        class: measurement
-        unit: F

--- a/custom_components/tuya_local/devices/econour_towerfan_hts-f305a.yaml
+++ b/custom_components/tuya_local/devices/econour_towerfan_hts-f305a.yaml
@@ -1,0 +1,127 @@
+name: Fan
+products:
+  - id: 0kcxic8phbllew01
+    manufacturer: EcoNour
+    model: HTS-F305A
+entities:
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: fresh
+            value: normal
+          - dps_val: nature
+            value: nature
+          - dps_val: sleep
+            value: sleep
+          - dps_val: auto
+            value: auto
+      - id: 3
+        name: speed
+        type: integer
+        range:
+          min: 1
+          max: 12
+      - id: 5
+        name: oscillate
+        type: boolean
+  - entity: select
+    name: Oscillation angle
+    icon: "mdi:arrow-left-right-bold-outline"
+    category: config
+    dps:
+      - id: 7
+        type: string
+        name: option
+        mapping:
+          - dps_val: "30"
+            value: "30°"
+          - dps_val: "60"
+            value: "60°"
+          - dps_val: "90"
+            value: "90°"
+          - dps_val: "120"
+            value: "120°"
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 13
+        type: boolean
+        name: switch
+  - entity: light
+    translation_key: display
+    category: config
+    dps:
+      - id: 15
+        type: boolean
+        name: switch
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        class: measurement
+        unit: C
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: 1h
+            value: 1h
+          - dps_val: 2h
+            value: 2h
+          - dps_val: 3h
+            value: 3h
+          - dps_val: 4h
+            value: 4h
+          - dps_val: 5h
+            value: 5h
+          - dps_val: 6h
+            value: 6h
+          - dps_val: 7h
+            value: 7h
+          - dps_val: 8h
+            value: 8h
+          - dps_val: 9h
+            value: 9h
+          - dps_val: 10h
+            value: 10h
+          - dps_val: 11h
+            value: 11h
+          - dps_val: 12h
+            value: 12h
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 28
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+  - entity: sensor
+    name: Temperature F
+    class: temperature
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        class: measurement
+        unit: F


### PR DESCRIPTION
Added config for EcoNour 42" tower fan
There seem to be 2 other versions of the device sold under the same name earlier #4214 
This is the newer version ATTOW (2026), added model number in the file name for distinction.