### PR TITLE
Add Elechico / Chico CCIB001-CC1177D ice bath heat pump controller

### DIFF
--- a/custom_components/tuya_local/devices/elechico_ccib001_heatpump.yaml
+++ b/custom_components/tuya_local/devices/elechico_ccib001_heatpump.yaml
@@ -4,14 +4,14 @@
 # Authoritative datapoint spec from Tuya IoT "Query Things Data Model"
 # (GET /v2.0/cloud/thing/<device_id>/model), 24 DPs total:
 #   1  switch            bool                     power on/off
-#   2  temp_set          value 3..45 °C step1     target temperature
-#   3  temp_current      value -40..200 °C  (ro)  inlet water temperature
+#   2  temp_set          value 3..45 °C step1     target temperature (°C)
+#   3  temp_current      value -40..200 °C  (ro)  inlet water temperature (°C)
 #   4  mode              enum [auto, heat, cool]  0-auto / 1-heat / 2-cool
 #   17 temp_unit_convert enum [c, f]
 #   20 fault             bitmap 14 bits:
 #      01 02 03 04 05 06 09 10 12 15 16 18 20 21
-#   25 temp_set_f        value 37..113 °F         mirror of 2
-#   26 temp_current_f    value -40..200 °F  (ro)  mirror of 3
+#   25 temp_set_f        value 37..113 °F         target temperature (°F)
+#   26 temp_current_f    value -40..200 °F  (ro)  inlet water temperature (°F)
 #   101..116  two schedule timers (timer1: 101-107,115 / timer2: 108-114,116):
 #     101/108 timerN enable (bool); 102-105/109-112 on-h,on-m,off-h,off-m;
 #     106/113 timer mode enum[auto,heat,cool]; 107/114 timer temp °C;
@@ -55,10 +55,33 @@ entities:
         range:
           min: 3
           max: 45
-        unit: C
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 37
+                  max: 113
+      - id: 25
+        type: integer
+        name: temp_set_f
+        optional: true
+        range:
+          min: 37
+          max: 113
       - id: 3
         type: integer
         name: current_temperature
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_current_f
+      - id: 26
+        type: integer
+        name: temp_current_f
+        optional: true
       - id: 17
         type: string
         name: temperature_unit
@@ -68,7 +91,6 @@ entities:
           - dps_val: f
             value: F
   - entity: binary_sensor
-    name: Fault
     class: problem
     category: diagnostic
     dps:
@@ -79,11 +101,6 @@ entities:
           - dps_val: 0
             value: false
           - value: true
-  - entity: sensor
-    name: Fault code
-    category: diagnostic
-    icon: "mdi:alert-circle"
-    dps:
       - id: 20
         type: bitfield
-        name: sensor
+        name: fault_code

--- a/custom_components/tuya_local/devices/elechico_ccib001_heatpump.yaml
+++ b/custom_components/tuya_local/devices/elechico_ccib001_heatpump.yaml
@@ -1,0 +1,89 @@
+# Elechico / Guangdong Chico CCIB001-CC1177D — pool / ice-bath heat pump chiller
+# (Tuya Wi-Fi module + separate MCU, TuyaMCU). Local protocol 3.4.
+#
+# Authoritative datapoint spec from Tuya IoT "Query Things Data Model"
+# (GET /v2.0/cloud/thing/<device_id>/model), 24 DPs total:
+#   1  switch            bool                     power on/off
+#   2  temp_set          value 3..45 °C step1     target temperature
+#   3  temp_current      value -40..200 °C  (ro)  inlet water temperature
+#   4  mode              enum [auto, heat, cool]  0-auto / 1-heat / 2-cool
+#   17 temp_unit_convert enum [c, f]
+#   20 fault             bitmap 14 bits:
+#      01 02 03 04 05 06 09 10 12 15 16 18 20 21
+#   25 temp_set_f        value 37..113 °F         mirror of 2
+#   26 temp_current_f    value -40..200 °F  (ro)  mirror of 3
+#   101..116  two schedule timers (timer1: 101-107,115 / timer2: 108-114,116):
+#     101/108 timerN enable (bool); 102-105/109-112 on-h,on-m,off-h,off-m;
+#     106/113 timer mode enum[auto,heat,cool]; 107/114 timer temp °C;
+#     115/116 timer temp °F. Not mapped here (thermostat scope).
+#
+# NOTE: the detailed telemetry visible on the controller HMI (exhaust gas /
+# evaporator coil / ambient temp, EEV opening, protection setpoints) is NOT
+# exposed in the Tuya data model — only the DPs above are available locally.
+name: Ice bath heat pump
+products:
+  - id: uliewnhms8amzxli
+    manufacturer: Elechico
+    model: CCIB001-CC1177D
+entities:
+  - entity: climate
+    translation_only_key: pool_heatpump
+    icon: "mdi:hot-tub"
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: auto
+                value: auto
+              - dps_val: heat
+                value: heat
+              - dps_val: cool
+                value: cool
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 3
+          max: 45
+        unit: C
+      - id: 3
+        type: integer
+        name: current_temperature
+      - id: 17
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+  - entity: binary_sensor
+    name: Fault
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: sensor
+    name: Fault code
+    category: diagnostic
+    icon: "mdi:alert-circle"
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor


