### PR TITLE
Add Fakro ARZ Wi-Fi roof blind

### DIFF
--- a/custom_components/tuya_local/devices/fakro_arz_roofblind.yaml
+++ b/custom_components/tuya_local/devices/fakro_arz_roofblind.yaml
@@ -3,7 +3,6 @@ products:
   - id: wj3t8r1dguccdryj
     manufacturer: Fakro
     model: ARZ Wi-Fi
-    name: Roof blind
 entities:
   # Only "position" (dp 2) is required for matching; everything else is
   # optional: true, because the device does not report all DPs in the first
@@ -52,6 +51,10 @@ entities:
       - id: 12
         type: bitfield
         name: fault_code
+        optional: true
+      - id: 103
+        type: boolean
+        name: service_flag
         optional: true
   - entity: binary_sensor
     class: moving
@@ -141,12 +144,4 @@ entities:
       - id: 104
         type: boolean
         name: switch
-        optional: true
-  - entity: binary_sensor
-    name: Service flag
-    category: diagnostic
-    dps:
-      - id: 103
-        type: boolean
-        name: sensor
         optional: true

--- a/custom_components/tuya_local/devices/fakro_arz_wifi_roof_blind.yaml
+++ b/custom_components/tuya_local/devices/fakro_arz_wifi_roof_blind.yaml
@@ -54,7 +54,6 @@ entities:
         name: fault_code
         optional: true
   - entity: binary_sensor
-    name: Moving
     class: moving
     category: diagnostic
     dps:
@@ -67,7 +66,6 @@ entities:
             value: false
           - value: true
   - entity: sensor
-    name: Voltage
     class: voltage
     category: diagnostic
     dps:
@@ -82,7 +80,6 @@ entities:
         mapping:
           - scale: 10
   - entity: sensor
-    name: Current
     class: current
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/fakro_arz_wifi_roof_blind.yaml
+++ b/custom_components/tuya_local/devices/fakro_arz_wifi_roof_blind.yaml
@@ -1,0 +1,155 @@
+name: Roof blind
+products:
+  - id: wj3t8r1dguccdryj
+    manufacturer: Fakro
+    model: ARZ Wi-Fi
+    name: Roof blind
+entities:
+  # Only "position" (dp 2) is required for matching; everything else is
+  # optional: true, because the device does not report all DPs in the first
+  # packet during setup. Optional DPs never block a match and improve match
+  # quality once they arrive.
+  - entity: cover
+    class: blind
+    dps:
+      - id: 1
+        type: string
+        name: control
+        optional: true
+        mapping:
+          - dps_val: open
+            value: open
+          - dps_val: stop
+            value: stop
+          - dps_val: close
+            value: close
+      - id: 2
+        type: integer
+        name: position
+        range:
+          min: 0
+          max: 100
+      - id: 2
+        type: integer
+        name: current_position
+        range:
+          min: 0
+          max: 100
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 12
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 12
+        type: bitfield
+        name: fault_code
+        optional: true
+  - entity: binary_sensor
+    name: Moving
+    class: moving
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+  - entity: sensor
+    name: Voltage
+    class: voltage
+    category: diagnostic
+    dps:
+      # dp 105 is documented with a scale of 10 (deci-volts). In practice this
+      # device always reports 0 here, but the scale is kept per the spec.
+      - id: 105
+        type: integer
+        name: sensor
+        optional: true
+        unit: V
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 181
+        type: integer
+        name: sensor
+        optional: true
+        unit: mA
+        class: measurement
+        range:
+          min: 0
+          max: 2500
+  - entity: sensor
+    name: Open load
+    class: current
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        optional: true
+        unit: mA
+        class: measurement
+        range:
+          min: 0
+          max: 2000
+  - entity: sensor
+    name: Close load
+    class: current
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        optional: true
+        unit: mA
+        class: measurement
+        range:
+          min: 0
+          max: 1800
+  - entity: number
+    name: Comfort position
+    category: config
+    icon: "mdi:sun-thermometer-outline"
+    dps:
+      - id: 113
+        type: integer
+        name: value
+        optional: true
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: switch
+    name: Comfort mode
+    category: config
+    icon: "mdi:weather-sunny"
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+        optional: true
+  - entity: binary_sensor
+    name: Service flag
+    category: diagnostic
+    dps:
+      - id: 103
+        type: boolean
+        name: sensor
+        optional: true


### PR DESCRIPTION
Adds support for the Fakro ARZ Wi-Fi external roof blind (product_id
`wj3t8r1dguccdryj`, manufacturer Fakro, model "ARZ Wi-Fi"). I run 8 of these
locally and have used this config daily for months.

The cover uses position (dp 2, 0–100) plus an open/stop/close control dp.
Everything else is optional and split into its own diagnostic/config entities:

| dp | entity | notes |
|----|--------|-------|
| 1 | cover control | open / stop / close |
| 2 | cover position | 0–100, the only required (match) dp |
| 12 | binary_sensor (problem) + fault_code | bitfield |
| 101 | sensor "Open load" (mA) | motor force threshold, read-only |
| 102 | sensor "Close load" (mA) | motor force threshold, read-only |
| 103 | binary_sensor "Service flag" | |
| 104 | switch "Comfort mode" | |
| 105 | sensor "Voltage" (V, scale 10) | reads 0 in practice; scale kept per spec |
| 106 | binary_sensor "Moving" | |
| 113 | number "Comfort position" (%) | |
| 181 | sensor "Current" (mA) | |

Verified:
- `ruff check .` / `ruff format --check .` — pass
- `yamllint custom_components/tuya_local/devices` — pass
- device config schema + entity validation (`tests/test_device_config.py` logic) — pass
- running live on 8 physical devices; open/close/position and all entities work