### PR TITLE
Leo's Loo Too / MEET: fix weight scale, decode notifications, add MEET variant

### DIFF
--- a/custom_components/tuya_local/devices/leos_loo_too.yaml
+++ b/custom_components/tuya_local/devices/leos_loo_too.yaml
@@ -13,22 +13,34 @@
 #   high   - add the "MEET" product id; mark DP2 (mode) and DP5 (delay) optional
 #            because they are absent on some units (MEET reports neither).
 #   high   - DP22 fault bitfield as a problem binary_sensor (same pattern and DP
-#            as sailesi_litterbox). Tuya fault labels (from the device data
-#            model): bit0 motor_fault, bit1 program_fault, bit2 g_sensor_fault.
-#   high   - decode DP21 notification bitfield into binary_sensors. Bit labels
-#            come from the device's own Tuya data model (the `notification`
-#            status_range: garbage_box_full, excessive_clean_times, cleaning,
-#            no_weight) and were cross-checked against observed behaviour over
-#            several days on all four units:
-#              bit0 (1)  = garbage_box_full -> "Bin full" (ground-truthed: the
-#                          box goes amber and latches this bit until the drawer
-#                          is emptied and the reset button pressed)
-#              bit2 (4)  = cleaning         -> "Cleaning" (auto-clean rotation)
-#              bit6 (64) = UV phase         -> "UV sterilizing" (an undocumented
-#                          device extension, not in the 4-bit documented model)
-#            bit1 (excessive_clean_times) and bit3 (no_weight) are left in the
-#            raw code sensor undecoded. All exposed as plain device states;
-#            alerting is left to the user's own automations.
+#            as sailesi_litterbox). Per the Tuya data model the bits are bit0
+#            motor_fault, bit1 program_fault, bit2 g_sensor_fault - UNVERIFIED
+#            here (no fault fired on any unit), so only the raw code is decoded,
+#            not per-bit sensors.
+#   high   - decode DP21 notification bitfield into binary_sensors. Bit meanings
+#            were established by OBSERVING the device (a multi-day capture of
+#            the async report stream plus a controlled manual-clean test), then
+#            checked against the Tuya data model. Observed behaviour is the
+#            source of truth; where the model disagrees, the device wins:
+#              bit0 (1)  = bin full -> "Bin full". Ground-truthed: the box goes
+#                          amber and latches this bit until the drawer is
+#                          emptied and reset. Matches model "garbage_box_full".
+#              bit1 (2)  = manual/commanded clean rotation active -> "Cleaning".
+#                          Held for the full ~71 s rotation on a timed
+#                          manual-clean press, then UV followed - the same
+#                          lifecycle as bit2. NOTE: the Tuya model labels this
+#                          bit "excessive_clean_times", which is WRONG for this
+#                          firmware: it is a sustained clean-active state, not a
+#                          momentary warning.
+#              bit2 (4)  = auto-clean rotation active -> "Cleaning". Same ~70 s
+#                          rotation lifecycle, self-triggered. Matches
+#                          "cleaning".
+#              bit6 (64) = UV sterilisation phase -> "UV sterilizing". Not in
+#                          the documented 4-bit model at all (a device add-on).
+#            "Cleaning" therefore matches bits 1|2 (mask 6) so it covers both
+#            manual and auto cleans. bit3 ("no_weight") was never observed and
+#            is left in the raw code sensor undecoded. All exposed as plain
+#            device states; alerting is left to the user's own automations.
 #   high   - remove DP7 "times used today" (code excretion_times_day): on the
 #            local protocol it always reads 1. It is a per-use event pulse that
 #            the Tuya cloud accumulates server-side (status_range report_type
@@ -122,8 +134,9 @@ entities:
       - id: 9
         type: boolean
         name: button
