### PR TITLE
Add self-clean (DPS 111) to Teknopoint Idra Skiv

### DIFF
--- a/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
@@ -342,3 +342,11 @@ entities:
       - id: 113
         type: bitfield
         name: fault_code2
+  - entity: switch
+    name: Self clean
+    icon: "mdi:air-filter"
+    category: config
+    dps:
+      - id: 111
+        name: switch
+        type: boolean

--- a/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
@@ -350,3 +350,4 @@ entities:
       - id: 111
         name: switch
         type: boolean
+        optional: true


### PR DESCRIPTION
## Summary

Adds DPS 111 (`cleaning`, Boolean) as a `switch` entity to the Teknopoint Idra Skiv air conditioner profile. This is the standard Tuya self-clean data point for air conditioners (category `kt`).

## What it does

When activated, the indoor unit displays "SC" and runs a self-clean cycle (freeze → defrost → dry on the evaporator coil, ~13 minutes). The DPS returns to `false` automatically when the cycle completes.

## Testing

- **Hardware**: 4× Teknopoint EVO-09 indoor units with IDRA iSKV4-28C9 water-cooled condenser
- **Integration**: tuya-local 2024.x, Home Assistant 2026.6.3
- **Discovery**: DPS 111 found via `tuya_local` debug logging (`full_poll` responses show `"111": false`)
- **Activation**: Setting DPS 111 to `true` via `switch.turn_on` triggers the SC cycle. Unit displays "SC", compressor runs (freeze phase), then auto-stops after ~13 min
- **Deactivation**: DPS 111 returns to `false` automatically on cycle completion

## Notes

- This is **not** the same as the IR remote's CLEAN button, which triggers a simpler fan-only drying cycle and does not change any Tuya DPS
- DPS 111 is the standard Tuya `cleaning` DP for category `kt` (documented in [Tuya Developer - Air Conditioner](https://developer.tuya.com/en/docs/iot/air-conditioner?id=Kabt7s8qhsb4h))
- The Teknopoint EVO-09 manual does not document this function — it appears to be a WiFi-module-level feature exposed by the Tuya chipset