### PR TITLE
feat(meaco_cirro_airconditioner): add Cirro+ 16000 BTU cooling only

### DIFF
--- a/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/meaco_cirro_airconditioner.yaml
@@ -8,6 +8,10 @@ products:
     manufacturer: Meaco
     model: Cirro+ 14000 BTU Inverter
     model_id: CIRRO14000PRO
+  - id: ppkadch47agj28tc
+    manufacturer: Meaco
+    model: Cirro+ 16000 BTU Inverter
+    model_id: CIRRO16000PRO
 entities:
   - entity: climate
     dps:


### PR DESCRIPTION
Adds the confirmed Tuya product id (`ppkadch47agj28tc`) for the Meaco Cirro+ 16000 BTU Inverter, cooling-only (CIRRO16000PRO). This was previously listed as an unconfirmed placeholder comment.

Confirmed against my own unit by reading it locally over protocol v3.5 — all datapoints match the existing Cirro config, and cooling-only is correctly detected (the heat-capability datapoint reports `C`, not `C_H`).