-  # DP22 fault bitfield. Tuya labels: bit0 motor_fault, bit1 program_fault,
-  # bit2 g_sensor_fault. Any non-zero bit -> problem; raw code kept too.
+  # DP22 fault bitfield. Any non-zero bit -> problem; raw fault_code kept so the
+  # specific bit can be decoded when one actually fires. (Tuya model labels,
+  # unverified here: bit0 motor, bit1 program, bit2 g_sensor.)
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -163,8 +176,11 @@ entities:
         name: sensor
         optional: true
         mapping:
-          # bit2 (4) = "cleaning": auto-clean rotation in progress.
-          - dps_val: 4
+          # bits 1|2 (mask 6): a clean rotation is active. bit2 = auto-clean,
+          # bit1 = manual/commanded clean (both observed holding for the full
+          # ~70 s rotation). The device's own model mislabels bit1 as
+          # "excessive_clean_times"; observation shows it is clean-active.
+          - dps_val: 6
             value: true
           - value: false
   - entity: binary_sensor

--- a/custom_components/tuya_local/devices/leos_loo_too.yaml
+++ b/custom_components/tuya_local/devices/leos_loo_too.yaml
@@ -1,16 +1,45 @@
-name: Pet toilet
+# Leo's Loo Too / MEET self-cleaning cat toilet  (Tuya category "msp")
+#
+# Corrected against live tinytuya DP dumps from four physical units (three
+# "Leo's Loo Too", one rebadged "MEET") plus the Tuya cloud values as a
+# reference oracle, and a multi-day passive capture of the async report stream
+# that decoded the DP21 notification bitfield. See the PR description / repo
+# README for the captured evidence.
+#
+# Changes vs the previous config, by confidence:
+#   high   - weight DP6 scale 0.1 -> 10 (raw is tenths of a kg: 42 -> 4.2 kg;
+#            0.1 produced 420 kg). Matches the other weight litterbox configs
+#            (duoqu, vevor, homall all use scale 10).
+#   high   - add the "MEET" product id; mark DP2 (mode) and DP5 (delay) optional
+#            because they are absent on some units (MEET reports neither).
+#   high   - DP22 fault bitfield as a problem binary_sensor (same pattern and DP
+#            as sailesi_litterbox, the sibling Tuya litterbox config).
+#   high   - decode DP21 notification bitfield into binary_sensors. Bits were
+#            confirmed by correlating the async report stream against observed
+#            device behaviour over several days across all four units:
+#              bit0 (1)  = bin full / needs emptying  (ground-truthed: the box
+#                          goes amber and holds this bit until the drawer is
+#                          emptied and the reset button pressed)
+#              bit1 (2)  = manual clean / reset rotation active
+#              bit2 (4)  = auto clean rotation active
+#              bit6 (64) = UV sterilisation phase active
+#            The raw code is kept as a diagnostic sensor for any undecoded bits.
+#            These are exposed as plain device states; alerting is left to the
+#            user's own automations rather than baked into the integration.
+#   high   - remove DP7 "times used today": it is a dead constant (=1) on every
+#            observed unit and never updates locally (corroborated by the public
+#            dump in issue #1840). The real use count is not exposed on the LAN.
+#   high   - remove the DP16 "light" entity: DP16 does not exist on this
+#            hardware (it was speculative and left the entity unavailable).
+name: Leo's Loo Too
 products:
   - id: 1badzyvwh1e1hrog
     manufacturer: "Leo's Loo"
     model: Too
+  - id: kw4ztiq3kxmcf8dx
+    manufacturer: "Leo's Loo"
+    model: Too (MEET)
 entities:
-  - entity: sensor
-    name: Times used today
-    icon: "mdi:counter"
-    dps:
-      - id: 7
-        type: integer
-        name: sensor
   - entity: switch
     name: Power
     category: config
@@ -27,6 +56,8 @@ entities:
       - id: 2
         type: string
         name: option
+        # Reported only by some units (the MEET variant omits it).
+        optional: true
         mapping:
           - dps_val: auto_clean
             value: Auto clean
@@ -40,13 +71,14 @@ entities:
       - id: 13
         name: switch
         type: boolean
-  - entity: light
+  - entity: switch
+    translation_key: sleep
     category: config
