### PR TITLE
Add Temprium PAC011 12,000 BTU Air Conditioner

### DIFF
--- a/custom_components/tuya_local/devices/temprium_pac011_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/temprium_pac011_airconditioner.yaml
@@ -21,6 +21,9 @@ entities:
                 value: dry
               - dps_val: Fan
                 value: fan_only
+              - dps_val: Heat
+                value: heat
+                available: support_heat
       - id: 2
         type: integer
         name: temperature
@@ -94,10 +97,11 @@ entities:
             value: comfort
       - id: 103
         type: string
-        name: model_id
+        name: support_heat
         mapping:
-          - dps_val: C
-            value: Cooling
+          - dps_val: C_H
+            value: true
+          - value: false
   - entity: binary_sensor
     class: problem
     category: diagnostic

--- a/custom_components/tuya_local/devices/temprium_pac011_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/temprium_pac011_airconditioner.yaml
@@ -1,0 +1,139 @@
+name: Air conditioner
+products:
+  - id: kzdx8i4g0wms1vta
+    manufacturer: Temprium
+    model: PAC011
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: Cool
+                value: cool
+              - dps_val: Dry
+                value: dry
+              - dps_val: Fan
+                value: fan_only
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 16
+          max: 32
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 61
+                  max: 90
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_current_f
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: Low
+            value: low
+          - dps_val: Mid
+            value: medium
+          - dps_val: High
+            value: high
+      - id: 15
+        type: string
+        name: swing_mode
+        mapping:
+          - dps_val: "OFF"
+            value: "off"
+          - dps_val: "ON"
+            value: "on"
+      - id: 19
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 23
+        type: integer
+        name: temp_set_f
+        optional: true
+        range:
+          min: 61
+          max: 90
+      - id: 24
+        type: integer
+        name: temp_current_f
+        optional: true
+      - id: 101
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: sleep
+          - dps_val: false
+            value: comfort
+      - id: 103
+        type: string
+        name: model_id
+        mapping:
+          - dps_val: C
+            value: Cooling
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 4
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 4
+            value: true
+          - value: false
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit


### PR DESCRIPTION
Identical to suntec_coolfix_airconditioner, except Dyr → Dry, and no sign of Heat mode, at least in the version on Amazon UK.

Diagnostics in dps 22 untested.

Note, this device has a bug confusing ºC and ºF, even in the official app. It'll say "81ºC" (!) then when switched to ºF, "28ºF", then a second later, "28ºC". When the temperature changes, it'll then go back to "82ºC", and so on. This behavior occurs in the API too, so I can't see a solution here that wouldn't be a hack.  Version: V.1.0.0(3.1.69), MCU: V1.0.0, no updates available.