### PR TITLE
Add support for Arlec APDC160WHA DC Pedestal Fan (Grid Connect)

### DIFF
--- a/custom_components/tuya_local/devices/arlec_apdc160wha_fan.yaml
+++ b/custom_components/tuya_local/devices/arlec_apdc160wha_fan.yaml
@@ -40,7 +40,7 @@ entities:
         type: string
         mapping:
           - dps_val: cancel
-            value: Off
+            value: "Off"
           - dps_val: "0_5"
             value: "0.5 Hours"
           - dps_val: "1_0"

--- a/custom_components/tuya_local/devices/arlec_apdc160wha_fan.yaml
+++ b/custom_components/tuya_local/devices/arlec_apdc160wha_fan.yaml
@@ -1,0 +1,83 @@
+name: Arlec APDC160WHA Fan
+
+products:
+  - id: smhdmlhcphmigvse
+    name: APDC160WHA
+
+entities:
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: normal
+            value: normal
+          - dps_val: nature
+            value: nature
+          - dps_val: sleep
+            value: sleep
+      - id: 3
+        name: speed
+        type: integer
+        range:
+          min: 1
+          max: 15
+      - id: 5
+        name: oscillate
+        type: boolean
+
+  - entity: select
+    name: Timer
+    category: config
+    dps:
+      - id: 22
+        name: option
+        type: string
+        mapping:
+          - dps_val: cancel
+            value: Off
+          - dps_val: "0_5"
+            value: "0.5 Hours"
+          - dps_val: "1_0"
+            value: "1 Hour"
+          - dps_val: "1_5"
+            value: "1.5 Hours"
+          - dps_val: "2_0"
+            value: "2 Hours"
+          - dps_val: "2_5"
+            value: "2.5 Hours"
+          - dps_val: "3_0"
+            value: "3 Hours"
+          - dps_val: "3_5"
+            value: "3.5 Hours"
+          - dps_val: "4_0"
+            value: "4 Hours"
+          - dps_val: "4_5"
+            value: "4.5 Hours"
+          - dps_val: "5_0"
+            value: "5 Hours"
+          - dps_val: "5_5"
+            value: "5.5 Hours"
+          - dps_val: "6_0"
+            value: "6 Hours"
+          - dps_val: "6_5"
+            value: "6.5 Hours"
+          - dps_val: "7_0"
+            value: "7 Hours"
+          - dps_val: "7_5"
+            value: "7.5 Hours"
+          - dps_val: "8_0"
+            value: "8 Hours"
+          - dps_val: "8_5"
+            value: "8.5 Hours"
+          - dps_val: "9_0"
+            value: "9 Hours"
+          - dps_val: "9_5"
+            value: "9.5 Hours"
+          - dps_val: "10_0"
+            value: "10 Hours"

--- a/custom_components/tuya_local/devices/arlec_apdc160wha_fan.yaml
+++ b/custom_components/tuya_local/devices/arlec_apdc160wha_fan.yaml
@@ -32,7 +32,7 @@ entities:
         type: boolean
 
   - entity: select
-    name: Timer
+    translation_key: timer
     category: config
     dps:
       - id: 22


### PR DESCRIPTION
Adds support for the Arlec APDC160WHA DC Pedestal Fan sold by Bunnings (Grid Connect).

Tested successfully on a physical Arlec APDC160WHA fan using Home Assistant 2026.6.4.

The previous definition exposed DPS 24 as a binary sensor, however this device does not support it and Home Assistant generated errors.

This definition supports:

- On/Off
- 15 fan speeds
- Preset modes (Normal, Nature, Sleep)
- Oscillation
- Timer


A Tuya Local diagnostics/DPS export is attached for verification.
[config_entry-tuya_local-01KTJJ5N2BFVECFM9AWMVZSTAZ.json](https://github.com/user-attachments/files/29669763/config_entry-tuya_local-01KTJJ5N2BFVECFM9AWMVZSTAZ.json)