+    class: switch
     dps:
-      - id: 16
+      - id: 10
         name: switch
         type: boolean
-        optional: true
   - entity: number
     category: config
     name: Cleaning delay
@@ -56,6 +88,8 @@ entities:
       - id: 5
         type: integer
         name: value
+        # Absent on the MEET variant.
+        optional: true
         range:
           min: 6
           max: 1200
@@ -69,8 +103,12 @@ entities:
         type: integer
         name: sensor
         unit: kg
+        # Live pad reading (box + litter + waste standing load), so it is a
+        # measurement rather than a stable per-cat weight.
+        class: measurement
         mapping:
-          - scale: 0.1
+          # Raw value is in tenths of a kg (42 -> 4.2 kg, cloud-confirmed).
+          - scale: 10
   - entity: button
     icon: "mdi:heat-pump-outline"
     name: Manual clean
@@ -78,3 +116,69 @@ entities:
       - id: 9
         type: boolean
         name: button
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+  # DP21 notification bitfield, decoded into individual device states (no
+  # problem/alert semantics - the box going amber is routine, so leave any
+  # alerting to the user's automations). bit0 latches until the bin is reset.
+  - entity: binary_sensor
+    name: Bin full
+    icon: "mdi:tray-full"
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 1
+            value: true
+          - value: false
+  - entity: binary_sensor
+    name: Cleaning
+    class: running
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          # bits 1|2 (mask 6): manual or auto rotation in progress.
+          - dps_val: 6
+            value: true
+          - value: false
+  - entity: binary_sensor
+    name: UV sterilizing
+    class: running
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 64
+            value: true
+          - value: false
+  # Raw notification code retained for any bits not yet decoded.
+  - entity: sensor
+    name: Notification code
+    icon: "mdi:bell-alert"
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        optional: true

--- a/custom_components/tuya_local/devices/leos_loo_too.yaml
+++ b/custom_components/tuya_local/devices/leos_loo_too.yaml
@@ -39,24 +39,29 @@
 #                          the documented 4-bit model at all (a device add-on).
 #            "Cleaning" therefore matches bits 1|2 (mask 6) so it covers both
 #            manual and auto cleans. bit3 ("no_weight") was never observed and
-#            is left in the raw code sensor undecoded. All exposed as plain
-#            device states; alerting is left to the user's own automations.
-#   high   - remove DP7 "times used today" (code excretion_times_day): on the
-#            local protocol it always reads 1. It is a per-use event pulse that
-#            the Tuya cloud accumulates server-side (status_range report_type
-#            "sum") into a daily total; the local value never changes, so it is
-#            useless as a local sensor. (The dump in issue #1840 also shows =1.)
-#   medium - remove the DP16 "light" entity: it exists in the Tuya data model
-#            but is never reported on the local protocol, so it only ever
-#            stranded a permanently-unavailable entity.
+#            is left undecoded in the raw notification_code attribute (carried
+#            on the fault binary_sensor). All exposed as plain device states;
+#            alerting is left to the user's own automations.
+#   high   - DP7 "times used today" (excretion_times_day) reads a constant 1 on
+#            the local protocol: a per-use pulse the cloud sums server-side, so
+#            the local value never changes. Rather than remove it (orphaning the
+#            entity in existing installs) it is kept, and hidden when the dp is
+#            absent (available null-test + hidden: unavailable). #1840's dump
+#            shows =1 too.
+#   medium - DP16 "light" is never reported on the local protocol here. It
+#            shipped in the released config, so it is kept but marked
+#            hidden: true rather than removed (removal would orphan the entity).
 name: Leo's Loo Too
 products:
   - id: 1badzyvwh1e1hrog
     manufacturer: "Leo's Loo"
     model: Too
+  # Same physical Leo's Loo Too hardware, owner-confirmed - this unit just
+  # shipped carrying the MEET / Chinese-market firmware profile, which enrols
+  # under a different Tuya product id. Not a separate MEET-branded product.
   - id: kw4ztiq3kxmcf8dx
     manufacturer: "Leo's Loo"
