### PR TITLE
Add Aqua Plus APAIO270 heat pump water heater

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -216,6 +216,7 @@
 
 - Apricus heat pump water heater
 - A.O. Smith HeatBot 15L electric water heater
+- Aqua Plus APAIO270 heat pump water heater
 - Aquatech Rapid/X6 heat pump water heater
 - Aquaviva AVH15S combo air-water heat pump
 - Arçelik AHPH-MM series combo air-water heat pump

--- a/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
+++ b/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
@@ -1,0 +1,312 @@
+name: Heat pump water heater
+products:
+  - id: zcuzgqkr3aef1hap
+    manufacturer: Aqua Plus
+    model: APAIO270
+entities:
+  - entity: water_heater
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: Stand
+                value: heat_pump
+              - dps_val: Boost
+                value: performance
+              - dps_val: ELE
+                value: electric
+      - id: 2
+        type: string
+        name: mode
+        hidden: true
+      - id: 4
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 15
+          max: 75
+      - id: 21
+        type: integer
+        name: current_temperature
+        unit: C
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 7
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Expansion valve position
+    icon: "mdi:pipe-valve"
+    category: diagnostic
+    dps:
+      - id: 14
+        type: integer
+        name: sensor
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 15
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Phase sequence module
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 17
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "NO"
+            value: Nothing
+          # "normal" and "ERR" are unconfirmed guesses - never observed live
+          - dps_val: normal
+            value: Normal
+          - dps_val: ERR
+            value: Error
+  - entity: sensor
+    name: Energy today
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Fan speed
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 19
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "OFF"
+            value: "Off"
+          - dps_val: LOW
+            value: Low
+          - dps_val: High
+            value: High
+  - entity: sensor
+    name: Suction (return gas) temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Return water temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Coil temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Discharge temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    translation_key: ambient_temperature
+    class: temperature
+    dps:
+      - id: 26
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: binary_sensor
+    name: Compressor
+    class: running
+    category: diagnostic
+    dps:
+      - id: 27
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Four-way valve
+    class: opening
+    category: diagnostic
+    dps:
+      - id: 28
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Circulation mode
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 30
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Fluorine
+          - dps_val: false
+            value: Water
+  - entity: sensor
+    name: Low pressure switch
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 29
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Close
+          - dps_val: false
+            value: Open
+  - entity: binary_sensor
+    name: Water pump
+    class: running
+    category: diagnostic
+    dps:
+      - id: 31
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Electric heating element
+    class: running
+    category: diagnostic
+    dps:
+      - id: 32
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: High pressure switch
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 33
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: false
+            value: Close
+          - dps_val: true
+            value: Open
+  - entity: sensor
+    name: Linked switch
+    class: enum
+    category: diagnostic
+    dps:
+      # true/false to Close/Open confirmed via app; significance of the
+      # linkage feature itself (likely PV/solar interlock) is unconfirmed
+      - id: 106
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Close
+          - dps_val: false
+            value: Open
+  - entity: sensor
+    name: Compressor runtime before defrost
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 41
+        type: integer
+        name: sensor
+        unit: min
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: V
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: W
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Total energy
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Water flow switch
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 107
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Close
+          - dps_val: false
+            value: Open

--- a/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
+++ b/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
@@ -36,6 +36,26 @@ entities:
         type: integer
         name: current_temperature
         unit: C
+  - entity: sensor
+    name: Target temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 4
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Tank temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
   - entity: binary_sensor
     translation_key: defrost
     category: diagnostic


### PR DESCRIPTION
## Summary

Adds device support for the Aqua Plus APAIO270 heat pump hot water system.

This device had no existing config and was being fuzzy-matched onto an unrelated reversible pool/spa heat pump config, producing a `climate` entity with wrong HVAC modes and a continuous `Unrecognised HVAC Mode of True ignored` warning.

- Modelled as a `water_heater` entity (`product_id: zcuzgqkr3aef1hap`) with the device's three real operation modes: Standard → `heat_pump`, Booster → `performance`, E-Heater → `electric`.
- Adds diagnostic sensors for tank/coil/discharge/suction temperatures, expansion valve position, fan speed, defrost/compressor/four-way-valve/water-pump/electric-heating-element status, high/low pressure switches, water flow switch, phase sequence module, circulation mode, energy/current/voltage/power, and compressor runtime before defrost.
- The full DP map (including several DPs not present in the standard schema, and English `code` strings that didn't match what they actually measured) was recovered via the Tuya Cloud API `/v2.0/cloud/thing/{id}/model` and `/shadow/properties` endpoints, then cross-checked against the manufacturer's own app.
- All three operation modes were verified live end-to-end: toggling Standard/Booster/E-Heater in the Tuya app was confirmed to transition `water_heater.hot_water_heat_pump`'s `current_operation` correctly in Home Assistant.
- DP labels/polarities for the pressure switches, water-flow switch, and several other diagnostic fields were empirically confirmed against the app's own "Temp. Query"/"Status Query" screens rather than assumed.

## Test plan

- [x] `uv run yamllint custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml` passes
- [x] `uv run ruff check .` / `uv run ruff check --select I .` / `uv run ruff format --check .` pass
- [x] `uv run pytest tests/test_device_config.py` passes (32/32)
- [x] No `product_id` collision with existing device configs
- [x] Deployed to a live production HA instance and verified: all three modes transition correctly, temperatures track live readings, no HVAC-mode warnings or entity errors since deployment