### PR TITLE
feat(fisher_summer_air_conditioner): add compatible Rotenso Teta

### DIFF
--- a/custom_components/tuya_local/devices/fisher_summer_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/fisher_summer_air_conditioner.yaml
@@ -18,6 +18,9 @@ products:
   - id: hrzr8mr0mtgfwwri
     manufacturer: ComfortStar
     model: 12000 BTU mini split
+  - id: hrzr8mr0mtgfwwri
+    manufacturer: Rotenso
+    model: Teta
 entities:
   - entity: climate
     translation_only_key: aircon_extra


### PR DESCRIPTION
Adds Rotenso Teta split air conditioner as a compatible model of the Fisher Summer config.         
The device reports product id hrzr8mr0mtgfwwri — the same id already listed for the ComfortStar 12000 BTU mini split, so this only adds a products entry (no dps changes).

Verified against the real device (protocol 3.4). Full dps dump matches the config:   
  {"1": false, "2": 260, "3": 25, "4": "wind", "5": "auto", "18": 0, "19": "c",                    
   "20": 0, "23": 77, "24": 790, "101": 0, "102": "off", "103": false,                             
   "105": "off", "110": 4330047, "113": "0", "114": "0", "116": 145,                               
   "119": "0", "120": "off", "123": "0000", "125": "great", "126": "0",                            
   "127": "0", "128": "0", "129": "1", "130": 26, "131": false, "132": false,                      
   "133": "0", "134": "{...}", "135": 1}                                                           
                                                                                                   
  Live tested in HA.