-    model: Too (MEET)
+    model: Too (MEET firmware)
 entities:
   - entity: switch
     name: Power
@@ -97,6 +102,17 @@ entities:
       - id: 10
         name: switch
         type: boolean
+  # DP16 "light" is never reported on the local protocol here, but it shipped in
+  # the released config, so it is kept and simply hidden by default rather than
+  # removed - removing a released entity would orphan it in existing registries.
+  - entity: light
+    category: config
+    hidden: true
+    dps:
+      - id: 16
+        name: switch
+        type: boolean
+        optional: true
   - entity: number
     category: config
     name: Cleaning delay
@@ -127,6 +143,28 @@ entities:
         mapping:
           # Raw value is in tenths of a kg (42 -> 4.2 kg, cloud-confirmed).
           - scale: 10
+  # DP7 "times used today" (excretion_times_day) reads a constant 1 on the local
+  # protocol here - a per-use pulse the cloud sums server-side, so the local
+  # value never changes. It shipped in the released config and another variant
+  # may report it, so rather than remove it (which would orphan the entity in
+  # existing installs) it is kept, and hidden when the dp is absent.
+  - entity: sensor
+    name: Times used today
+    icon: "mdi:counter"
+    hidden: unavailable
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        optional: true
+      - id: 7
+        type: integer
+        name: available
+        optional: true
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
   - entity: button
     icon: "mdi:heat-pump-outline"
     name: Manual clean
@@ -136,7 +174,9 @@ entities:
         name: button
   # DP22 fault bitfield. Any non-zero bit -> problem; raw fault_code kept so the
   # specific bit can be decoded when one actually fires. (Tuya model labels,
-  # unverified here: bit0 motor, bit1 program, bit2 g_sensor.)
+  # unverified here: bit0 motor, bit1 program, bit2 g_sensor.) The raw DP21
+  # notification code rides along here as the notification_code attribute rather
+  # than as its own sensor - it is only useful for decoding any leftover bits.
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -151,6 +191,10 @@ entities:
       - id: 22
         type: bitfield
         name: fault_code
+      - id: 21
+        type: bitfield
+        name: notification_code
+        optional: true
   # DP21 notification bitfield, decoded into individual device states (no
   # problem/alert semantics - the box going amber is routine, so leave any
   # alerting to the user's automations). bit0 latches until the bin is reset.
@@ -196,13 +240,3 @@ entities:
           - dps_val: 64
             value: true
           - value: false
-  # Raw notification code retained for any bits not yet decoded.
-  - entity: sensor
-    name: Notification code
-    icon: "mdi:bell-alert"
-    category: diagnostic
-    dps:
-      - id: 21
-        type: bitfield
-        name: sensor
-        optional: true

