### PR TITLE
feat(devices): add support for EKAZA EKAV-T229Z Zigbee lock

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1503,3 +1503,1445 @@ thing, it expands the support requirements beyond the capacity of the
 volunteer manpower of this project. The community would be better served by
 making Tuya devices work with the standard BLE and Zigbee support in
 Home Assistant rather than the other way around.
+# Supported devices
+
+### Heaters
+
+- Advanced Fires 1500 electric fireplace
+- Amantii Bespoke R1-2-AP1 fireplace
+- Andersson GSH heater
+- Arlec 2200W and 2400W panel heaters, CEH243HA ceramic heater
+- Atomi AT1632/AT1635 ceramic heaters
+- Auchsiag 750W/1500W electric fireplace
+- Bestherm Nessa Connect panel heater
+- Betterlife BT1500 IR heater
+- Blumfeldt/Klarstein Cosmic Beam Smart 24 infrared radiant heater
+- Brandon Basics towel warmer
+- Breville AirRounder Plus Connect purifier heater
+- Bonaire HPC5200020 electric heater
+- BVF CP1 heater
+- Caldo Up T fan heater
+- Calex Smart Convector heater
+- Cecotec ReadyWarm 8400 Fan and 2000 Max Box Ceramic heaters
+- Cixi Jemell PTC-1919 PTC heater
+- Cleverio AR10/AR20 panel heaters
+- Create Warm Clear vertical heater
+- Create Warm Towel Advance bathroom heater
+- Cronos GPH-D-DA heater
+- Devola Intelligent and Patio heaters
+- Dynasty BTX fireplace
+- Ecostrad Accent iQ heating panel
+- Ecostrad iQ ceramic radiators
+- Ecostrad iQ heating elements
+- Emke Orbrad PTR towel radiator
+- Essentials Smart Home electric bathroom heater
+- eTowel Mini04 plus towel rail thermostat
+- Eurom Alutherm 1000,1500,2000,2500 heaters
+- Eurom Hot-Shot 2000 heaters
+- Eurom Mon Soleil 300,600,800, 350,601,720 and 300,450,720 Verre heaters
+- Eurom Mon Soleil DSP 400,650,770 heaters
+- Eurom Sani heated towel rail
+- Eurom Sani Wall Heat 2000 and Wall Designheat 2000 heaters
+- Eurom Sani 400,600,800 heaters
+- Goldair GPPH, GCPV, GECO, GPOC and PH-ET heaters
+- Hama radiator controller
+- Heatstorm DH-100-TWI, HS-1500 and HS-6000-GC heaters
+- Herschel Select XLS heated bathroom mirror with lights
+- Herschel infrared heater
+- HJZ oil column radiator
+- Hombli radiator controller
+- INOW Wi-Fi heating element (single and dual air/water temperature control variants)
+- Juskys OH125BW2 oil radiator
+- Kennedy II/JR electric fireplace
+- Kesser Infrared 400W wall and 3000W heaters with and without lights.
+- Klarstein Bornholm Smart 1500 convection heater
+- Klarstein Bornholm Electric heater (1kW, based on WBR3)
+- Klarstein WnoderSky IR heater (360W ACO14)
+- Klarstein Wonderwall IR heaters (including Air Art, Bornholm, 600 models)
+- Kogan flame effect heater - KAWHMFP20BA model
+- Kogan tower heater - KASTHFP2KWA model
+- Kogan panel heaters - KAHTP, KAWFHTP, KASMGPH models
+- Lebenlang LBL0380 heater
+- Lehmann LHOHC-2013C electric radiator
+- Livn Arosa electric fireplace
+- Magnum MRC floor heating (2 variants)
+- Mellerware Comfy electric radiator (tested with Medium 1200W)
+- Modern Ember Vibrance XH-BG-15W/30WZKWIFI-10 electric fireplace
+- Modern Flames Orion electric fireplace
+- Nedis ceramic PTC fan heater
+- Nedis convection heater - WIFIHTPL20F model
+- Nutromo SH014 space heater
+- Nybro heater
+- Orbegozo RRW heater
+- Orion OWH-PTC2000 heater
+- Point POPANW600 panel heater
+- Princess 350 panel heater
+- Prosto PTC 2000 heater
+- Purline Hoti M100 heater
+- Quality Heating QH-GD Elegant Series IR panel heaters
+- Rovsun NSC-150-7A2R oil column heater
+- Rumba bathroom heater
+- Sai Me Tei towel rail
+- Semptec ZX7007 infrared heater
+- Sichler ZX-7655/ZX-7656 hybrid infrared convection heater
+- SolAire Vitra S2 panel heater
+- Sonnenkonig Eco 700 IR panel heater (probably also other Eco/Elegance series heaters)
+- Sunred Smart Triangle Dark patio wall heater
+- Taurus Agadir Connect oil column heaters
+- Tecxerllon 1500W panel heater
+- Termoplaza 900 panel heater
+- Touchstone Sideline electric fireplace
+- TyloHelo SaunaLogic2 sauna controller
+- Valehaus SYZN119 towel warmer
+- Vonroc GPH-XA-HEMAN heater
+- VTA+ Axial fan heater
+- Wärme Designer wall panel heater
+- WarmeHaus AFD-02-TJ thermostatic towel rail element
+- Wetair WCH-750 heater
+- Zephir ZMW4000V wall heater
+
+### Air Conditioners / Heat pumps
+
+- Airton air conditioner
+- Arlec PA1123BKHA portable air conditioner
+- Ballu Aura air conditioner
+- Be Cool BC14KL2101F
+- Beltax BAC-1009 air conditioner
+- Brokton BRST12 air conditioner
+- Carson CB PA280
+- Cecotec ForceClima Soundless portable air conditioner
+- Chiltrix CX50 and CX35
+- Confortotal CICON242 mini split air conditioner
+- Cooper&Hunter Nordic Evo Ng
+- Costway portable air conditioner models with and without heating
+- Daewoo Dhome OL-A011 air conditioner (DA9KWE)
+- Daizuki heat pump
+- Della air conditioner
+- De'Longhi Pinguino portable air conditioner
+- Duux Blizzard portable air conditioner
+- Eberg Cooly C35HD
+- Eberg Qubo Q40HD
+- EG4 solar heat pump
+- ElectriQ 12WMINV
+- ElectriQ Airflex, EcoSilent models
+- ElectriQ SupremeCool SC16HPW
+- Fersk Vind 2
+- Fisher Summer air conditioner
+- Fral Super Cool FSC08 WiFi portable air conditioner
+- Fral Super Cool FSC14.2 DH portable air conditioner
+- Friedrich Uni-Fit air conditioner (models: UCT14A30, UCT12A30, UCT08B10A)
+- Fujicool Yuzu heat pump
+- Goldair GCPAC350W portable air conditioner
+- Haier Airmart wall air conditioner
+- Hokkaido HKEDM 263 ZL air conditioner
+- Idea Heating Belt (with CS1 USB dongle)
+- Ideal Clima TQCT07 fancoil air conditioner
+- Igenix IG9901WIFI portable air conditioner
+- Inventor Comfort and Leon air conditioners
+- Kaisai Pro Heat+ air conditioner
+- Klarstein Iceblock Ecosmart air conditioner
+- Kogan portable air conditioners (Y09, Y12, Y16, Vostok)
+- Kogan vertical window air conditioner
+- Lyfco OL-A012 air conditioner
+- MeacoCool MC Series Pro portable air conditioners
+- Medion Life P1002 portable air conditioner
+- Monzana Klimaanlage air conditioner
+- MyCond Berg air conditioner
+- Nedis ACMB1WT12 portable air conditioner
+- Rotenso Roni R35WI and Roni X
+- Royal Clima Fresh air conditioner
+- Royal Sovereign RSAI-12SA mini split air conditioner
+- Sencor MT7048C air conditioner
+- Sendo air conditioner
+- Sensei air conditioner
+- SmartDGM PAC-W11C01 portable air conditioner
+- Sonnenkönig Fresco 140/180 air conditioner
+- Star-Light air conditioner (also confirmed to work with Polar branded devices)
+- Suntec Wellness Coolfixx portable air conditioner
+- Teknopoint Idra Skiv air conditioner
+- Tesla Smart TAF and AUX series air conditioners
+- TroniTechnik Hellnar Klimagerät
+- Trotec PAC-W 2600 SH heat pump
+- TruCool TC1160 air conditioner
+- Vaco Moby Blue 14 / Arrifana 16 portable heat pump
+- Vivax Cool ACP-12CH35REWI
+- Vivion 300123/4/5 air conditioners
+- Windmill window air conditioner
+- Woods Cortina and Milan portable air conditioners
+
+### Pool heaters / heat pumps
+
+- Aquastrong HEX pool heat pumps
+- Brustec BR-80 pool heat pump
+- BWT FI 45 heat pump
+- Edge Theory Labs cold plunge heat pump
+- Evotherm ETI series heat pump
+- Fairland IPHCR15, RMIC06, X20 pool heat pumps (also Pool Systems and other brands)
+- Garden PAC pool heat pump (also works with Summerwave Si Series)
+- Henden Essential pool heat pump
+- Komeco QC60 pool heat pump
+- Madimack Eco, Elite V2,V3,V4 and other model pool heat pumps
+- Mountfield Azuro pool heat pump
+- Poolex Silverline, Q-7, Q-line, Arctic, Vertigo, Ice Spa, Mag FI, JetLine Premium FI heat pumps
+- Poolsana InverPower Next pool heat pump
+- Poolstyle PSL-150-00xx pool heat pump
+- Pool Systems IPS Pro pool heat pump (also Fairland Inver-X)
+- Pro-Energy PE08 pool heat pump
+- Remora pool heat pump
+- Sibrape CBC-Pool BP heat pump
+- Steinbach Solid 4.3 and Silent Mini pool heat pumps
+- Swim & Fun InverBoost pool heat pump
+- Turbro 75000 btu pool heat pump
+- Waterco Electroheat ECO-V pool heat pump
+- W'eau pool heat pump (simple model and a more complex 13kW model)
+
+- these seem to use a small number of common controllers with minor variations, and many other Pool heat pumps will work using the above configurations.
+  Report issues if there are any differences in presets or other features,
+  or if any of the "unknown" values that are returned as attributes can
+  be figured out.
+
+### Water heaters
+
+- Apricus heat pump water heater
+- A.O. Smith HeatBot 15L electric water heater
+- Aquatech Rapid/X6 heat pump water heater
+- Aquaviva AVH15S combo air-water heat pump
+- Arçelik AHPH-MM series combo air-water heat pump
+- Axen KS-100W/EN8BP combo heat pump (rebranded as Arielli)
+- Chiltrix CX50 combo heat pump
+- City Energy L10WFE gas water heater
+- Deakon EVI DC inverter heat pump
+- EMS Thermal 200L domestic heat pump hot water system
+- Envirosun ES330M9 hot water system
+- Ferroli EGEA and Titano Twin water heaters
+- Fisher air to water heat pump
+- Geyserwise TSE1 and MWS Geyser controller kits
+- Giatsu VAW 2 heat pump water heater
+- Haier air-water combo heat pump
+- HY multifunctional heat pump V1.2
+- Hydrotherm Dynamic/X8 heat pump hot water systems (Gen 5 and 6)
+- Intaflo Intabloc DC Inverter air-water heat pump
+- ITS-4.5HD super water heat pump
+- Joyonway PB562 spa pool controller
+- Koi Duo HTW-TD-080KOID
+- Lohxa SR208C solar water heating controller
+- Macro MA-20WODP gas water heater
+- Modena ES-15-SKY water heater
+- Neopower Black Diamond all-in-one heat pump water heater
+- Nulite NL-B245 monobloc heat pump
+- Oekoboiler RS series heat pump water heater
+- Powerworld PW040, PWS58330, PWS58410 air+water heat pumps
+- Rinnai Enviroflo heat pump water heater
+- Sanden GAU-A45HPD WiFi heat pump controller
+- Shuangri SR223 solar water heating controller
+- Sime EcoMaxi VB200 heat pump water heater
+- SolarEast (Adlar Castra) Aurora II heat pump
+- Tauclima DGN-250 heat pump water heater
+- Thermann R290 heat pump water heater
+- Thermex IF series V pro and Lima 80V hot water systems
+- Thermoval Aqua TI water heater
+
+### Thermostats
+
+- 4-TH quad temperature/humidity smart switch
+- Arlec PCTH01HA temperature/humidity smart switch
+- Atorch AT4PTW DIN rail thermostat
+- Atorch S1TW, S1BWP-T/H thermostat smart switches
+- Avatto ME81, WS20R and WT100 thermostats
+- Avonflow AFD14-H radiator thermostat
+- Awow/Mi-heat TH213 thermostat (two variants)
+- Beca BAC-002, BAC-006, BAC-2005ALW, BHT-002/3000, BHP-6000 thermostats
+- Beca BHT-12 thermostat smartplug
+- Beok TCB/W38 thermostat (also sold as RT-70 under other brands)
+- Beok TGR81 thermostat _(also reported working with Myuet ME98, Avatto WT81/ME81)_
+- Beok SH-TGM50-WP, TGM50, TOL47, TR8B thermostats
+- Beok TR9B _(rebadged as Vancoo and perhaps others)_, TR9B-AC2 thermostats
+- BHT-002-GALW and GABW thermostats _(rebadged as many different brands)_
+- Brade MC6 thermostat _(rebadged as many different brands)_
+- Computherm Q20 thermostat
+- Dr Heater DR-008 electric radiant floor thermostat
+- Drexma WiStat ET7AW thermostat
+- DunWore F60 floor heating thermostat
+- EARU Electronic K6H-3A-W thermostat
+- Elko EKO07262 thermostat
+- EleChico CCST6001 thermostat
+- Elitech ECS-974T refrigeration thermostat
+- Emmeti Zona thermostat
+- Engo E901WiFi and EFAN230 thermostats
+- Essentials Wall thermostat
+- ETOP-FCU thermostat (Jaga JRT-100TW)
+- ETOP-HP thermostat (CH7100)
+- ETOP-HT thermostat
+- ETOP-HT-CH thermostat (branded as Ferco GN1)
+- ETOP-HT=CH Pro thermostat (branded as PNI CT36 Pro)
+- Ettroit LN4102 thermostat
+- Eurom WiFi thermostat
+- Euroster 4040 Smart thermostat
+- EZAIoT R9Lite thermostat
+- EZAIoT thermostat smartplug
+- Garza Aspen and (unknown model) thermostats
+- Herschel XLS T-MS mains and T-PL plugin thermostats
+- Hysen HY02TP, HY08ACF, HY08WE-2, HY101RF thermostats
+- Inkbird IPT-2CH v2.0 reptile thermostat
+- Inkbird ITC306A, ITC308, C236T thermostat smartplugs
+- Jiahong ET-44W, ET-61, ET-72W thermostats (also sold under the ThermoLife, and Warmme brands)
+- Kiturami NCTR-100 water and heating thermostat
+- KKMoon knob thermostat
+- Konlen WF72TT/WF96TT dual temperature controller
+- Ledlux thermostat
+- ME80 touchscreen thermostat
+- Mi-Heat TH11-WF thermostat
+- Minco MH-1823D thermostat
+- Moes BHT-002 thermostat (without external temp sensor)
+- Moes MS-103 temperature and humidity switch (partial functions, temperature only)
+- Moes WHT-009, WHT-S01 thermostats
+- Multi Leaf DY-107 thermostat
+- Myuet ME82 thermostat
+- Nashone MTS-700-WB thermostat smartplug
+- Netmostat N-1 (RTAFN1) thermostat
+- Owon PCT513 thermostat
+- Pilot Wire RP5 bath thermostat
+- Plikc Neve X W/RFW and Neve Pro W thermostats
+- PNI CT45 thermostat
+- Polytherm Polyalpha thermostat
+- Psmart T436 thermostat
+- RYRA TYTE-D1 thermostat with energy monitoring
+- Sajun steam room
+- Salcar T9W thermostat _(likely also Tellur TSH02)_
+- Saswell C16 thermostat _(rebadged as Warmme, Klima and others)_
+- Saswell T29UTW thermostat
+- SimPal TY-130 thermostat switch
+- T5E-WF thermostat
+- Tellur thermostat
+- Thermoval TVT40 thermostat
+- Vine TJ550 thermostat
+
+### Fans
+
+- generic 5-speed fan controller (HomeMate, Conbre)
+- 3A Nue 3 speed fan and light controller
+- Aeratron AE3+ ceiling fan (may match other Aeratron models with same WiFi module)
+- Airwoods AV-EW8/DF heat recovery ventilation with humidity control
+- Amico 52" ceiling fan with light
+- Anko HEGSM40 fan
+- Arida Venti 160 small through-wall heat-recovery ventilation fan
+- Arlec ceiling fan and light remote control kit (CFR225HA also works for Sulion Cadillac)
+- Arlec Grid Connect smart ceiling fan (with and without light)
+- Arlec 19, 12, 6, 4 speed speed fans
+- Aspen ASP 200 fan
+- Atomberg Gorilla fan V2
+- Atomi 52 inch ceiling fan
+- Ausclimate EcoSmart pedestal and desk fans
+- Aygrochy ventilation duct fan
+- Aziot fan modular switch
+- BKZO ceiling fan with RGBCW light
+- Blitzwill ceiling fan with light
+- Brandson A307362x3 tower fan
+- Breville AirDynamic 3D pedestal fan
+- Brilliant Ceiling fan with light, and remote controller
+- Calibo Cloudfan DC ceiling fan with light
+- Carro ceiling fan with cool and warm white lights
+- Carro PN-04F02D fan with dimmable light
+- Casafan ECO Neo III ceiling fan with light
+- Cecotec ceiling fan with light
+- Chameleon TCG 100cm tower fan
+- Chanfok ceiling fan with cool/warm white dimmable light (2 variants)
+- ComfortZone Powr Curve stand fan
+- Create XW-FAN-215-D ceiling fan with light (dimming and non-dimming variants)
+- Depauley WS-FPZ37-18I-EU ceiling fan with light
+- Deta fan controllers (6914HA Series 2 and 3)
+- Djive ARC humidifying fan
+- dLuft Smart Flow ventilator fan
+- Dometek Diamond ceiling fan with light
+- Dream Maker Feel DM01 fan
+- Duux Whisper Flex pedestal fan
+- Duux Whisper Flex Ultimate
+- Dyras TF-16WIFI tower fan
+- Eberg Fyn tower fan
+- EcoNour 42" tower fan
+- Efenz Kith ceiling fan with light
+- Eglo 5 speed + sleep ceiling fan (with or without light and presets)
+- eLinkSmart KH-SY2626 pedestal fan
+- Fanco Eco Silent Deluxe ceiling fan with LED light
+- Fanforce ceiling fan with light
+- Fisher F-ERVQ-B150CO2 heat recovery ventilator
+- FlinQ Breeze indoor pedestal fan
+- Funai Fuji ERW-150 Ultimate ventilation fan
+- GHome SW19 ceiling fan and light switch
+- Globe ceiling fans with RGBCW lights (with and without presets)
+- Goldair GCPF315 fan
+- Goldair Platinum tower fan (2 variants)
+- Hiper T3 bladeless fan
+- Hoenofly Smart Amari ceiling fan with light
+- Hoenofly Smart Wood low profile ceiling fan with lights
+- Holmes SmartConnect Digital Tower Fan (36 and 40 inch variants)
+- Hombli 6-speed ceiling fan with RGBCW light
+- Homebase 12" oscillating fan
+- HomeMate 5 speed fan regulator
+- Howeall register booster fan (also branded Sanycasa)
+- Humhold 24" low profile ceiling fan with RGB+CW lights
+- Hunter Pacific 6 and 9 speed ceiling fans with light
+- HYD WeAir Plus bladeless fan with heating function
+- Immax Neo Lite Vento ceiling fan with light
+- Inkbird IVC001W fan controller
+- InTec ceiling fan with light
+- Kavunion C1 100 ventilation fan
+- KCvents VT501-W heat recovery ventilation
+- Kendal KVT-Touchtower pedestal fan
+- Klarstein Airfold Smart ceiling fan with light
+- Klarstein Skyscaper Ice cooling fan
+- Klarstein Skytower Grand Smart cooling fan
+- Keyun MKCFE002 RGB chandelier fan
+- Kogan bladeless and 3D oscillating fans
+- Ledkia fan and light controller
+- Ledvance Ceiling fan with light
+- Lexy F501 fan
+- Ligency E26 socket ceiling fan with RGBCW light
+- Living Comfort LC310S twin window fan
+- Lucci Connect Wi-Fi fan remote
+- Lumary A1 and B2 ceiling fans with lights
+- Magnovent Cefiro ceiling fan with lights
+- Mantra ceiling fan with light
+- Milano ceiling fan
+- New Widetech WPF-16SW5 7-speed pedestal fan
+- Novadigital ceiling fan with light
+- NP-DVL-01 ceiling fan with RGB+CW light
+- OmniBreeze DC2313R tower fan (4-speed and 5-speed models)
+- Orison Chanfok Neo ceiling fan with light
+- Orison RGB ambient bladeless ceiling fan
+- Ovlaim ceiling fan with cool/warm white dimmable light
+- Plikc Ario WiFi air vent
+- Point One Technology Storm VSPEC-IV dual axis corner fan
+- Prestige M3 ceiling fan with light
+- Princess DC pedestal fan
+- Princess Smart air cooler
+- Princess Smart Tower fan
+- Prism+ Oasis Pro ceiling fan with RGBCCT light
+- Pro Breeze AirFlo 43" pedestal fan
+- Qiachip QI-FLRC-1 ceiling fan with light
+- Reiga ceiling fans with and without light
+- Reventon / Holtop Smart ERV heat recovery ventilator
+- Riyue Box 3 fan with light
+- Roomratv ceiling fan with light
+- Royal Clima RCB 150 ventilation system
+- Scheeair Nova 100 ventilation fan
+- Siguro SGR-FN-U32xx tower fan
+- Skyfan DC fan
+- Skyfan DC fan with light
+- Smart Mist3 TX-1602MF (ZJ-1522A-WiFi)
+- Smartmi Air Circulating fan
+- Stirling FS1-40DC pedestal fan
+- Sulion Crixus L ceiling fan with light
+- Temple and Webster Alina ceiling fan
+- TMWF02 fan controller
+- Treatlife DS02-F fan switch
+- Treatlife DS03 fan with dimmable light
+- Varin CFWI50 RGBCW ceiling fan
+- Varin VA-E003 ceiling fan with light
+- Windcalm ceiling fans with and without cool/warm white dimmable light
+- Yidi/NHZS fan and light wall switch
+- Yijingkc 284-8 ceiling fan
+- Yoevu EOS ceiling fan with CCT light
+- Yunlong ceiling fan with RGBCW lights
+
+### Air Purifiers
+
+- Alen BreatheSmart 35i and 45i air purifiers
+- Arlec APR005HA air purifier
+- Breville Easy Air, Smart Air Connect, Smart Air Viral Protect Plus and Night Glow purifiers
+- Cecotec TotalPure purifier
+- Cleverio AP100 air purifier
+- ComfortZone AP100 air purifier
+- Duux Bright air purifier
+- essentials portable air purifier
+- Himox H05 and H06 air purifiers
+- Homemedics C500 air purifier
+- Honeywell Air Touch P2 Air Purifier
+- Hosome air purifier
+- iHunt 400m³/h and 50m³/h air purifiers
+- Jafanda JF260S and JF500 air purifiers
+- Kilo Plus air purifier
+- Klarta Stor 2 and Forste 4 air purifiers
+- Kogan 2S and 5 pro air purifiers
+- Lifubide X600 air purifier
+- Meaco Clean CA-HEPA air purifier
+- Morento HY4866-WF, MR5866, MR7566-WF air purifiers
+- NAC AP470 air purifier
+- NX-100AP Rapid air purifier
+- Poiema One air purifier
+- Proscenic A8 and A9 air purifiers
+- Renpho RP-AP001S air purifier
+- Siguro Air Master AP-K50 air purifier
+- Smartmi E1 and P1 air purifiers
+- Soho SO-350WUI Air Purifier
+- Soleusair A02 and A10 air purifiers
+- Stadler Form Roger air purifier
+- Tesla Smart S300, Pro and Mini air purifiers
+- Trident AirDome-70 air purifier
+- TrueLife P3 and P7 air purifiers
+- Vephos True air purifier
+- Vestfrost VP-A1Z40HW air purifier
+- Vork VK6067AW air purifier
+
+### Dehumidifiers
+
+- Aktobis WDH-214US, WDH-310EK and WDH-870FW dehumidifiers
+- AlecoAir D12 ECO, D12/D16 Home, D14, D16, D25 Traditio dehumidifiers
+- Argo Dry Pury Evo WF dehumidifier
+- Arida S7L-2 dehumidifier
+- Cecotec BigDry 4000 dehumidifier
+- Clean Air Optima CA-702 dehumidifier
+- Cleverio AD100 dehumidifier
+- Climative DH-20S Cube ION dehumidifier
+- DH-CSK03W dehumidifier
+- Dura Comfort DH50PWM dehumidifier
+- Ebac DJ4000 dehumidifier
+- Eberg Rico R12E2 dehumidifier
+- ElectriQ CD12PRO-LE, CD12PW, CD20PRO-LE-V2/V4, CD25PRO-LE-V2 dehumidifiers
+- ElectriQ DESD9LW dehumidifier (two variants)
+- Electriq PD45E dehumidifier
+- Eeese Adam, Anna, Carl, Emil, Otto, Thor dehumidifiers
+- Emerio DH-129238.1 dehumidifier
+- Goldair GPDH340, GPDH420 dehumidifiers
+- Gologi GO021 dehumidifier
+- Greenmigo Alpha Q25 dehumidifier
+- Hiniso dehumidifier
+- Honeywell TP(30/50/70) dehumidifiers
+- HTW HTWD020A4 dehumidifier
+- Hyundai Sahara dehumidifier
+- Inkbird IHC-200 humidity controller
+- Inventor Atmosphere XL, Eva Ion Pro, Rise Pro dehumidifiers
+- JJPro JPD01, JPD02 dehumidifers
+- Juro-Pro 2006 dehumidifier
+- Klarstein DryFy Pro Connect dehumidifier
+- Kogan SmarterHome 7L desiccant dehumidifier
+- Krisbow Sync 36W dehumidifier
+- LDH-7700 dehumidifier
+- Luko dehumidifier
+- Meaco DD8L Pro dehumidifier
+- MeacoDry Arete Two 10L dehumidifier
+- Morris MDB-12160HIW dehumidifier
+- NWT WDH-02EM dehumidifier
+- Pro Breeze 30L dehumidifier
+- Pro Breeze D-23 dehumidifier
+- Qlima D720, D812 and D820A dehumidifiers
+- Rohnson R-9530 dehumidifier
+- Sefaul Q8 dehumidifier
+- Shinco 30D dehumidifier (also matches Klarstein DryFy Connect)
+- Siguro SGR DH-F300W dehumidifier
+- Stadler Form Lukas dehumidifier
+- Sygonix Smarter dehumidifier
+- Tesla Smart XL dehumidifier
+- VacPlus dehumidifier
+- Vivosun DE0003 dehumidifier
+- Wellio D008A 20L dehumidifier
+- Woods MRD25GW and WDD90 dehumidifiers
+
+### Humidifiers
+
+- Advwin 13L humidifier
+- airx H8 humidifier
+- AlecoAir PU55 Humino humidifier
+- Arida Eva humidifier
+- BlitzWolf BW-SH2, BW-SH5 humidifiers
+- Breville Smart Mist Glow Connect humidifier
+- Carro VES1011 humidifier
+- Clean Air Optima CA-604B, CA-605B, CA-607B humidifiers
+- Clofte Duo 400 humidifier
+- Duux Beam 2 humidifier
+- Eanons QT-JS2014 purifying humidifier
+- Eberg HUMI H03G1 humidifier
+- Homvana H111S humidifier
+- Inkbird IHC-200 humidity controller
+- Klarta Humea and Humea Grande humidifiers
+- Kyvol EA200 humidifier
+- Miro Q-Tower humidifier
+- OGACFO LFHM055 humidifier
+- RZTK Aqua Pro humidifier
+- Stadler Form Eva, Karl, Karl Big, Noah humidifiers
+- Tesla Smart humidifier
+- Venta AH510 Original Connect humidifier
+- Wetair WAW-H1210LW humidifier
+- Wilfa Haze HU-400BC and Moist C HU-430CW humidifiers
+
+### Aroma diffusers
+
+- Asakuki aroma diffuser with light (newer devices seem to require the Dituo config below)
+- Cadance ultrasonic aroma diffuser with light and music playback
+- Calex V2 aroma diffuser
+- Delixing KCL-1802A-M aroma diffuser
+- Dituo DT-1522-YN aroma diffuser
+- Etersky aroma diffuser with light
+- GD2050WIFI aroma diffuser
+- Haoyunma BD100 aroma diffuser
+- InLine ultrasonic aroma diffuser
+- Maxico aroma diffuser with light (cannot be differentiated automatically from Ditua above)
+- Revesien Q-Pro-W aroma diffuser
+- Tesla Smart aroma diffuser with light
+- YX-025 WB aroma diffuser
+- YX316WIFI aroma diffuser
+- YYM-805SW aroma diffuser with light (also supports GX Aroma diffuser)
+
+### Kitchen Appliances
+
+- Aeno EK1S and EK7S kettles
+- Aeno KS1S kitchen scale
+- Amenzo dishwasher
+- Anko 1.7L smart kettle
+- BlitzHome BH-CDW1 dishwasher
+- Ciarra CBCS4850 range hood
+- Casdon 16J3S dishwasher
+- Casdon KG1 inline water dispenser
+- Casdon TD Pro 2 and T2E ovens
+- Cecofry 5500 Connected air fryer
+- Etna VW644MC dishwasher
+- Fiesta DK-1G smart kettle
+- Goldair GGK1000 smart kettle
+- Götze and Jensen KT975K smart kettle
+- Homend Royaltea kettle
+- Inkbird iBBQ-4BW, iBBQ-4T, IBS-M1S, IBS-M2, IBT-26S, INT-12-BW cooking probe thermometers
+- Inkbird ISC-007BW smoker fan controller
+- Inkbird sous vide cooker (also supports Silvercrest sous vide sticks)
+- KKT Kolbe kitchen hood
+- Klarstein Amazonia dishwasher
+- Klarstein Ava range hood
+- Koenic KTM-221723-M kettle
+- Kogan glass 1.7L smart kettle (at least 2 different variants)
+- Korex AX-WF306N smart kettle
+- Leoffen LFIM6000 ice cube maker
+- Recteq RT-700, RT-1250, RT-B380X grills
+- Rohnson R-2858 SmartChef XL soft cooking air fryer
+- Setti+ KT950W smart kettle
+- Silvercrest 1.7L smart kettle
+- Silvercrest coffee maker
+- Silvercrest HF-6602T air fryer
+- Svensson Smart06C kettle
+- Ultenic K10 air fryer
+- Wandai GS-801 infant formula maker (sold as Easybaby, Gustino)
+- Weeket KE4071TF, KES5211TE-CE smart kettles
+- Wine Enthusiast Prestige S beverage center
+
+### Smart Meter/Circuit Breaker
+
+- amiciSmart AS-SM-63A energy meter
+- Atorch S1BW,S1WP energy monitoring switches with display
+- Atorch AT2PL energy monitoring breaker switch (also working for GR2PWS)
+- Atorch AT4PW energy monitor
+- Atorch DT20HBW DC battery monitor
+- Aulifants SMES200 energy monitoring breaker switch
+- Avidsen Soria 400W solar inverter
+- CBI Astute smart controller breaker switch
+- CNC YCB9ZF-100W 1P circuit breaker
+- Compteur digital electric (single phase)
+- CT-1203 dual clamp meter
+- Dcenta dual clamp meter
+- Dewin KWS-306WF 3-phase energy monitoring breaker switch
+- DTS238-7 3 phase smart meter
+- Dual CT clamp bidirectional meter
+- EARU EAEMP3C-100-TY-W 3 phase bidirectional energy monitoring breaker
+- EARU EAMPDW-TY-63 3-phase energy monitoring breaker
+- EARU EASEM-D 3-phase multi circuit power meter
+- EARU SW RCB, DBN breakers
+- eMylo EAI-90 smart meter
+- ERZ04C smart meter
+- Gaqqee KWS-302-WF energy meter
+- Geonav HISB80A energy meter
+- GTS8-40 2P simple circuit breaker
+- Ketotek KTEM06pro energy meter
+- MatSee Plus bidirectional two channel clamp meter (multiple variants)
+- Meterk single phase clamp meter
+- Ourtop ATMS100133 energy meter
+- Owon PC341 3 in 16 out clamp energy meter
+- Parkside PG/PMW-300 solar inverter
+- PC311-TY 2 phase power clamp meter
+- PC321-TY 3 phase power clamp meter
+- PC473 3-phase energy monitor
+- PJ-1103, PJ-1103A power clamp meters
+- PZIOT E01 energy meter
+- SG600MD solar inverter (also SG700MD, other SGxx0MD and SGxx0W models) sold under various brands
+- SmartMCB SMT006 energy meter (10 byte and 8 byte phase info variants)
+- Solar Grid/Smart GTB series solar inverter
+- Stepuptech SG800, SPD800 solar inverters
+- SWC32v2 CBU circuit breaker energy meter
+- Taffware 1P-J-63 circuit breaker
+- Taxnele circuit breaker and energy meter
+- TOMPD-63LW, 63-WIFI energy meter circuit breakers
+- Tomzn energy meter (SWC32v4 and other models)
+- Tongou QCB2-WB WiFi 4P circuit breaker (3-phase and single phase variants)
+- Tongou SA1 WiFi energy meter
+- Tongou SMR1 20 and 40 circuit breakers
+- Tongou ST463JWT 4P 3-phase circuit breaker
+- Tongou TO-Q-SYS-WT energy monitoring circuit breaker
+- Unknown brand dual channel smart meter
+- V-WIFI-DL01-ES energy consumption single clamp meter
+- V-WIFI-DL02-ES energy consumption dual clamp meter
+- Veratti V4 3-phase energy meter circuit breaker
+- WDYK 2P63A, 3P 400V, 4P100A energy meter circuit breakers
+- WMDL 2C dual channel bidirectional energy meter
+- Xoca DAC2121C BI energy meter
+- Yagusmart 3PN 63A 3-phase multi-tariff energy meter
+- Zemismart SDM01-TW0-12-ZM 3-phase bidirectional energy meter
+- Zemismart SMD02T-TZ 2-phase 120A bidirectional energy meter
+- Zemismart SPM02-(multiple variants) 3-phase energy meter
+- Zemismart ZMAi-90 smart switch energy meter
+- ZM-Wi-Fi smart meter
+
+### Battery Chargers
+
+- Absina Wallbox EV charger (also sold as Dé Wallbox and supporting 16, 32, 40 and 50A single and 3-phase variants)
+- ADPOW GO-B6 Pro-32A EV charger
+- AFYEEV 16A 11kW, 32A 22kW portable EV chargers
+- Aimiler 11kW EV charger
+- Ampbolt Level 1/2 portable EV charger
+- dé Wall EV charger (3-phase 22Kw)
+- Demuda 4048/6048 MPPT solar charge controller
+- Dowell iOneAIO EV charger
+- EcoPoint EV charger
+- Emini 16A Public EV charger
+- EVSun EV charger
+- Feyree EV charger (several models)
+- Immax Neo Lite 3-phase 22kW EV charger
+- Ipengen GO-E31-16A and 32A EV chargers
+- Junsun 32A EV charger
+- Kolanky 3.6kW EV charger
+- MakeSkyBlue MPPT solar battery charger
+- Nine 32A EV charger
+- Noeifevo Q21W EV charger
+- Oscal PowerMax 6000 portable power station
+- Parkside PLGS 2012 A1 smart charger for powertools
+- SEVR X1 EV charger
+- SRNE SE Series lithium battery
+- Suntree SPG3 EV charger
+- Tary TA-AC380/22 EV charger
+- Tera W01 EV charger
+- Vevor Level 2, portable 7kW and 3.7kW EV chargers
+- Voldt 8-13A EV charger
+- Wada Power Q8 EV charger
+- WOUEJ 22kW EV charger
+- Zencar Wpro 32A 3P EV charger
+
+### SmartPlugs/Wall sockets/Wall switches/Inline switches
+
+Most smartplugs follow a fairly standard template from Tuya, so many
+will work with other brands configs. However there are many
+permutations of features enabled, and some manufacturers move
+datapoints around so smartplugs take up a lot more configurations than
+such simple devices should. A future release will look at
+consolidating these into a smaller number of configs. When you add a device,
+the default selected option for the device type has the most matching
+datapoints, so provided it looks like the same type of device, it is probably
+the best option.
+
+- Acme SH3305 powerstrip (2 x 3 outlet switch + USB switch)
+- Arlec PB88UHA 4 way powerstrip with child lock
+- Aubess 1-gang switch with energy monitoring
+- Aubess 2 and 3-gang switches
+- Aziot 4, 7 and 8 gang multi-switches
+- Bauhn APSW-0624 5 way powerstrip (with unswitched USB)
+- BBCoin AC5299 PCIe computer switch
+- Blitzwolf BW-SHP6 PRO smartplug with child lock
+- Blitzwolf BW-SHP-9 3 outlet + USB powerstrip
+- Brilliant 1/2/3/4 gang wall switches with power monitoring
+- Brilliant quad powerstrip with USB
+- CBI Astute smart controller
+- CE Smart Home LQ-2-W3 AC wall outlet
+- Denver SHP-200mk2 dual smartplug with power monitoring
+- DIGOO DG-SP202 dual smartplug with energy monitoring and timers
+- DIGOO DG-SP01 USB smartplug with night light
+- Dual power monitoring smartplug (Geex)
+- Dual power monitoring smartplug v2 (Smatrul, Deltaco, Knightsbridge)
+- Eightree ET43 3-outlet powerstrip with energy monitoring
+- ES01 3 outlet + USB powerstrip with individual timers
+- ESP Fort EC-SPSP USB and mains smartplug
+- Gosund P1 3 outlet + USB powerstrip with power monitoring
+- Gosund SP112-RTL power monitoring smartplug with USB
+- Gosund SP211 power monitoring dual smartplug
+- Gosund WP9-RTL 3 outlet + USB powerstrip with child lock and initial state
+- Grid Connect double outlet wall socket
+- Grid Connect double outlet with Energy Monitoring, Master and Individual switches and Child Lock
+- Grid Connect USB charger with power socket
+- HomeMate 2gang and 4gang switches
+- Inna/Automat-ON AUTO000014 7 channel underfloor heating controller
+- JH PCIe mini computer switch
+- JH PCIe pro+ computer switch
+- KMC 4-outlet wall tap with energy monitoring
+- LerLink high power switch
+- Linkoze LKWSW201 dual button
+- Logicom Strippy 4 way power strip with USB
+- Loratap RR400W-V2 relay switch
+- Loratap RR620W-JL dual relay switch
+- M604 quad wall switch
+- Makegood double power point (sold under AusElectronicsDirect, Cleverlife, Kogan, Ozsmartthings and other brands)
+- MakeGood double switch with timers and power monitoring on whole device
+- Minoston 6 preset timer switch
+- Mirabella Genio smartplug with USB
+- Moes 3-gang switch
+- Moes 4-gang (quad) switch
+- Moes motion sensor smart switch
+- Moes PIR wall switch
+- Moes Star Feather Scene Switches (3 and 4 gang tested)
+- MoesHouse smartplug with RGBW nightlight
+- Noiee NSP21 smartplug
+- Noiee PU13 smartplug
+- Novadigital 4-way switch with backlight, power on state and timers
+- Pop-up smart socket (unknown brand)
+- Qnect QN-WPO3 3 outlet + USB powerstrip with individual timers
+- Relay switch with 433MHz remote (unbranded)
+- RCU16 16ch relay module
+- Single switch with backlight (unbranded)
+- Smart P01 power monitoring smartplug
+- Somgam single wall switch
+- Somgam double wall switch
+- Teckin SS42 outdoor double smartplug
+- Tellur 3 outlet + USB power strip with individual timers
+- Tongou TOVTH-216WTTDA temperature humidity sensor dual smart switch
+- TY-12W/24W 12/24 switch relay boards (boards with 8 - 24 relays supported)
+- UK002WL2 dual switch
+- WF-WS02 RJ dual switch with master
+- Woox R4028/DIGOO DG-PS01 3 outlet + USB powerstrip with individual timers
+
+Other brands may work with the above configurations, or the below are
+generic configurations that basically follow Tuya's templates with
+different features enabled, so are known to work with multiple brands
+of device.
+
+- 2 outlet plus 2 USB smartplug with individual timers
+- 3 way power monitoring strip
+  _confirmed as working with LSC Smart Connect powerstrip_
+- 4 way power monitoring strip (2 types)
+  _confirmed as working with Kogan KASPS10A3P3UA 3 socket + USB powerstrip_
+- 4 way powerstrip with USB
+  _confirmed as working with AOFO ZLD-44EU-W, another variant with Home Awesome device_
+- 4 way powerstrip with USB and restore power state config.
+- Generic smartplug with power monitoring (older models)
+  _confirmed as working with Kogan, Blitzwolf and Gosund single smartplugs (smartplugv1)_
+- Generic smartplug with power monitoring (newer models)
+  _confirmed as working with Kogan single smartplug with USB and Rillpac smartplugs (smartplugv2)_
+- Generic smartplug with power monitoring requiring polling of sensors
+  _same as above smartplugv2, but only reports power/current/voltage when explicitly requested - choose `smartplugv2_polled_power`_
+- Generic smartplug with power monitoring and USB ports
+  _confirmed as working with Gosund SP112 smartplugs_
+- Generic smartplug with more advanced energy monitoring
+  _confirmed working with CBE smartplugs, another variant with child lock, backlight and inching switch confirmed with Aubess and Elivco, and another variant with Gosund UP111-RTL_
+- Generic smartplug with some additional encoded schedule info.
+  _confirmed working as a simple switch and timer with Kashimura KJ-173_
+- Generic smartplug without power monitoring but with most other features (initial state setting, light options, child lock)
+  _confirmed working with SX1 relay socket_
+- Generic double switch with timers (confirmed with Living dual switch and another v2 variant with Avatto dual switch)
+- Generic multi switches (up to 8-gang in any combination - confirmed with non-standard eMylo US-083e dual outlet+USB switches)
+- Generic triple and quad switches (confirmed with Songam wall switches)
+- Generic triple and quad switches with timers (confirmed with Pearl Xystec USB hub)
+- Generic quad powerstrip with USB and power monitoring (confirmed with EKF Connect Pro)
+- Simple switch - a switch only, can be a fallback for many other unsupported devices, to allow just power to be switched on/off.
+- Simple switch with timer - a single switch and timer, will probably work for a lot of smart switches that are not covered by the more advanced configs above.
+- Simple switch with timer v2 - the above with timer moved from dp 11 to 9, confirmed with a Nexxt 220V smart switch.
+- Simple dual switch (confirmed with eMylo dual RF/WiFi switches)
+- Simple triple switch - three switches in a single device, tested with Somgam 3 gang wall switches.
+- Simple quad switch - four switches in a single device, tested with Somgam 4 gang wall switches.
+- Simple 6-way switch - six switches in a single device
+- Simple 8 switch - eight switches in a single device
+- RGB Nightlight outlet - one smartplug with a small built-in RGB light.
+
+### Lighting
+
+- Generic CCT lightbulb (supporting color temperature and brightness) - old and new style
+- Generic dimmable light (2 types, using dp 1,2 and 20,22)
+- Generic RGBCW/RGBWW lightbulb (confirmed with Lijun branded bulb, expected to match others also). Three versions - standard dps layout starting from 20, with and without scene/music modes and timer, and a non-standard layout starting from 1 but following the same pattern (tested with "A60" bulbs).
+- Generic RGBWC (RGBCW with color temperature inverted) lightbulbs, tested with YSR-CGD-RGB Smart Bowl lamp.
+- Generic RGBW lightbulb in the standard and non-standard patterns above but without color temperature control.
+- Generic dimmable/color temperature adjustable desktop lamp (confirmed with Setti+ SL601)
+- Generic "Dreamlight" RGBIC and RGBCW LED strips (tested with LSC RGBIC+CCT 2x5m and Outsmart RGBIC LED strips)
+- Generic RGB only "Dreamlight" LED strip
+- Generic RGB only light bar - like the lights above, but no white light controls supported.
+- Unbranded 1CH dimmer module
+- Unbranded 4-in-1 10GHz motion sensor
+- Unbranded dual dimmer module
+- A60 1800-2700K RGBWW light
+- Arknoah Aquarium lights
+- Arlec 10 path lights
+- Arlec LVE160HA ball lights
+- Asahom S105A-C outdoor lighting
+- Atomi smart color string light
+- Blitzwolf BW-LT31 LED strip
+- Brilliant Smart 22W twin flood lights with motion sensor
+- Brilliant Smart PIR outdoor sensor light switch
+- Brizlabs string lights
+- Calex S45 Clear E27 lightbulb
+- Deltaco LED Strip (SH-LW5M)
+- Deta/Arlec motion sensor lights (DET100HA/DET102HA/MAL315HA)
+- Deta 6910HA series2 dimmer switch
+- Dim2Warm G95 Gold 1800-2700K CCT lightbulb
+- Dream of You dual dimmable lamp
+- Dreamegg Nite 1 baby sound machine
+- Dual-mode magic light string controller
+- Edison Smart Treo dual-zone CCT ceiling light
+- Elegrp DTR10 dimmer light switch
+- Enbrighten Café string lights
+- Enbrighten Curtain lights
+- EZValo Smart desk lamp
+- Fancy LEDs screen sync light 2.0
+- Feit dimmer (may work with other brands that just have a switch, dimmer and
+  optional minimum brightness and bulb type)
+- Feit OneSync Smart Bridge lighting controller
+- Feit RGBWW light bulb (like generic RGBWW, but without scene support)
+  - FlinQ Smart multicolor string lights
+- Galaxy Projector
+- Gosund SW2 dimmer switch
+- HDMI sync light
+- HDMI TV ambient lighting 65
+- Hombli CCT 2024 Christmas lights
+- iHD001 LED controller
+- Ion LED WiFi dimmer
+- iSparkle Curtain Micro Lights
+- Kojima motion sensor RGBCW nightlight
+- Ledvance Smart+ Planon panel light with backlight
+- Lexi Lighting string light Wifi adapter
+- LightStar CCT track light
+- Loycco sound machine with nightlight (also sold as Momland nightlight with white noise)
+- Loycco Smart Nursery light
+- Loginovo TV sync backlight
+- LSC Smart Connect CCT + RGB ceiling light
+- LSC Smart Connect CCT + RGB led strip
+- LSC Smart Connect garden spotlights
+- LSC Smart Connect Neon LED strip
+- LSC Smart Connect Party string lights
+- LSC smart connect RGB CCT lightbulb (similar to older generic bulbs, so may work for others)
+- Lytmi Fantasy/Neo 3 HDMI sync backlight
+- Malmbergs QS-WIFI-D02-TRIAC single dimmer module
+- Malmbergs QS-WIFI-D02-TRIAC-2C dual dimmer module
+- Malmbergs NV-SWQ triple dimmer module
+- Marpou RGBCW ceiling light
+- MiBoxer WL-Box2 zone control gateway
+- Mirabella Genio Pixel LED oval light
+- Moes dimmer switch
+- Moes motion sensor lights (XZ-CGV3)
+- Moes star projector
+- MoesGo dimmer switch
+- Nedis Smart LED Strip
+- NemoLight Extreme Series aquarium light
+- Newone WF39M dimmer smartplug
+- Nince RGB LED strip
+- oLight Sphere ambient light
+- Outon Smart Lamp
+- Peteme recessed lighting
+- PowerAsia RGB 6-inch recessed lighting
+- RGB48 RGBIC string light
+- Richelieu tunable white LED puck light (166142030)
+- Spa Electrics Iris pool light controller
+- Space Dog Music Lamp (works for Aurora Smart Galaxy Star)
+- SunnyBot plant light
+- Tampa Magnetic LED System CD-TY-WY05
+- Teberno LED strip light (LGC-005 OEM3)
+- Tech Inc 3m neon strip
+- TG Electro TG-MS-PIR-S201 motion sensor light
+- Treatlife outdoor dimmer with dual outlets
+- TV-TYA238-AK-2MP ambient TV sync backlight
+- Ustellar UT99911 RGB monitor light bar
+- V Jules.V SK17 galaxy projector
+- Xinled XLD-CL002 RGBCW lightbulb
+- WF520D dual dimmer touchpanel
+
+### Covers
+
+- Simple garage door
+- Simple blind controller (two variants - `simple_blinds` lets the position be set, but does not trust it to accurately reflect the current position always, `position_blinds` does trust the position to accurately reflect the current position)
+- Simple gate opener (simple garage door with timer)
+- Curtain with feedback (same DP layout as QS C01 curtains, but reads back the current_position from the position as some of these seem to accuraately report position as well)
+- Abalon BCM700D curtain motor (likely to work with other brands)
+- AGL Ultracontato r2 door controller
+- AGL Ultra Magic gate opener
+- Avatto curtain and double light switch (CL02, CLS02 models)
+- Avatto curtain and light switch
+- Avatto curtain switch
+- Avatto roller blind controller
+- Benexmart blind motor
+- BobYun Tech gatePro gate opener
+- CCB-11 blind controller
+- CC curtain controller 1
+- CST WB V1 cover switch with backlight
+- Curry Smarter 6-Gen roller shutter switch
+- Dongguan garage door
+- Dongguan LY1678-2 curtain robot
+- Dooya curtain motor
+- Eachen GD-DC5 garage door opener
+- Eruiklink curtain motor
+- Etersky curtain switch with backlight and timing control
+- FS-03W curtain switch with backlight control
+- Garen TSI Fit and Kit Central garage door openers
+- Graywind window shades
+- GW Motor roller blinds
+- HHC AM68 curtain motor
+- Kimex motorized cinema screen
+- Kogan garage door with tilt sensor
+- KY motor 35W-10 shutter controller
+- Loonas smart curtain
+- LoraTap GDC100W garage door opener
+- LoraTap QCSC420W double curtain switch
+- LoraTap SC500W-V1 curtain switch (supports many other simple curtain/blind controllers)
+- LS830-TY curtain
+- M027 curtain module (sold under several brands, including zemismart, meterk and others)
+- M515 curtain motor
+- Moes SCS80 Touch curtain switch with backlight and timing control
+- Moes WS-USR-2C double curtain switch with backlight
+- Moes WS-Y-EUC curtain switch with backlight and timing control
+- Outdoor Inc zip blind
+- QS-WIFI-C01(BK) curtain module
+- QS-WIFI-C02 dual curtain module
+- Safe CON09 barrier controller
+- SHerko curtain motor
+- SmartCurtains A-series ACS-WT curtain motor (may work for other models)
+- Wistar roller blind controller
+- Yueqing Combo YET848PC curtain motor
+- ZC34T-03-3A swing arm window opener
+- Zemismart AM25 roller blinds
+- Zemismart curtain rail
+- Zemismart roller shade
+- Zitech Basic 3.0 sliding door controller
+
+### Robot vacuums
+
+- Abir X8 vacuum cleaner
+- Airrobo P20 vacuum cleaner
+- Cecotec Conga 1970, X70, Z100 vacuum cleaners
+- Horniture G20, Q6 Pro vacuum cleaners
+- iHome Autoac Nova vacuum cleaner
+- ILIFE A12, A30 pro, V20, V30 vacuum cleaners
+- Kabum Smart 500, 700 vacuum cleaners
+- Kogan LX10, LX15, LX8 vacuum cleaners
+- Kyvol E30 vacuum cleaner
+- Lefant LS1 Pro, M213, N33, T700 vacuum cleaners
+- Lenovo E1 vacuum cleaner
+- Liectroux G7. XR500 vacuum cleaners
+- Lubluelu A901, SL60D vacuum cleaners
+- MAMNV BR151 vacuum cleaner with mop
+- Medion S10 SW, S20 SW, X10 SW vacuum cleaners
+- Mellerware City Move vacuum cleaner
+- Neatsvor X600 vacuum cleaner
+- OPK K2 vacuum cleaner
+- Parkside PPWD 30 A1 workshop vacuum
+- Proscenic M9, 850T vacuum cleaners
+- Realme TechLife vacuum cleaner
+- Rinkmo D2 vacuum cleaner
+- Rowenta X-plorer 75 S vacuum cleaner
+- Tefal X-plorer serie 75 animal vacuum
+- Tesvor S6 vacuum cleaner with mop
+- TTEC Robi Pro vacuum cleaner
+- Ultenic T10 vacuum cleaner
+- Zedar R600 vacuum cleaner
+
+### Lawnmowers
+
+- MoeBot S-series mowers (also sold under Parkside and other brands, may require protocol version set manually to 3.4)
+
+### Locks
+
+Note: Locks that are battery powered and do not use a hub are unlikely to
+work reliably, even if listed below.
+
+- BSTUOKEY access control keypad
+- EKAZA EKAV-T229Z Zigbee digital lock (via hub)
+- Hornbill Y4 Smart lock
+- Lucking HF06 smart lock
+- NovaDigital SL-06 smart lock
+- Orion Grid Connect smart fingerprint entrance lock
+- Orion Grid Connect smart lock
+- Sboard III mini Weigand access control interface
+- SmarDeer Lock33 smart lock
+- Tediton K7 smart lock
+
+### Sirens
+
+- A03 siren
+- Airam S1WFAA siren
+- ECoolBuy Siren with temperature and humidity sensor
+- Neo Coolcam Siren with temperature and humidity alert (NAS-AB02W)
+- Orion Grid Connect SWS07HA indoor siren
+- Orion Grid Connect outdoor siren (also Elesion NX-4980)
+- Sirena WS-902 Plus outdoor strobe siren
+- STL siren
+
+### Doorbells
+
+- Cleverio CD200 video doorbell
+- (Fuers?) video doorbell
+- Iebeyond ECH doorbell with 433MHz RF hub
+- iGET HOME DS1 video doorbell
+- HunterTBK HF-6602T video doorbell
+- KW02 video doorbell
+- Linda Smart 7S video doorbell
+- LSC Smart Connect video doorbell
+- MyQ TD8 video doorbell
+- Orno Sigo doorbell
+- Vidos M13-XT video dual gate doorbell
+- WHM-04 doorbell (sold under various brands)
+
+### Cameras
+
+Note that this integration does not include any support for video
+streams. Some cameras that provide local feeds may be able to be
+configured using RTSP or ONVIF feeds if they have static IP address,
+port and password.
+
+- BCom Majic IPBox intercom camera
+- Camnsmart E27-TY camera
+- Door peephole camera
+- EMOS IP-300 camera with floodlight
+- Garage door opener camera combo
+- HomeMate PTZ indoor camera
+- Kerui 200W camera
+- Kerui JS-P162 300W camera
+- LSC Smart Connect dual band outdoor camera
+- LSC Smart Connect Outdoor PTZ camera
+- LSC Smart Connect PTZ camera
+- Moes PTZ indoor security camera (WCM-P52 v1 and v2)
+- Nedis outdoor camera
+- Nexsmart Watch 2, Air 2, Air 3 cameraa
+- Pinelake BF02 birdfeeder camera
+- RH-PD10 3MP peephole doorbell camera
+- RL video intercom (reported unable to connect)
+- SC116-WZ3A PTZ camera
+- SMCM DDV-207 Doorbell Pro camera
+
+### Alarm control panels
+
+- Aixi-SHS Big siren alarm system
+- BlitzWolf BW-IS6 security alarm system
+- CPVAN CP2W alarm system
+- Digoo DG-HAMB GSM security alarm system
+- eTiger S6 alarm system
+- GauTone PG-103 security alarm system
+- HLG Infinity alarm
+- Kerui 120dB siren alarm
+- Nevian NVS-A6WG alarm panel (also branded as Curv)
+- Smart alarm siren (unbranded)
+- Staniot smart security panel
+- Tolviviov DP-W2.1 security alarm panel
+- TS106 alarm system
+- Wolf Guard WT2R alarm system
+- ZX-DB11 doorbell and alarm system
+- ZX-DB11B doorbell and alarm system
+- ZX-G30 alarm system
+
+### Pet care
+
+- Advwin 6L camera pet feeder
+- AF3W pet feeder
+- Arlec Grid Connect 5L pet feeder
+- BNETA F1-D pet feeder (likely compatible with Petwant F1-C)
+- Catit Pixi smart fountain
+- Catit pet feeder (Pixi 2.2kg dispenser and 6 meal versions, and another non-Pixi branded single dispenser)
+- Ceres Plus camera pet feeder
+- Cleverio PF100 pet feeder
+- Doel cat litter box
+- Duoqu Neo-A cat litter box
+- Dxophiex fish feeder
+- Els Pet Spaceship pet litter box
+- Evergreen Solar bird feeder camera
+- Faroro PF50 pet feeder
+- Faroro TD20 pet treat camera
+- FeelNeedy P-LFP01 camera pet feeder
+- Frienhund ACF180W-A dual camera pet feeder
+- Fukumaru AF01-W pet feeder
+- Hapaw pet fountain
+- Happy Llama Tech SoCool pet feeder
+- HoneyGuardian S56 pet feeder
+- iLonda L88 fish feeder
+- Imipaw DUW21 WBR3D cat feeder
+- iPettie W5 pet feeder
+- Kanchou pet fountain
+- Leo's Loo Too pet toilet
+- Littepets MA2 series Cute Baby cat litter box
+- LSC Smart Connect pet feeder
+- Meegeem cat litter box
+- Meowmatic pet feeder
+- Mini-B Public litter box
+- MolyPet F02W pet feeder
+- Mypin 6L camera pet feeder
+- Nedis pet feeder
+- Newpet pet feeder
+- Ningbo BF314A camera pet feeder
+- Oneisall PFD-002 Pro IR pet feeder
+- Papifeed pet feeder
+- Pawspik Microchip pet feeder
+- Petempo PAF-02 pet feeder
+- Petlibro PLAF103 pet feeder
+- Petlibro PLAF203 camera pet feeder
+- Petoneer Fresco EzGo pet fountain
+- Petoneer Fresco Hydrate Ultra pet fountain (2 versions)
+- Petoneer Fresco Mini pet fountain
+- Petoneer Nutri PF004 pet feeder
+- Petory F03W pet feeder
+- Petree 2.0 litter box
+- Petrust TK-WF002 pet fountain
+- PetSnowy Snow+ litter box
+- PetsPride OO15 camera pet feeder
+- Petwant F13-W 6-meal pet feeder
+- PNI water feeder
+- Puppy Kitty automatic pet feeder (F14-W and another model)
+- Repetsun double bowl 5L pet feeder
+- Rojeco PTM-001 pet feeder (two versions)
+- Rojeco V200 DU3L-VS camera pet feeder
+- Sailesi self-cleaning litter box
+- Sobralik pet fountain
+- Tesla Smart pet feeder
+- Tonepie T1PRO cat litter box
+- Tonepie T1 Pro MAX cat litter box
+- V330L pet feeder
+- Vevor 76L self-cleaning litter box
+- WellToBe Automatic Pet Feeder (WB S36D)
+- Xtuos dual pet feeder
+- Yakry camera pet feeder
+- YP pet feeder
+- Yuposl dual-band pet feeder
+- Zedar K1200 cat litter box
+
+### Remote controllers
+
+- Arlec HUBRF06HA RF 8x8 learning remote transmitter
+- Avatto WHS20S remote control with temperature and humidity sensors
+- Moes IR/RF remote controller (also IR controller pro, may work only for IR)
+- Moes touchscreen control panel mini with IR remote and Bluetooth sigmesh hub
+- Universal remote control with temperature and humidity sensors
+- S11+ IR/RF remote controller
+- Universal remote controller (must match by product id - report yours if not listed and it uses dps 201 and 202 only)
+- Woox R7246 remote control with temperature and humidity sensors
+- YET YET6956WTR-B 240-930MHz RF 4 button controller
+
+### Valves
+
+- ARD-100+ valve controller
+- Aubess Rainpoint TTP106W irrigation system
+- Becasmart BAF-908 irrigation system
+- FrankEver BV05 water valve
+- Frizzlife LP365P water monitor shut-off valve
+- Garza Wi-Fi garden irrigation system (ITV103W with 433MHz WiFi hub)
+- Gidrolock Standard water leak detection valve
+- Haozee water valve
+- Hoenyzy DN15 / DN20 / DN25 gas and water valve timers
+- Holman WX1 tap timer (sprinkler controller)
+- Holman WX2 dual tap timer
+- Holman WX8 8 sprinkler irrigation controller
+- KRain KRX8 (also KRX6) irrigation controller
+- Neo NAS-WV02W water use monitoring valve
+- Neptun Smart and Smart+ water leak control systems
+- Qoto 03 smart water valve / sprinkler controller
+- Qoto 05 smart water valve / sprinkler controller
+- SH07-8 / SH07S-TY smart sprinkler controller (sold as Aquarobo, Leictory LK06 and other brands)
+- Sunlary indoor plant watering system
+- Wasserstein AquaPal water monitor
+- Zemismart DP-WBS01 8-zone sprinkler controller (also sold as Benexmart and other brands)
+
+### Miscellaneous
+
+- generic illuminance sensor (2 types using different dps)
+- generic PIR motion sensor
+- generic PIR with alarm
+- generic smoke detector
+- Air Housekeeper 6-in-1 air quality monitor
+- Akai heat pump clothes dryer
+- Aquark Mr. Pure salt pool chlorinator
+- ASIP-0622 indoor planter
+- Bcetasy 18-in-1 air quality monitor
+- Boundless Brothers PA-210W gas alarm
+- Brennenstuhl WFD3050P PIR motion activated CCT spotlight
+- Bresser Smart 7-in-1 weather station
+- Bresser Smart Thermo-hygrometer
+- Chtoocy MC82 refrigerator thermometer
+- CO2-Box air quality monitor
+- CO2v1 carbon dioxide sensor
+- C30W gas leak detector
+- CT20W PIR motion detector
+- Dekala Lumos sunrise alarm clock
+- Dienmern DM165A noise meter
+- Digma DiSense G1 gas leak detector
+- EASTtime D401 water purifier
+- E Chief SGH01 hydroponic planter
+- EM3390TF weather station (tested with Viflykoo branded device, probably identical to the same model number branded as Uzoli, Jely and others)
+- EM3395TY-2 weather station
+- Emax EM3378 Weather Station (selling as Hiper P1 and other rebrands)
+- EPT ultrasonic 3m tank level sensor
+- Eureka ERK-S62 adjustable desk
+- Goldair Platinum SleepSmart electric blanket
+- GratKit filament dryer
+- GZAIR radon gas detector
+- Haier Nayun NY-GS-04 combustible gas alarm
+- Haoliyuen EWC02 air quality monitor
+- Haozee explosive gas leak and carbon monoxide alarm
+- Haozee PS10 mmWave presence sensing light switch
+- Houschen anti-fog bathroom mirror with lights
+- HRT AS90 temperature and humidity alarm
+- Holman Helios weather station
+- iHseno ZTU human presence sensor
+- idoo Smart Bloom 8 hydroponic system
+- Immax Neo Lite 7-in-1 weather station
+- Inkbird IAQM-129-W air quality monitor
+- Inkbird PTH-9CW air quality monitor
+- Kishin BS-DW002 motion sensor (sold under various brands)
+- KKMoon 7in1 air quality monitor
+- Kogan bidet toilet seat
+- Kogan KASMWEKFITEA fitted electric blanket
+- Kogan KAWHTNOSLPA white noise sleep aid
+- Konlen SNT957W-TDE E3S temperature alarm
+- Konlen/Rockson WF96L water level controller
+- Madimack InverChlor pool salt and mineral chlorinator
+- Madimack InverFlow Pro pool pump (also AquaForte Inverter VSP, Aquagem Inverpro)
+- Manta Windy MT0200B weather station
+- Mayborn GroClock Connect sleep training alarm clock (also sold under Tommee Tippee and other brands)
+- ME201W level sensor
+- Mirabella Genio motion sensor
+- Moes human presence sensor
+- Moes single outlet water timer
+- Moes smart wake up light alarm clock
+- Momcozy white noise machine (2 variants)
+- Mustool MT15/MT29 air quality box
+- Nedis WIFIPD10WT pill dispenser
+- Nedis WIFISA10CWT air quality monitor
+- Nobito air quality monitor
+- Palicy EC Pro 4 pool chlorinator
+- PGST PA-010 indoor temperature and humidity sensor
+- PH-W218 water quality monitor
+- Pinjia PJ3101A presence sensor
+- PlantsIO Ivy and Ivy Gen2 smart planters
+- PNI Sofe House Smart Gas 300 alarm
+- Prodotec PT02 air quality monitor
+- Protmex PT-19DW alarm clock with temperature and humidity monitor
+- PTH9BW air quality monitor
+- PV28-AW 3-in-1 CO2 monitor
+- PV28-CW 8 in 1 air quality monitor
+- QTFV3-3 air quality monitor
+- Raddy PT-5 pool thermometer
+- RainPoint TTV103FRF water timer
+- RQ400A gas alarm
+- RSE TY-WFH v3.01 gate controller
+- RTCZ-03 human presence sensor
+- Ryakka 7-in-1 smart pool monitor
+- SD123 HPR01 human presence radar
+- SNT957W-TDE temperature sensor
+- SNT957W-DE CBU temperature and humidity sensor
+- Speaka SP-TVCM-510 TV mount
+- Steigen Solar Pro clothes drying rack
+- Sunbeam dual heated mattress pad
+- Sunbeam single heated mattress pad
+- Sundream LC-series salt pool chlorinator (rebranded as Poolomio)
+- SWS-001 smart weather station
+- TH05Z temperature and humidity sensor
+- TH08 temperature and humidity sensor
+- TH16 temperature and humidity sensor
+- Timeguard WFPIR motion light controller
+- Tontine electric blanket
+- TOPENS TC196 remote control for gate openers
+- Treatlife 24GHz mmWave human presence sensor
+- TX-E gas sensor/alarm
+- Vevor YT60307 weather station
+- Vivo FD55 motorized TV mount
+- VT-14N1 9-in-1 air quality monitor
+- W-2839 water quality monitor
+- Weaja WJ-TUYA-S9 gas alarm
+- WeatherStation Pro
+- Wenzhi WZ-100M-W human presence sensor
+- Wenzhi WZ35 human presence sensor
+- Xiumii human presence radar
+- Xtreme TC20 carbon monoxide detector
+- Yieryi water quality monitor (also matches unbranded PH-W3988 device)
+- Yinmik WF-3188 water quality monitor
+- Yu Home Yu Turbo laundry drying rack
+- Zecamin ZG-205W mmWave human presence sensor
+- Zeissler ZSw.1312 water leak detector
+- ZMP71SH variable speed swimming pool pump
+- ZN-2C09 9-in-1 air quality monitor
+- ZX-GS21 gas leak alarm monitor
+- ZY-HPS01 human presence sensor
+- ZY-M100-WiFi mmWave human presence sensor (2 versions)
+- ZY-M201-WiFi mmWave human presence sensor
+
+### Devices supported via Bluetooth hubs
+
+- Adaprox Fingerbot plus
+- Ailrinni fingerprint door lock
+- AM24 venetian blinds motor
+- Arlec smart button
+- Arlec usb strip light
+- BSTUOKEY Invisible induction door lock
+- Diivoo DWV010, WT05 dual water timers
+- Dituo DT-T2190A aroma diffuser
+- Gainsborough Liberty entrance lock
+- HCT-611 water timer
+- HCT-626 dual water timer
+- HU06 smart lock
+- imitOS square downlight
+- Ironzon fingerprint lock
+- KB150A keypad fingerprint lock
+- MoistenLand water timer
+- Nice Digi door lock
+- Orion DL021HA lock
+- O'TU R1O1 fingerprint door lock
+- Positivo Smart keypad and voice locks
+- Primebras Athenas lock
+- PT216/PT19DB-2 temperature and humidity sensor
+- Raykube A1 Pro Max clip over door lock
+- RESTMO FML026A water meter
+- SGS01 plant sensor
+- Smart Ape solar garden light
+- SOP10 water sprinkler
+- TCS024B plant moisture sensor
+- TH05 temperature and humidity sensor
+- THB2 temperature and humidity sensor
+- Unistyle WT-04W water timer
+- XCase NX-4964 lock box
+- YL01 water quality tester
+- YSG BS01 lock
+- Generic water timers (confirmed with Johgee, Diivoo and Royal Gardineer branded devices)
+
+### Devices supported via IR hubs
+
+In general IR hubs are supported as generic IR remote controllers.
+Some specialised devices have built-in sensors to also present other
+entity types as sub devices.
+
+- Air conditioner / heat pump via Moes IR hub
+- Neo IR Air Conditioner controller
+
+### Devices supported via Zigbee hubs
+
+- Aubess temperature and humidity sensor
+- Avatto TRV06 radiator valve (also sold branded as Thaleos)
+- Avatto ZWT198 thermostat
+- Beok BAC-009 smart knob thermostat
+- EKAZA EKAV-T229Z Zigbee digital lock
+- Generic Zigbee Door Sensor
+- Haozee RB-SRAIN01 solar rain sensor
+- Haozee ZG-302ZM mmWave presence dual light switch
+- Intelbras IFR7000 door lock
+- Loginovo mmWave human presence sensor
+- LoraTap QCSC400ZB-V2 curtain switch
+- LoraTap SC500ZB-V2 curtain controller
+- Loratap SS9600ZB 6 button remote control
+- Meian SW02 water leak detector
+- Moes BRT-100-TRV thermostat radiator valve
+- Moes dual dimmer module
+- Moes RGBCW lightbulb
+- Moes TRV601/605/606 thermostat radiator valve
+- Moes ZHT-002 thermostat
+- MultiIR MIR-TE100-TY temperature and humidity sensor
+- Nedis ZBRC10WT 4 button remote control
+- Nedis ZBSD10WT door/window sensor
+- Nedis ZBSC10WT temperature and humidity sensor
+- Neo Siren Alarm 2
+- PY321-Z-TY energy meter
+- RTI-Tek T5Z thermostat
+- Smart air box BR V2
+- Temperature and humidity sensor with alarm feature
+- TH02 Z3-P3Z temperature and humidity sensor
+- WL-898WZ water leak sensor
+- WL-RTCZ-05Z human presence sensor
+- Zemismart SPM01 energy meter
+- Zemismart ZM85EL-1x roller blind motor
+- ZPmeter 214C-Z water meter (with and without valve control)
+- ZTH08ZTU temperature and humidity sensor
+
+NOTE: this project does not intend to expand the scope to support non-Tuya
+devices via Tuya hubs. Though it may be techincally feasible to do such a
+thing, it expands the support requirements beyond the capacity of the
+volunteer manpower of this project. The community would be better served by
+making Tuya devices work with the standard BLE and Zigbee support in
+Home Assistant rather than the other way around.

