### PR TITLE
Petlibro PLAF203: expose feeding schedule as writable meal plan

### DIFF
--- a/custom_components/tuya_local/devices/petlibro_camera_feeder.yaml
+++ b/custom_components/tuya_local/devices/petlibro_camera_feeder.yaml
@@ -12,9 +12,6 @@ entities:
         type: string
         name: sensor
         optional: true
-      - id: 231
-        type: hex
-        name: schedule
       - id: 237
         type: string
         name: planned_feed_report
@@ -23,6 +20,20 @@ entities:
         type: string
         name: manual_feed_report
         optional: true
+  - entity: text
+    translation_key: meal_plan
+    category: config
+    hidden: true
+    dps:
+      # Meal plan is a hex blob of 5-byte slots:
+      # - Days (1 bit per day, bitmask)
+      # - Hour
+      # - Minute
+      # - Portions
+      # - Enabled (1) / disabled (0)
+      - id: 231
+        type: hex
+        name: value
   - entity: light
     translation_key: indicator
     category: config


### PR DESCRIPTION
## Summary

The Petlibro PLAF203 (Pet feeder) config mapped DP 231, the feeding schedule, as a read-only `schedule` extra attribute on the status sensor, so it could be observed but not changed.

This moves DP 231 to a dedicated `text` entity using the existing `meal_plan` translation_key (the same pattern already used by `advwin_6l_petfeeder` and `catit_pixi_6meal_feeder`), so the feeding schedule can be edited and individual feeding slots enabled or disabled locally.

## Format

DP 231 is a hex blob of 5-byte slots (days bitmask, hour, minute, portions, enabled(1)/disabled(0)), documented inline in the config. This matches the meal-plan blob already documented for the catit feeder.

## Testing

- `yamllint` passes on the changed file.
- Structural validation: the `text`/`meal_plan` entity and its DP shape are correct, the `meal_plan` translation_key and icon resolve, and DP 231 now appears exactly once in the config.
- Writes to DP 231 verified over LAN with tinytuya (protocol 3.4) on a real PLAF203: `set_value(231, ...)` is acknowledged by the device and round-trips.

No new translation keys or icons are introduced (`meal_plan` already exists in the translations and icons).