--- a/custom_components/tuya_local/devices/leos_loo_too.yaml
+++ b/custom_components/tuya_local/devices/leos_loo_too.yaml
@@ -1,68 +1,33 @@
-# Leo's Loo Too / MEET self-cleaning cat toilet  (Tuya category "msp")
-#
-# Corrected against live tinytuya DP dumps from four physical units (three
-# "Leo's Loo Too", one rebadged "MEET") plus the Tuya cloud values as a
-# reference oracle, and a multi-day passive capture of the async report stream
-# that decoded the DP21 notification bitfield. See the PR description / repo
-# README for the captured evidence.
-#
-# Changes vs the previous config, by confidence:
-#   high   - weight DP6 scale 0.1 -> 10 (raw is tenths of a kg: 42 -> 4.2 kg;
-#            0.1 produced 420 kg). Matches the other weight litterbox configs
-#            (duoqu, vevor, homall all use scale 10).
-#   high   - add the "MEET" product id; mark DP2 (mode) and DP5 (delay) optional
-#            because they are absent on some units (MEET reports neither).
-#   high   - DP22 fault bitfield as a problem binary_sensor (same pattern and DP
-#            as sailesi_litterbox). Per the Tuya data model the bits are bit0
-#            motor_fault, bit1 program_fault, bit2 g_sensor_fault - UNVERIFIED
-#            here (no fault fired on any unit), so only the raw code is decoded,
-#            not per-bit sensors.
-#   high   - decode DP21 notification bitfield into binary_sensors. Bit meanings
-#            were established by OBSERVING the device (a multi-day capture of
-#            the async report stream plus a controlled manual-clean test), then
-#            checked against the Tuya data model. Observed behaviour is the
-#            source of truth; where the model disagrees, the device wins:
-#              bit0 (1)  = bin full -> "Bin full". Ground-truthed: the box goes
-#                          amber and latches this bit until the drawer is
-#                          emptied and reset. Matches model "garbage_box_full".
-#              bit1 (2)  = manual/commanded clean rotation active -> "Cleaning".
-#                          Held for the full ~71 s rotation on a timed
-#                          manual-clean press, then UV followed - the same
-#                          lifecycle as bit2. NOTE: the Tuya model labels this
-#                          bit "excessive_clean_times", which is WRONG for this
-#                          firmware: it is a sustained clean-active state, not a
-#                          momentary warning.
-#              bit2 (4)  = auto-clean rotation active -> "Cleaning". Same ~70 s
-#                          rotation lifecycle, self-triggered. Matches
-#                          "cleaning".
-#              bit6 (64) = UV sterilisation phase -> "UV sterilizing". Not in
-#                          the documented 4-bit model at all (a device add-on).
-#            "Cleaning" therefore matches bits 1|2 (mask 6) so it covers both
-#            manual and auto cleans. bit3 ("no_weight") was never observed and
-#            is left undecoded in the raw notification_code attribute (carried
-#            on the fault binary_sensor). All exposed as plain device states;
-#            alerting is left to the user's own automations.
-#   high   - DP7 "times used today" (excretion_times_day) reads a constant 1 on
-#            the local protocol: a per-use pulse the cloud sums server-side, so
-#            the local value never changes. Rather than remove it (orphaning the
-#            entity in existing installs) it is kept, and hidden when the dp is
-#            absent (available null-test + hidden: unavailable). #1840's dump
-#            shows =1 too.
-#   medium - DP16 "light" is never reported on the local protocol here. It
-#            shipped in the released config, so it is kept but marked
-#            hidden: true rather than removed (removal would orphan the entity).
-name: Leo's Loo Too
+name: Pet toilet
 products:
   - id: 1badzyvwh1e1hrog
     manufacturer: "Leo's Loo"
     model: Too
-  # Same physical Leo's Loo Too hardware, owner-confirmed - this unit just
-  # shipped carrying the MEET / Chinese-market firmware profile, which enrols
-  # under a different Tuya product id. Not a separate MEET-branded product.
+  # Same hardware under the MEET / Chinese-market firmware, which enrols under a
+  # different Tuya product id - not a separate product.
   - id: kw4ztiq3kxmcf8dx
     manufacturer: "Leo's Loo"
     model: Too (MEET firmware)
 entities:
+  - entity: sensor
+    name: Times used today
+    icon: "mdi:counter"
+    # Constant 1 on the local protocol; the cloud sums per-use pulses
+    # server-side, so the LAN value never changes.
+    hidden: unavailable
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        optional: true
+      - id: 7
+        type: integer
+        name: available
+        optional: true
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
   - entity: switch
     name: Power
     category: config
@@ -79,7 +44,7 @@ entities:
       - id: 2
         type: string
         name: option
-        # Reported only by some units (the MEET variant omits it).
+        # Absent on some units (the MEET variant omits it).
         optional: true
         mapping:
           - dps_val: auto_clean
@@ -102,11 +67,9 @@ entities:
       - id: 10
         name: switch
         type: boolean
-  # DP16 "light" is never reported on the local protocol here, but it shipped in
-  # the released config, so it is kept and simply hidden by default rather than
-  # removed - removing a released entity would orphan it in existing registries.
   - entity: light
     category: config