### PR DESCRIPTION
## New device: ice bath / cold plunge heat pump controller

**Brand / manufacturer:** Guangdong Chico Electronic Inc. (brand site: Elechico)
**Model:** CCIB001-CC1177D (4.3&#34; TFT touch controller PCBA)
**Product ID:** `uliewnhms8amzxli`
**Product page:** https://www.elechico.com/m/?cid-261_id-255_productinfo.html
**Manual:** https://github.com/barbalexs/elechico-ccib001-docs/blob/main/Controller%20CCIB001-CC1177D--Manual%20of%20ice%20bath%20heat%20pump%20controller%20-TFT.pdf
**Wiring diagram:** https://github.com/barbalexs/elechico-ccib001-docs/blob/main/Controller%20CCIB001-CC1177D--Wiring%20diagram%20of%20ice%20bath%20heat%20pump%20controller%20-TFT.pdf

Adds a `climate` entity (off/auto/heat/cool, 3–45 °C, °C/°F) plus a `problem`
`binary_sensor` carrying the fault flag with a `fault_code` attribute. Verified
locally against a real device (protocol 3.4): matched by product id, values
correct in all modes, fault flag toggles on DP20 ≠ 0.

### Entities
- **climate** — power (dp1) + mode (dp4 `auto`/`heat`/`cool`) → hvac_mode;
  target temp (dp2) and current temp (dp3) in °C, redirecting to dp25/dp26 with
  a 37–113 °F range when the unit (dp17) is set to `f`.
- **binary_sensor** (`problem`, diagnostic) — on when dp20 ≠ 0, exposing the raw
  bitmap as a `fault_code` attribute.

### Review changes (commit `f0d2117`)
Addressed maintainer review:
- temperature / current_temperature now redirect to dp25 / dp26 with the °F
  range for the `f` unit case;
- folded the separate "fault code" sensor into a `fault_code` attribute on the
  problem binary_sensor;
- dropped the binary_sensor name so HA's class translation is used.

### LOCAL DPS received from device
```json
{"1": false, "2": 3, "3": 6, "4": "cool", "17": "c", "20": 0, "26": 6,
 "101": false, "102": 7, "103": 0, "104": 9, "105": 0, "106": "cool",
 "107": 3, "108": false, "109": 20, "110": 0, "111": 20, "112": 30,
 "113": "auto", "114": 3}
```

### Data model (Tuya &#34;Query Things Data Model&#34;) — 24 DPs
| DP | code | type | range / values |
|----|------|------|----------------|
| 1 | switch | bool | power |
| 2 | temp_set | value | 3–45 °C, step 1 |
| 3 | temp_current | value (ro) | −40…200 °C |
| 4 | mode | enum | auto, heat, cool |
| 17 | temp_unit_convert | enum | c, f |
| 20 | fault | bitmap | 01 02 03 04 05 06 09 10 12 15 16 18 20 21 |
| 25 | temp_set_f | value | 37–113 °F |
| 26 | temp_current_f | value (ro) | −40…200 °F |
| 101–116 | timer3/4 … | mixed | two schedule timers (see below) |

**Not mapped (deliberate, thermostat scope):** DP101–116 are two schedule
timers (enable / on-h / on-m / off-h / off-m / mode / temp, ×2). Can add on
request as switch/number/select.

**Note:** the rich telemetry shown on the controller HMI (exhaust-gas /
evaporator-coil / ambient temp, EEV opening, protection setpoints) is **not**
present in the Tuya data model — only the 24 DPs above are available locally.

Config passes `yamllint` and `pytest tests/test_device_config.py` locally.