### PR TITLE
Add Coibeu WKFS-004 ceiling fan light

### DIFF
--- a/custom_components/tuya_local/devices/coibeu_wkfs004_fanlight.yaml
+++ b/custom_components/tuya_local/devices/coibeu_wkfs004_fanlight.yaml
@@ -1,0 +1,69 @@
+name: Ceiling fan light
+products:
+  - id: 05nijjtjtotiiuyw
+    manufacturer: Coibeu
+    model: WKFS-004
+entities:
+  - entity: light
+    icon: "mdi:ceiling-fan-light"
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 22
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+      - id: 102
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: fresh
+            value: fresh
+          - dps_val: nature
+            value: nature
+      - id: 104
+        type: integer
+        name: speed
+        mapping:
+          - dps_val: 15
+            value: 17
+          - dps_val: 30
+            value: 33
+          - dps_val: 45
+            value: 50
+          - dps_val: 60
+            value: 67
+          - dps_val: 75
+            value: 83
+          - dps_val: 100
+            value: 100
+      - id: 105
+        type: string
+        name: direction
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: time
+    translation_key: timer
+    category: config
+    dps:
+      - id: 112
+        type: integer
+        name: second
+        optional: true
+        range:
+          min: 0
+          max: 86399


### PR DESCRIPTION
## Device

Coibeu WKFS-004 — Wi-Fi ceiling fan with dimmable light (Tuya category `dj`, protocol 3.5). Product id `05nijjtjtotiiuyw`.

## Entities

- **light**: on/off (dp 20) + brightness (dp 22, 10–1000)
- **fan** (`fan_with_presets`): on/off (dp 101), preset mode `fresh`/`nature` (dp 102), speed (dp 104), direction (dp 105)
- **switch** `sound`: beep/sound toggle (dp 103)
- **time** `timer`: light timer (dp 112)

## Notes

The motor has 6 physical speed levels, and the remote sends exactly `15/30/45/60/75/100` on dp 104. These are mapped to 6 discrete percentages so the fan exposes `speed_count = 6` instead of a continuous slider.

DP values, the sound toggle, and the speed steps were confirmed by live capture against the physical device (tinytuya, protocol 3.5).

Checks run locally: `yamllint`, `ruff check`, `ruff format --check`, `pytest tests/test_device_config.py`, `pytest tests/test_translations.py` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)