### PR TITLE
The NHZS fan speed was incorrectly displayed as 20% by default, even though it was 100% in Home Assistant.

### DIFF
--- a/custom_components/tuya_local/devices/nhzs_fan_switch.yaml
+++ b/custom_components/tuya_local/devices/nhzs_fan_switch.yaml
@@ -13,7 +13,7 @@ entities:
         name: speed
         range:
           min: 1
-          max: 20
+          max: 100
   - entity: time
     translation_key: timer
     category: config


### PR DESCRIPTION
The NHZS fan speed was incorrectly displayed as 20% by default, even though it was 100% in Home Assistant. This has now been fixed.

- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Please describe in simple terms what you are submitting. Do not paste a multi-page AI generated rambling story here, as the maintainers do not have time to read that.


