### PR TITLE
Support Trident Air Dome 60

### DIFF
--- a/custom_components/tuya_local/devices/trident_airdome60_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/trident_airdome60_airpurifier.yaml
@@ -1,0 +1,163 @@
+name: Air purifier
+products:
+  - id: xkorr6vvmwjthxnl
+    manufacturer: Trident
+    model: AirDome-60
+entities:
+  - entity: fan
+    translation_key: air_purifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      - id: 3
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: manual
+            value: manual
+          - dps_val: sleep
+            value: sleep
+      - id: 4
+        name: speed
+        type: string
+        mapping:
+          - dps_val: speed1
+            value: 17
+          - dps_val: speed2
+            value: 33
+          - dps_val: speed3
+            value: 50
+          - dps_val: speed4
+            value: 67
+          - dps_val: speed5
+            value: 83
+          - dps_val: speed6
+            value: 100
+
+  - entity: sensor
+    class: pm25
+    dps:
+      - id: 2
+        name: sensor
+        type: integer
+        unit: ugm3
+        class: measurement
+
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        name: lock
+        type: boolean
+
+  - entity: light
+    translation_key: backlight
+    category: config
+    dps:
+      - id: 8
+        name: switch
+        type: boolean
+
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 18
+        name: option
+        type: string
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: "1h"
+            value: "1h"
+          - dps_val: "2h"
+            value: "2h"
+          - dps_val: "4h"
+            value: "4h"
+          - dps_val: "6h"
+            value: "6h"
+          - dps_val: "8h"
+            value: "8h"
+          - dps_val: "12h"
+            value: "12h"
+
+  - entity: sensor
+    translation_key: air_quality
+    class: enum
+    dps:
+      - id: 21
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: great
+            value: excellent
+          - dps_val: good
+            value: good
+          - dps_val: medium
+            value: poor
+          - dps_val: severe
+            value: severe
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+      - id: 22
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: Clean filter 2
+          - dps_val: 2
+            value: Replace filter 3
+
+  - entity: button
+    name: Filter 2 reset
+    category: config
+    class: restart
+    dps:
+      - id: 101
+        name: button
+        optional: true
+        type: boolean
+
+  - entity: button
+    name: Filter 3 reset
+    category: config
+    class: restart
+    dps:
+      - id: 102
+        name: button
+        optional: true
+        type: boolean
+
+  - entity: select
+    name: Airflow angle
+    category: config
+    dps:
+      - id: 103
+        name: option
+        type: string
+        mapping:
+          - dps_val: "30"
+            value: "30"
+          - dps_val: "60"
+            value: "60"
+          - dps_val: "90"
+            value: "90"

--- a/custom_components/tuya_local/devices/trident_airdome60_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/trident_airdome60_airpurifier.yaml
@@ -128,9 +128,8 @@ entities:
             value: Replace air activator
 
   - entity: button
-    name: Washable filter reset
+    translation_key: filter_reset
     category: config
-    class: restart
     dps:
       - id: 101
         name: button

--- a/custom_components/tuya_local/devices/trident_airdome60_airpurifier.yaml
+++ b/custom_components/tuya_local/devices/trident_airdome60_airpurifier.yaml
@@ -123,26 +123,16 @@ entities:
           - dps_val: 0
             value: ok
           - dps_val: 1
-            value: Clean filter 2
+            value: Clean washable filter
           - dps_val: 2
-            value: Replace filter 3
+            value: Replace air activator
 
   - entity: button
-    name: Filter 2 reset
+    name: Washable filter reset
     category: config
     class: restart
     dps:
       - id: 101
-        name: button
-        optional: true
-        type: boolean
-
-  - entity: button
-    name: Filter 3 reset
-    category: config
-    class: restart
-    dps:
-      - id: 102
         name: button
         optional: true
         type: boolean


### PR DESCRIPTION
Similar to the existing AirDome-70, but with 6 fan speeds instead of 3, plus three extra controls the 70 doesn't expose: a countdown timer, a fault/problem sensor, and a second filter-reset button.

DP map (from `QueryThingsDataModel`):

| dp | code | type | range |
|----|------|------|-------|
| 1 | switch | bool | |
| 2 | pm25 | value | 0-999 |
| 3 | mode | enum | auto, manual, sleep |
| 4 | fan_speed_enum | enum | speed1-speed6 |
| 7 | child_lock | bool | |
| 8 | light | bool | |
| 18 | countdown_set | enum | cancel, 1h, 2h, 4h, 6h, 8h, 12h |
| 21 | air_quality | enum, ro | great, good, medium, severe |
| 22 | fault | bitmap, ro | e1=clean filter 2, e2=replace filter 3 |
| 101 | filter2_reset | bool | |
| 102 | replacefilter3_reset | bool | |
| 103 | flow_angle | enum | 30, 60, 90 |