### PR TITLE
Add support for Moes House Dual Zigbee Socket (ph1joc22)

### DIFF
--- a/custom_components/tuya_local/devices/moes_dual_zigbee_socket.yaml
+++ b/custom_components/tuya_local/devices/moes_dual_zigbee_socket.yaml
@@ -1,0 +1,76 @@
+name: Moes Dual Zigbee Socket
+
+products:
+  - id: ph1joc22
+    manufacturer: Moes House
+    model: Tomada dupla Zigbee Soft
+
+entities:
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders:
+      x: "1"
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders:
+      x: "2"
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+
+  - entity: time
+    translation_key: timer_x
+    translation_placeholders:
+      x: "1"
+    category: config
+    dps:
+      - id: 9
+        type: integer
+        optional: true
+        name: second
+        range:
+          min: 0
+          max: 43200
+
+  - entity: time
+    translation_key: timer_x
+    translation_placeholders:
+      x: "2"
+    category: config
+    dps:
+      - id: 10
+        type: integer
+        optional: true
+        name: second
+        range:
+          min: 0
+          max: 43200
+
+  - entity: select
+    translation_key: initial_state
+    category: config
+    dps:
+      - id: 27
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "off"
+          - dps_val: "on"
+            value: "on"
+          - dps_val: "memory"
+            value: memory
+
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 29
+        type: boolean
+        name: lock


### PR DESCRIPTION
## Summary

This PR adds support for the **Moes House Dual Zigbee Socket** (Product ID `ph1joc22`).

The device is a **Zigbee sub-device** connected through a Tuya Zigbee gateway and has been tested successfully using Tuya Local.

## Device Information

| Field | Value |
|------|------|
| Manufacturer | Moes House |
| Model | Tomada dupla Zigbee Soft |
| Product ID | `ph1joc22` |
| Device Category | Zigbee Dual Socket |
| Protocol | 3.4 |

## Configuration

When adding the device in **Tuya Local**, use:

| Field | Description |
|------|-------------|
| Device ID | Tuya Device ID of the Zigbee sub-device |
| UUID | Node ID (CID) of the Zigbee sub-device |
| Host | IP address of the Tuya Zigbee gateway |
| Local Key | Local Key of the Tuya Zigbee gateway |
| Protocol Version | 3.4 |

**Important**

This is a **Zigbee sub-device**.

Do **not** use the gateway Device ID or UUID.

Use:

- the **sub-device Device ID**
- the **sub-device UUID (CID / Node ID)**
- the **gateway IP address**
- the **gateway Local Key**

## Supported datapoints

| DP | Function |
|----|----------|
| 1 | Switch 1 |
| 2 | Switch 2 |
| 9 | Countdown Timer 1 |
| 10 | Countdown Timer 2 *(optional)* |
| 27 | Initial State |
| 29 | Child Lock |

## Validation

The configuration was tested on a real device.

Verified features:

- ✅ Switch 1
- ✅ Switch 2
- ✅ Countdown Timer 1
- ✅ Initial State
- ✅ Child Lock
- ✅ State synchronization between Smart Life and Home Assistant
- ✅ Local control through Tuya Local

DP10 is marked as optional because it is firmware-dependent and was not exposed by the tested device.