+    # Not reported on the local protocol here.
     hidden: true
     dps:
       - id: 16
@@ -137,34 +100,11 @@ entities:
         type: integer
         name: sensor
         unit: kg
-        # Live pad reading (box + litter + waste standing load), so it is a
-        # measurement rather than a stable per-cat weight.
+        # Live pad load (box + litter + waste), not a per-cat weight.
         class: measurement
         mapping:
-          # Raw value is in tenths of a kg (42 -> 4.2 kg, cloud-confirmed).
+          # Raw value is tenths of a kg (42 = 4.2 kg).
           - scale: 10
-  # DP7 "times used today" (excretion_times_day) reads a constant 1 on the local
-  # protocol here - a per-use pulse the cloud sums server-side, so the local
-  # value never changes. It shipped in the released config and another variant
-  # may report it, so rather than remove it (which would orphan the entity in
-  # existing installs) it is kept, and hidden when the dp is absent.
-  - entity: sensor
-    name: Times used today
-    icon: "mdi:counter"
-    hidden: unavailable
-    dps:
-      - id: 7
-        type: integer
-        name: sensor
-        optional: true
-      - id: 7
-        type: integer
-        name: available
-        optional: true
-        mapping:
-          - dps_val: null
-            value: false
-          - value: true
   - entity: button
     icon: "mdi:heat-pump-outline"
     name: Manual clean
@@ -172,14 +112,12 @@ entities:
       - id: 9
         type: boolean
         name: button
-  # DP22 fault bitfield. Any non-zero bit -> problem; raw fault_code kept so the
-  # specific bit can be decoded when one actually fires. (Tuya model labels,
-  # unverified here: bit0 motor, bit1 program, bit2 g_sensor.) The raw DP21
-  # notification code rides along here as the notification_code attribute rather
-  # than as its own sensor - it is only useful for decoding any leftover bits.
   - entity: binary_sensor
     class: problem
     category: diagnostic
+    # Any non-zero DP22 bit -> problem; raw fault_code kept to decode the bit
+    # when one fires (model labels, unverified: bit0 motor, bit1 program,
+    # bit2 g_sensor).
     dps:
       - id: 22
         type: bitfield
@@ -195,12 +133,10 @@ entities:
         type: bitfield
         name: notification_code
         optional: true
-  # DP21 notification bitfield, decoded into individual device states (no
-  # problem/alert semantics - the box going amber is routine, so leave any
-  # alerting to the user's automations). bit0 latches until the bin is reset.
   - entity: binary_sensor
     name: Bin full
     icon: "mdi:tray-full"
+    # DP21 bit0; latches until the bin is emptied and reset.
     dps:
       - id: 21
         type: bitfield
@@ -220,10 +156,8 @@ entities:
         name: sensor
         optional: true
         mapping:
-          # bits 1|2 (mask 6): a clean rotation is active. bit2 = auto-clean,
-          # bit1 = manual/commanded clean (both observed holding for the full
-          # ~70 s rotation). The device's own model mislabels bit1 as
-          # "excessive_clean_times"; observation shows it is clean-active.
+          # DP21 bits 1|2 (mask 6): a clean rotation is active (bit2 auto,
+          # bit1 manual/commanded).
           - dps_val: 6
             value: true
           - value: false

--- a/custom_components/tuya_local/devices/leos_loo_too.yaml
+++ b/custom_components/tuya_local/devices/leos_loo_too.yaml
@@ -13,24 +13,30 @@
 #   high   - add the "MEET" product id; mark DP2 (mode) and DP5 (delay) optional
 #            because they are absent on some units (MEET reports neither).
 #   high   - DP22 fault bitfield as a problem binary_sensor (same pattern and DP