--- a/custom_components/tuya_local/devices/ekaza_ekavt229z_lock.yaml
+++ b/custom_components/tuya_local/devices/ekaza_ekavt229z_lock.yaml
@@ -1,0 +1,303 @@
+name: Door lock
+# EKAZA EKAV-T229Z Zigbee digital lock (category jtmspro).
+# Observed via Tuya cloud as sub-device (requires hub for local access).
+# DP IDs follow Tuya Zigbee residential lock standard; product_id not yet known.
+products:
+  - id: ekaza_ekavt229z
+    manufacturer: EKAZA
+    model: EKAV-T229Z
+    model_id: EKAV-T229Z
+entities:
+  - entity: lock
+    dps:
+      # Unlock history / method reports (standard Zigbee residential lock)
+      - id: 1
+        type: integer
+        name: unlock_fingerprint
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      - id: 2
+        type: integer
+        name: unlock_password
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      - id: 3
+        type: integer
+        name: unlock_temp_pwd
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      - id: 4
+        type: integer
+        name: unlock_dynamic_pwd
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      - id: 5
+        type: integer
+        name: unlock_card
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      # Door closed/open status from geomagnetic / sensors
+      - id: 47
+        type: string
+        name: open
+        optional: true
+        readonly: true
+        mapping:
+          - dps_val: open
+            value: true
+          - dps_val: closed
+            value: false
+          - dps_val: unknown
+            value: null
+            hidden: true
+      # Motor locked state (true = bolt locked)
+      - id: 57
+        type: boolean
+        name: lock_state
+        optional: true
+      # Double-lock / reverse-lock (true = double locked from inside)
+      - id: 12
+        type: boolean
+        name: lock
+        optional: true
+      # Remote unlock result
+      - id: 22
+        type: boolean
+        name: remote_result
+        optional: true
+        persist: false
+      # Remote unlock history (member / method id)
+      - id: 41
+        type: integer
+        name: unlock_app
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      # Password-free remote unlock (Zigbee residential lock: DP 49)
+      - id: 49
+        type: base64
+        name: code_unlock
+        optional: true
+        sensitive: true
+      # Voice remote unlock history
+      - id: 62
+        type: integer
+        name: unlock_voice
+        optional: true
+        persist: false
+        range:
+          min: 0
+          max: 999
+      # Offline password unlock report
+      - id: 32
+        type: string
+        name: unlock_offline_pwd
+        optional: true
+        persist: false
+        sensitive: true
+  - entity: sensor
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 10
+        type: integer
+        name: sensor
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: binary_sensor
+    name: Double locked
+    class: lock
+    category: diagnostic
+    dps:
+      - id: 12
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: binary_sensor
+    name: Door
+    class: door
+    category: diagnostic
+    dps:
+      - id: 8
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: binary_sensor
+    name: Motor locked
+    class: lock
+    category: diagnostic
+    dps:
+      - id: 57
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: event
+    name: Alert
+    category: diagnostic
+    dps:
+      - id: 9
+        type: string
+        name: event
+        optional: true
+        persist: false
+        mapping:
+          - dps_val: wrong_finger
+            value: wrong_finger
+          - dps_val: wrong_password
+            value: wrong_password
+          - dps_val: wrong_card
+            value: wrong_card
+          - dps_val: wrong_face
+            value: wrong_face
+          - dps_val: tongue_bad
+            value: tongue_bad
+          - dps_val: too_hot
+            value: too_hot
+          - dps_val: unclosed_time
+            value: unclosed_time
+          - dps_val: tongue_not_out
+            value: tongue_not_out
+          - dps_val: pry
+            value: pry
+          - dps_val: key_in
+            value: key_in
+          - dps_val: low_battery
+            value: low_battery
+          - dps_val: power_off
+            value: power_off
+          - dps_val: shock
+            value: shock
+          - dps_val: defense
+            value: defense
+          - dps_val: wrong_unlock
+            value: wrong_unlock
+  - entity: event
+    name: Hijack
+    class: safety
+    category: diagnostic
+    dps:
+      - id: 35
+        type: boolean
+        name: event
+        optional: true
+        persist: false
+        mapping:
+          - dps_val: true
+            value: hijack
+          - dps_val: false
+            value: null
+  - entity: event
+    class: doorbell
+    category: diagnostic
+    dps:
+      - id: 14
+        type: boolean
+        name: event
+        optional: true
+        persist: false
+        mapping:
+          - dps_val: true
+            value: ring
+          - dps_val: false
+            value: null
+  - entity: select
+    name: Doorbell song
+    icon: "mdi:bell-ring"
+    category: config
+    dps:
+      - id: 15
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: ding_0
+            value: Ding 0
+          - dps_val: ding_1
+            value: Ding 1
+          - dps_val: ding_2
+            value: Ding 2
+          - dps_val: ding_3
+            value: Ding 3
+          - dps_val: ding_4
+            value: Ding 4
+          - dps_val: ding_5
+            value: Ding 5
+          - dps_val: ding_6
+            value: Ding 6
+          - dps_val: ding_7
+            value: Ding 7
+          - dps_val: ding_8
+            value: Ding 8
+          - dps_val: ding_9
+            value: Ding 9
+          # Some firmwares use numeric chime ids instead
+          - dps_val: "1"
+            value: Chime 1
+          - dps_val: "2"
+            value: Chime 2
+          - dps_val: "3"
+            value: Chime 3
+          - dps_val: "4"
+            value: Chime 4
+          - dps_val: "5"
+            value: Chime 5
+          - dps_val: "6"
+            value: Chime 6
+          - dps_val: "7"
+            value: Chime 7
+          - dps_val: "8"
+            value: Chime 8
+          - dps_val: "9"
+            value: Chime 9
+  - entity: text
+    name: Remote unlock set key
+    category: config
+    icon: "mdi:key-variant"
+    hidden: true
+    dps:
+      - id: 48
+        type: base64
+        name: value
+        optional: true
+        sensitive: true
+  - entity: text
+    name: New credential
+    category: config
+    icon: "mdi:card-plus"
+    hidden: true
+    dps:
+      - id: 54
+        type: base64
+        name: value
+        optional: true
+        sensitive: true
+  - entity: text
+    name: Delete credential
+    category: config
+    icon: "mdi:card-minus"
+    hidden: true
+    dps:
+      - id: 55
+        type: base64
+        name: value
+        optional: true
+        sensitive: true


