### PR TITLE
Add Celsius variant of TCL AirMax heat pump (Nordis Orion EVO)

### DIFF
--- a/custom_components/tuya_local/devices/daizuki_heatpump_c.yaml
+++ b/custom_components/tuya_local/devices/daizuki_heatpump_c.yaml
@@ -1,0 +1,308 @@
+name: Heat pump (Celsius)
+products:
+  - id: hw50w7qvxluhslkk
+    manufacturer: TCL
+    model: AirMax (export, °C)
+  - id: hw50w7qvxluhslkk
+    manufacturer: Nordis
+    model: Orion EVO
+entities:
+  - entity: climate
+    translation_only_key: aircon_extra
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: auto
+                value: heat_cool
+              - dps_val: cold
+                value: cool
+              - dps_val: hot
+                value: heat
+              - dps_val: wind
+                value: fan_only
+              - dps_val: wet
+                value: dry
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 160
+          max: 310
+        mapping:
+          - scale: 10
+            step: 10
+      - id: 3
+        type: integer
+        name: current_temperature
+        precision: 0
+        range:
+          min: -20
+          max: 100
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: mute
+            value: quiet
+          - dps_val: low
+            value: low
+          - dps_val: mid_low
+            value: medlow
+          - dps_val: mid
+            value: medium
+          - dps_val: mid_high
+            value: medhigh
+          - dps_val: high
+            value: high
+          - dps_val: strong
+            value: strong
+      - id: 18
+        type: integer
+        name: current_humidity
+        mapping:
+          - dps_val: 0
+            value: null
+      - id: 105
+        type: string
+        name: sleep_mode
+      - id: 110
+        type: bitfield
+        name: flags
+      - id: 113
+        type: string
+        name: swing_mode
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: Full
+          - dps_val: "2"
+            value: Upper
+          - dps_val: "3"
+            value: Lower
+      - id: 114
+        type: string
+        name: swing_horizontal_mode
+        mapping:
+          - dps_val: "0"
+            value: "off"
+          - dps_val: "1"
+            value: Full
+          - dps_val: "2"
+            value: Left
+          - dps_val: "3"
+            value: Center
+          - dps_val: "4"
+            value: Right
+      - id: 119
+        type: string
+        optional: true
+        name: electricity_management
+      - id: 120
+        type: string
+        optional: true
+        name: gen_mode
+      - id: 123
+        type: hex
+        name: flags_2
+      - id: 125
+        type: string
+        name: air_quality
+        optional: true
+      - id: 128
+        type: string
+        optional: true
+        name: model_code
+      - id: 129
+        type: string
+        optional: true
+        name: energy
+      - id: 130
+        type: integer
+        optional: true
+        name: eco_temp
+      - id: 132
+        type: boolean
+        name: hot_cool
+      - id: 133
+        type: string
+        optional: true
+        name: swing_action
+      - id: 134
+        type: json
+        optional: true
+        name: statistics
+  - entity: select
+    name: Vertical position
+    category: config
+    icon: "mdi:unfold-more-horizontal"
+    dps:
+      - id: 126
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Unknown
+          - dps_val: "1"
+            value: Top
+          - dps_val: "2"
+            value: Slightly up
+          - dps_val: "3"
+            value: Middle
+          - dps_val: "4"
+            value: Slightly down
+          - dps_val: "5"
+            value: Bottom
+  - entity: select
+    name: Horizontal position
+    category: config
+    icon: "mdi:unfold-more-vertical"
+    dps:
+      - id: 127
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Unknown
+          - dps_val: "1"
+            value: Leftmost
+          - dps_val: "2"
+            value: Slight Left
+          - dps_val: "3"
+            value: Center
+          - dps_val: "4"
+            value: Slight Right
+          - dps_val: "5"
+            value: Rightmost
+  - entity: select
+    name: Sleep mode
+    category: config
+    icon: "mdi:weather-night"
+    dps:
+      - id: 105
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "Off"
+          - dps_val: "normal"
+            value: Standard
+          - dps_val: "old"
+            value: "Elderly"
+          - dps_val: "child"
+            value: "Child"
+  - entity: light
+    translation_key: display
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0008"
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0010"
+  - entity: switch
+    name: Soft wind
+    category: config
+    icon: "mdi:weather-windy"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "8000"
+  - entity: switch
+    name: Anti-mildew
+    category: config
+    icon: "mdi:water-off-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0100"
+  - entity: switch
+    name: Health
+    category: config
+    icon: "mdi:heart-outline"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0020"
+  - entity: switch
+    translation_key: anti_frost
+    category: config
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "1000"
+  - entity: switch
+    name: Eco mode
+    category: config
+    icon: "mdi:leaf"
+    dps:
+      - id: 123
+        type: hex
+        name: switch
+        mask: "0001"
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    class: pm25
+    category: diagnostic
+    hidden: unavailable
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: ugm3
+        optional: true
+        class: measurement
+      - id: 101
+        type: integer
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true
+  - entity: binary_sensor
+    name: Filter
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 131
+        type: boolean
+        name: sensor


### PR DESCRIPTION
The existing `daizuki_heatpump.yaml` (product id `hw50w7qvxluhslkk`) assumes the
device reports Fahrenheit: DP 2 is `unit: F`, range 610-880, and DP 3 carries a
`target_range` mapping (-20..100 to -4..212).

The same product id is used on export/EU-market units (Tuya cloud
`product_name` is "TCL外销分体机" - "TCL export split unit", sold in the EU as
Nordis Orion EVO among others), which report Celsius x10 on DP 2. The device
has no C/F setting and exposes no unit DP, so a conditional mapping within one
config is not possible.

With the current config, a 24 °C setpoint (DP 2 = 240) is displayed as -4 °C
in HA. This PR adds a sibling config with `unit: C`, setpoint range 16.0-31.0,
and the DP 3 conversion mapping removed. All other entities are unchanged from
the original config.

DPS dump from my unit with panel at 24 °C, room 24 °C:

    {'1': False, '2': 240, '3': 24, '4': 'cold', '5': 'low', '18': 0, '20': 0,
     '101': 0, '105': 'off', '110': 135724, '113': '0', '114': '0', '119': '0',
     '120': 'off', '123': '0000', '125': 'great', '126': '5', '127': '1',
     '128': '0', '129': '1', '130': 26, '131': False, '132': False, '133': '0',
     '134': '{"t":...,"s":false,"clr":true}'}

Tested live on a Nordis Orion EVO: setpoint read/write, HVAC modes and fan
speeds all working correctly with this config.