-#            as sailesi_litterbox, the sibling Tuya litterbox config).
-#   high   - decode DP21 notification bitfield into binary_sensors. Bits were
-#            confirmed by correlating the async report stream against observed
-#            device behaviour over several days across all four units:
-#              bit0 (1)  = bin full / needs emptying  (ground-truthed: the box
-#                          goes amber and holds this bit until the drawer is
-#                          emptied and the reset button pressed)
-#              bit1 (2)  = manual clean / reset rotation active
-#              bit2 (4)  = auto clean rotation active
-#              bit6 (64) = UV sterilisation phase active
-#            The raw code is kept as a diagnostic sensor for any undecoded bits.
-#            These are exposed as plain device states; alerting is left to the
-#            user's own automations rather than baked into the integration.
-#   high   - remove DP7 "times used today": it is a dead constant (=1) on every
-#            observed unit and never updates locally (corroborated by the public
-#            dump in issue #1840). The real use count is not exposed on the LAN.
-#   high   - remove the DP16 "light" entity: DP16 does not exist on this
-#            hardware (it was speculative and left the entity unavailable).
+#            as sailesi_litterbox). Tuya fault labels (from the device data
+#            model): bit0 motor_fault, bit1 program_fault, bit2 g_sensor_fault.
+#   high   - decode DP21 notification bitfield into binary_sensors. Bit labels
+#            come from the device's own Tuya data model (the `notification`
+#            status_range: garbage_box_full, excessive_clean_times, cleaning,
+#            no_weight) and were cross-checked against observed behaviour over
+#            several days on all four units:
+#              bit0 (1)  = garbage_box_full -> "Bin full" (ground-truthed: the
+#                          box goes amber and latches this bit until the drawer
+#                          is emptied and the reset button pressed)
+#              bit2 (4)  = cleaning         -> "Cleaning" (auto-clean rotation)
+#              bit6 (64) = UV phase         -> "UV sterilizing" (an undocumented
+#                          device extension, not in the 4-bit documented model)
+#            bit1 (excessive_clean_times) and bit3 (no_weight) are left in the
+#            raw code sensor undecoded. All exposed as plain device states;
+#            alerting is left to the user's own automations.
+#   high   - remove DP7 "times used today" (code excretion_times_day): on the
+#            local protocol it always reads 1. It is a per-use event pulse that
+#            the Tuya cloud accumulates server-side (status_range report_type
+#            "sum") into a daily total; the local value never changes, so it is
+#            useless as a local sensor. (The dump in issue #1840 also shows =1.)
+#   medium - remove the DP16 "light" entity: it exists in the Tuya data model
+#            but is never reported on the local protocol, so it only ever
+#            stranded a permanently-unavailable entity.
 name: Leo's Loo Too
 products:
   - id: 1badzyvwh1e1hrog
@@ -116,6 +122,8 @@ entities:
       - id: 9
         type: boolean
         name: button
+  # DP22 fault bitfield. Tuya labels: bit0 motor_fault, bit1 program_fault,
+  # bit2 g_sensor_fault. Any non-zero bit -> problem; raw code kept too.
   - entity: binary_sensor
     class: problem
     category: diagnostic
@@ -155,8 +163,8 @@ entities:
         name: sensor
         optional: true
         mapping:
-          # bits 1|2 (mask 6): manual or auto rotation in progress.
-          - dps_val: 6
+          # bit2 (4) = "cleaning": auto-clean rotation in progress.
+          - dps_val: 4
             value: true
           - value: false
   - entity: binary_sensor


### PR DESCRIPTION
## Leo's Loo Too / MEET self-cleaning cat toilet — corrected config + notification decode

This corrects and extends the `leos_loo_too.yaml` config (Tuya category `msp`)
against live data from **four physical units** — three "Leo's Loo Too"
(`1badzyvwh1e1hrog`) and one rebadged "MEET" (`kw4ztiq3kxmcf8dx`) on identical
hardware — plus the Tuya cloud values as a reference oracle, and a multi-day
passive capture of the device's async report stream that decoded the DP21
notification bitfield.

### Changes