### PR DESCRIPTION
## Summary

Adds local support for the **EKAZA EKAV-T229Z** Zigbee digital door lock (`jtmspro`).

- Device config maps battery, lock/motor state, door open/closed, reverse-lock, unlock method history (fingerprint/password/temp/dynamic/card/app/voice), alerts, hijack, doorbell, doorbell song, and remote code unlock (DP 48/49).
- DP IDs follow the [Tuya Zigbee residential lock standard](https://developer.tuya.com/en/docs/iot/zigbee-doorlock-dp?id=K9fembhbeab0p), cross-checked against live cloud status for this product.
- Listed under Locks and Zigbee hub devices in `DEVICES.md`.

### Device details (from cloud)

| Field | Value |
| --- | --- |
| Manufacturer | EKAZA |
| Model | EKAV-T229Z |
| Category | `jtmspro` |
| Connection | Zigbee sub-device (requires hub) |
| Observed DPs (codes) | `unlock_*`, `open_close`, `alarm_lock`, `residual_electricity`, `reverse_lock`, `doorbell`, `doorbell_song`, `closed_opened`, `lock_motor_state`, `remote_no_pd_setkey` / `remote_no_dp_key`, etc. |

### Notes

- Product ID is currently a placeholder (`ekaza_ekavt229z`) until a local discovery / cloud `productKey` is confirmed from a setup log.
- Remote unlock uses the standard password-free remote unlock pair (DP 48/49) via `code_unlock` (8-digit pairing code).
- Battery Zigbee locks only report when awake; expect event-driven updates via the hub.

## Test plan

- [ ] Add device in tuya-local using hub host/device_id/local_key + lock `node_id`
- [ ] Confirm device type **Door lock / EKAZA EKAV-T229Z** is offered (or matches after partial DPS)
- [ ] Battery entity reports percentage
- [ ] Lock state / door sensors update on open/close and lock/unlock
- [ ] Alert event fires on wrong credential (if tested)
- [ ] Doorbell song select works (if supported by hub path)
- [ ] Optional: remote unlock with 8-digit code if pairing key is known