### PR TITLE
feat: Add Sensio 240V Kinetic Receiver device configuration

### DIFF
--- a/custom_components/tuya_local/devices/sensio_240v_kinetic_receiver.yaml
+++ b/custom_components/tuya_local/devices/sensio_240v_kinetic_receiver.yaml
@@ -1,0 +1,66 @@
+name: Dimmer
+products:
+  - id: azt4dppefleigvb0
+    manufacturer: Sensio
+    model: 240V Kinetic Receiver
+    model_id: SE780990
+entities:
+  - entity: light
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: number
+    name: Minimum brightness
+    category: config
+    icon: "mdi:lightbulb-on-40"
+    dps:
+      - id: 3
+        type: integer
+        name: value
+        optional: true
+        range:
+          min: 10
+          max: 1000
+  - entity: button
+    name: Pair
+    category: config
+    dps:
+      - id: 101
+        type: boolean
+        name: button
+        optional: true
+      - id: 103
+        type: boolean
+        name: result
+        optional: true
+  - entity: button
+    name: Clear
+    category: config
+    dps:
+      - id: 102
+        type: boolean
+        name: button
+        optional: true
+      - id: 104
+        type: boolean
+        name: result
+        optional: true
+  - entity: number
+    name: Countdown
+    category: config
+    icon: "mdi:timer"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: s
+        range:
+          min: 0
+          max: 86400

--- a/custom_components/tuya_local/devices/sensio_240vkinetic_light.yaml
+++ b/custom_components/tuya_local/devices/sensio_240vkinetic_light.yaml
@@ -52,15 +52,13 @@ entities:
         type: boolean
         name: result
         optional: true
-  - entity: number
-    name: Countdown
+  - entity: time
+    translation_key: timer
     category: config
-    icon: "mdi:timer"
     dps:
       - id: 105
         type: integer
-        name: value
-        unit: s
+        name: second
         range:
           min: 0
-          max: 86400
+          max: 86399


### PR DESCRIPTION
Adds support for the Sensio 240V Kinetic Receiver, a single channel 240V LED dimmer with wireless kinetic switch pairing.

Single dimmable channel (dp 1 switch, dp 2 brightness, dp 3 min brightness)
Wireless kinetic switch pair/clear commands with result feedback (dp 101-104)
Countdown timer (dp 105)
Product ID: azt4dppefleigvb0 (SKU SE780990)