| Change | Confidence | Evidence |
| --- | --- | --- |
| **Weight DP6 scale `0.1` → `10`** | high | Raw is tenths of a kg (42 → 4.2 kg, matches cloud). The old `0.1` produced 420 kg. Consistent with the other weight litterbox configs (`duoqu`, `vevor`, `homall` all use `scale: 10`). |
| **Add the `kw4ztiq3kxmcf8dx` product id** | high | One unit enrols under this second product id. Owner-confirmed it is the *same* physical Leo's Loo Too hardware carrying the MEET / Chinese-market firmware profile — not a separate MEET product — so it stays under the `Leo's Loo` brand with model `Too (MEET firmware)`. |
| **DP2 (mode) / DP5 (delay) → `optional`** | high | Absent on that firmware variant (reports neither). |
| **DP22 fault → problem binary_sensor** | high | Same DP/pattern as the sibling `sailesi_litterbox` config. Also carries the raw DP21 notification code as a `notification_code` attribute (per review — see below). |
| **Decode DP21 notification bitfield** | high | See bit table below — confirmed by correlating the async report stream against observed device behaviour across all four units over several days. |
| **Keep DP7 "times used today", hidden** | high | Dead constant (`=1`) on every observed unit; never updates locally (also `1` in #1840's dump), so the real per-use count is not exposed on the LAN. Per review, rather than removing it (which would orphan the entity in existing installs) it is kept with an `available` null-test + `hidden: unavailable`, so it hides only where the DP is absent. |
| **Keep DP16 "light", hidden** | high | Never reported on the local protocol, so it only stranded an `unavailable` entity — but per review it is kept with `hidden: true` rather than removed, to avoid orphaning it in existing registries. |

### DP21 notification bits (decoded)

| Bit (value) | Meaning | Exposed as |
| --- | --- | --- |
| bit0 (1) | **Bin full / needs emptying** — box goes amber and *latches* this bit until the drawer is emptied and the reset button pressed | `binary_sensor` "Bin full" (plain on/off state) |
| bit1 (2) | Manual / commanded clean rotation active | folded into "Cleaning" (class `running`, mask 6) |
| bit2 (4) | Auto-clean rotation active | folded into "Cleaning" (class `running`, mask 6) |
| bit6 (64) | UV sterilisation phase active | `binary_sensor` "UV sterilizing" (class `running`) |

The raw notification code is retained as a `notification_code` attribute on the
DP22 Fault sensor (per review — not its own entity) so any remaining undecoded
bits stay observable. These are exposed as plain device **states** —
"bin full" is routine operation, not a malfunction, so no `problem`/alert
semantics are baked in; alerting is left to the user's own automations. (The
separate DP22 **Fault** binary_sensor keeps `class: problem`, as a fault is a
genuine device malfunction.)

The **bit0 "bin full"** decode was ground-truthed: an owner found the physical
amber "needs emptying" ring on a box while DP21 read exactly `1`; pressing the
reset button cleared it (`1 → 2 → …`), all signalled through DP21.

The **bit1 vs bit2** distinction was ground-truthed with a controlled test: a
timed manual-clean button press drove `DP21 0 → 2`, and **`2` held for 71 s** —
the full clean rotation, watched on the device — before clearing to `0`, with
the UV phase (`64`) following 6 s later. That is the identical lifecycle to a
bit2 auto-clean, just signalled on bit1, so **both bits mean "a clean rotation
is active"** and "Cleaning" masks them together (mask 6). Note: the device's own
Tuya data model labels bit1 `excessive_clean_times`, but the sustained 71-second
hold shows it is a clean-active state on this firmware, not a momentary warning —
so this decode follows the observed behaviour, not that label. (The DP22 fault
bit labels `motor`/`program`/`g_sensor` from the same model are left unverified,
as no fault fired on any unit; only the raw fault code is exposed.)

### Notes for the maintainer
- New binary_sensors use `name:` rather than `translation_key:` — happy to
  switch to translation keys (with `strings.json` additions) if preferred.
- Prior art: #1840 has another owner's raw dump corroborating DP7=1 and DP101=15.


