### PR TITLE
Add horizontal swing (DPS 106) to Teknopoint Idra Skiv

### DIFF
--- a/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
@@ -251,6 +251,19 @@ entities:
             value: Slightly down
           - dps_val: "5"
             value: Bottom
+  - entity: select
+    name: Horizontal position
+    category: config
+    icon: "mdi:arrow-left-right"
+    dps:
+      - id: 106
+        type: string
+        name: option
+        mapping:
+          - dps_val: "off"
+            value: "Off"
+          - dps_val: "same"
+            value: "Swing"
   - entity: switch
     translation_key: sleep
     category: config

--- a/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/idra_skiv_airconditioner.yaml
@@ -96,10 +96,17 @@ entities:
         type: string
         optional: true
         mapping:
-          - dps_val: c
-            value: C
           - dps_val: f
             value: F
+          - value: C
+      - id: 106
+        type: string
+        name: swing_horizontal_mode
+        mapping:
+          - dps_val: "off"
+            value: "off"
+          - dps_val: "same"
+            value: "on"
   - entity: switch
     name: Auxiliary heat
     icon: "mdi:heating-coil"
@@ -251,19 +258,6 @@ entities:
             value: Slightly down
           - dps_val: "5"
             value: Bottom
-  - entity: select
-    name: Horizontal position
-    category: config
-    icon: "mdi:arrow-left-right"
-    dps:
-      - id: 106
-        type: string
-        name: option
-        mapping:
-          - dps_val: "off"
-            value: "Off"
-          - dps_val: "same"
-            value: "Swing"
   - entity: switch
     translation_key: sleep
     category: config


### PR DESCRIPTION
## Summary

Adds DPS 106 (horizontal vane position) as a `select` entity to the Teknopoint Idra Skiv air conditioner profile.

## What it does

Controls the horizontal left/right swing of the indoor unit vane:
- `Off` — no horizontal swing
- `Swing` — horizontal sweep active (dps_val: `same`)

The RA1A1 remote control has a dedicated "Left&right swing" button for this function.

## Testing

- **Hardware**: 4× Teknopoint EVO-09 indoor units with IDRA iSKV4-28C9 water-cooled condenser
- **Integration**: tuya-local, Home Assistant 2026.6.3
- **Discovery**: DPS 106 found via `tuya_local` debug logging (`full_poll` responses show `"106": "same"` or `"106": "off"`)
- **Values observed**: `"off"` (no swing) and `"same"` (swing active) across 4 units

## Notes

- DPS 106 was already documented in the project but not exposed in the device profile
- The EVO-09 catalogue confirms horizontal swing support
- Additional fixed positions may exist (the remote cycles through multiple directions) but only `off` and `same` have been observed so far — additional values can be added as they are discovered