### PR TITLE
Include the device error code in connection failure logs

### DIFF
--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -34,6 +34,17 @@ from .helpers.log import log_json
 
 _LOGGER = logging.getLogger(__name__)
 
+# Extra context for tinytuya error codes whose message does not fully describe
+# the possible causes.  Error 914 in particular is reported for any failure to
+# negotiate a session, which includes a device that is refusing connections
+# until it is power cycled, not just a misconfigured key or protocol version.
+_ERROR_HINTS = {
+    "914": (
+        " (an incorrect local key or protocol version, or a device that has "
+        "stopped accepting local connections and needs to be power cycled)"
+    ),
+}
+
 
 def _collect_possible_matches(cached_state, product_ids):
     """Collect possible matches from generator into an array."""
@@ -658,12 +669,14 @@ class TuyaLocalDevice(object):
         )
 
         last_err_code = None
+        last_err_msg = None
         for i in range(connections):
             try:
                 if not self._hass.is_stopping:
                     retval = await self._hass.async_add_executor_job(func)
                     if isinstance(retval, dict) and "Error" in retval:
                         last_err_code = retval.get("Err")
+                        last_err_msg = retval.get("Error")
                         if last_err_code == "900":
                             # Some devices (e.g. IR/RF remotes) never return
                             # status data; error 900 is their normal response
@@ -699,12 +712,24 @@ class TuyaLocalDevice(object):
                         self._api_protocol_working = False
                         for entity in self._children:
                             entity.async_schedule_update_ha_state()
+                    if last_err_code:
+                        log_format = "%s Device reported error %s: %s%s"
+                        log_args = (
+                            error_message,
+                            last_err_code,
+                            last_err_msg,
+                            _ERROR_HINTS.get(last_err_code, ""),
+                        )
+                    else:
+                        log_format = "%s"
+                        log_args = (error_message,)
+
                     if self._api_working_protocol_failures == 1 and not (
                         last_err_code == "914" and self._protocol_configured == "auto"
                     ):
-                        _LOGGER.error(error_message)
+                        _LOGGER.error(log_format, *log_args)
                     else:
-                        _LOGGER.debug(error_message)
+                        _LOGGER.debug(log_format, *log_args)
 
                 if not self._api_protocol_working:
                     await self._rotate_api_protocol_version()

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -40,8 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 # until it is power cycled, not just a misconfigured key or protocol version.
 _ERROR_HINTS = {
     "914": (
-        " (an incorrect local key or protocol version, or a device that has "
-        "stopped accepting local connections and needs to be power cycled)"
+        "  If previously running OK, likely the device needs to be power cycled."
     ),
 }
 

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -39,9 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 # negotiate a session, which includes a device that is refusing connections
 # until it is power cycled, not just a misconfigured key or protocol version.
 _ERROR_HINTS = {
-    "914": (
-        "  If previously running OK, likely the device needs to be power cycled."
-    ),
+    "914": ("  If previously running OK, likely the device needs to be power cycled."),
 }
 
 

--- a/custom_components/tuya_local/device.py
+++ b/custom_components/tuya_local/device.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 # negotiate a session, which includes a device that is refusing connections
 # until it is power cycled, not just a misconfigured key or protocol version.
 _ERROR_HINTS = {
-    "914": ("  If previously running OK, likely the device needs to be power cycled."),
+    "914": "  If previously running OK, likely the device needs to be power cycled.",
 }
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from time import time
 
 import pytest
@@ -676,3 +677,56 @@ def test_should_poll(subject):
     # Test initial polling
     subject._cached_state = {}
     assert subject.should_poll
+
+
+@pytest.mark.asyncio
+async def test_refresh_error_reports_device_error_code(subject, mock_api, caplog):
+    """The error code and message returned by the device are logged."""
+    subject._api_protocol_working = False
+    subject._protocol_configured = "3.3"
+    mock_api().status.return_value = {
+        "Error": "Check device key or version",
+        "Err": "914",
+        "Payload": None,
+    }
+
+    with caplog.at_level(logging.ERROR):
+        await subject.async_refresh()
+
+    assert "914" in caplog.text
+    assert "Check device key or version" in caplog.text
+    # 914 is ambiguous, so the possible causes are spelled out
+    assert "power cycled" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_error_without_error_code_is_unchanged(subject, mock_api, caplog):
+    """A failure that is not a device error logs the bare message."""
+    subject._api_protocol_working = False
+    subject._protocol_configured = "3.3"
+    mock_api().status.side_effect = Exception("connection refused")
+
+    with caplog.at_level(logging.ERROR):
+        await subject.async_refresh()
+
+    assert "Failed to refresh device state for Some name." in caplog.text
+    assert "Device reported error" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_error_914_stays_quiet_when_rotating_protocols(
+    subject, mock_api, caplog
+):
+    """914 is expected while auto-detecting, so it must not log at error."""
+    subject._api_protocol_working = False
+    subject._protocol_configured = "auto"
+    mock_api().status.return_value = {
+        "Error": "Check device key or version",
+        "Err": "914",
+        "Payload": None,
+    }
+
+    with caplog.at_level(logging.ERROR):
+        await subject.async_refresh()
+
+    assert caplog.text == ""


### PR DESCRIPTION
### Problem

When a device connection fails, `_retry_on_failed_connection` captures the error tinytuya returned but then logs only the generic message:

```
ERROR ... Failed to refresh device state for Bedroom Fan/Light.
```

The error code is dropped. Enabling debug logging doesn't recover it either — the code is never formatted into any message, so the only way to see it today is to reproduce the call outside Home Assistant with tinytuya directly.

This matters most for **error 914**. tinytuya returns 914 for *any* failure to negotiate a session, but its message — "Check device key or version" — names only two of the causes. A device that has stopped accepting local connections and needs a power cycle returns the same 914 with a perfectly correct key and protocol version.

That case is common: #5347, #5136, #4862 and [jasonacox/tinytuya#581](https://github.com/jasonacox/tinytuya/issues/581) are all the same shape — the device works fine in the Tuya app, tinytuya says 914, and only a power cycle fixes it. Because the log says nothing, every one of those reports starts by re-checking the local key, which is not the problem.

I hit this on a Treatlife DS03. The stored key was byte-identical to the one in the cloud, and the device still returned 914 on every protocol version. The log gave no hint that "check your key" was a dead end.

### Change

Keep the error code and the device's own message, and log them with the existing text. For 914, spell out the causes it can stand for:

```
ERROR ... Failed to refresh device state for Bedroom Fan/Light. Device reported error
914: Check device key or version (an incorrect local key or protocol version, or a
device that has stopped accepting local connections and needs to be power cycled)
```

Failures that aren't device errors (socket errors, timeouts) log exactly as before.

The existing carve-out that keeps 914 at debug level while auto-detecting the protocol version is untouched — 914 is expected there, and that path stays quiet.

### Tests

Three tests added to `tests/test_device.py`:

- `test_refresh_error_reports_device_error_code` — the code, the message and the 914 hint appear in the error log. Fails without this change.
- `test_refresh_error_without_error_code_is_unchanged` — a plain exception still logs the bare message, with no "Device reported error" suffix.
- `test_refresh_error_914_stays_quiet_when_rotating_protocols` — 914 during protocol auto-detection still does not log at error level.

`pytest tests/test_device.py` → 43 passed. `ruff check` and `ruff format --check` clean.

### Note

This only makes the failure legible; it doesn't fix it. The underlying device-side fault belongs upstream in tinytuya, where 914 conflates causes that are distinguishable on the wire. I'm investigating that separately and will report it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)