### PR TITLE
Make loonas_curtain position invert conditional on motor direction

### DIFF
--- a/custom_components/tuya_local/devices/loonas_curtain.yaml
+++ b/custom_components/tuya_local/devices/loonas_curtain.yaml
@@ -43,6 +43,7 @@ entities:
           max: 100
         mapping:
           - invert: true
+          - available: reversed
       - id: 3
         name: current_position
         type: integer
@@ -52,6 +53,16 @@ entities:
           max: 100
         mapping:
           - invert: true
+          - available: reversed
+      - id: 5
+        name: reversed
+        type: string
+        optional: true
+        hidden: true
+        mapping:
+          - dps_val: back
+            value: true
+          - value: false
       - id: 7
         name: work_state
         type: string


### PR DESCRIPTION
Fixes the issue #5486 

loonas_curtain.yaml unconditionally inverts the position dps (2 and 3). However, when the motor direction (dp 5, control_back_mode, exposed as the "Reverse" config switch) is set to back, the device already reports position percentages flipped, so the unconditional invert becomes a double inversion: HA shows open as closed and disables the wrong cover buttons at the extremes. Commands via dp 1 (open/close/stop) are unaffected.

When the Reverse setting (dp 5, control_back_mode) is set to "back", the device reports position percentages already flipped, so the unconditional invert on dps 2 and 3 caused a double inversion: HA showed open as closed and disabled the wrong cover buttons at the extremes.

Invert the position dps only when dp 5 is "forward" or not reported (preserving existing behaviour for devices without dp 5), and skip the inversion when dp 5 is "back", matching what the Tuya app shows.