### PR TITLE
Fix cover state stuck on opening/closing when motor settles near target position

### DIFF
--- a/custom_components/tuya_local/cover.py
+++ b/custom_components/tuya_local/cover.py
@@ -153,7 +153,7 @@ class TuyaLocalCover(TuyaLocalEntity, CoverEntity):
             and self._position_dp
         ):
             setpos = self._position_dp.get_value(self._device)
-            if setpos == pos:
+            if setpos is not None and abs(setpos - pos) <= 2:
                 # if the current position is around the set position,
                 # which is not closed, then we want is_closed to return
                 # false, so HA gets the full state from position.

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -350,6 +350,12 @@ class TestCurrentState:
         cover._position_dp.get_value.return_value = 50
         assert cover._current_state == "opened"
 
+    def test_mid_position_near_setpos_is_opened(self):
+        cover = _make_cover(action=False, currentpos=True, position=True)
+        cover._currentpos_dp.get_value.return_value = 49
+        cover._position_dp.get_value.return_value = 50
+        assert cover._current_state == "opened"
+
     def test_mid_position_with_open_cmd_is_opening(self):
         cover = _make_cover(action=False, currentpos=True, position=True, control=True)
         cover._currentpos_dp.get_value.return_value = 50


### PR DESCRIPTION
## Problem

On covers that have `position` and `current_position` dps but no reliable `action` dp, setting the cover to a mid position (anything other than fully open/closed) leaves the entity stuck reporting `opening`/`closing` after the motor has stopped — or `unknown` once the control dp returns to `stop`.

Fully opening or closing works fine, because the <5% / >95% thresholds resolve those cases.

## Cause

`_current_state` resolves a mid position by comparing the set position against the current position, but requires them to be **exactly equal**:

```python
setpos = self._position_dp.get_value(self._device)
if setpos == pos:
```

Some motors settle a percent or two off their target. My Zemismart ZM25R2 (`zemismart_roller_shade_zm25r2`) consistently lands 1% off — e.g. dps snapshot from diagnostics while stationary:

```
"1": "stop",   # control
"2": 14,       # target position
"3": 15,       # current position
"7": "opening" # unreliable_action, latched by firmware
```

Since `14 != 15`, the equality check never passes, and the state falls through to the last command on the control dp — reporting `opening`/`closing` indefinitely while the cover is stationary.

## Fix

Allow a small tolerance (±2%) in the comparison, which matches the intent of the existing comment ("if the current position is **around** the set position"). Also guards against `setpos` being `None` (the position dp is optional in some configs), which previously compared unequal and now would otherwise raise in `abs()`.

Tested on the ZM25R2: mid positions now settle to a resolved state (`open` at the reached position) instead of sticking on `opening`/`closing`, and full open/close behaviour is unchanged.

## Tests

Added `test_mid_position_near_setpos_is_opened` covering the near-match case. All existing cover tests pass (`58 passed`).
