### PR TITLE
Added delta sensor with total and average mode

### DIFF
--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -153,6 +153,49 @@ entities:
           - scale: 100
 
   - entity: sensor
+    mode: delta
+    delta_function: total
+    name: Total energy
+    class: energy
+    dps:
+      - id: 127
+        name: sensor
+        type: integer
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+      - id: 128
+        name: delta_start_key
+        type: integer
+      - id: 129
+        name: delta_key
+        type: integer
+
+  - entity: sensor
+    mode: delta
+    delta_function: average
+    averaging_window: 400
+    name: Power
+    class: power
+    dps:
+      - id: 127
+        name: sensor
+        type: integer
+        unit: W
+        class: measurement
+        mapping:
+          - scale: 100
+
+      - id: 128
+        name: delta_start_key
+        type: integer
+
+      - id: 129
+        name: delta_key
+        type: integer
+
+  - entity: sensor
     class: energy
     dps:
       - id: 127

--- a/custom_components/tuya_local/sensor.py
+++ b/custom_components/tuya_local/sensor.py
@@ -3,12 +3,14 @@ Setup for different kinds of Tuya sensors
 """
 
 import logging
+from collections import deque
 
 from homeassistant.components.sensor import (
     STATE_CLASSES,
     SensorDeviceClass,
     SensorEntity,
 )
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .device import TuyaLocalDevice
 from .entity import TuyaLocalEntity, unit_from_ascii
@@ -16,6 +18,26 @@ from .helpers.config import async_tuya_setup_platform
 from .helpers.device_config import TuyaEntityConfig
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.warning("Tuya Local patched sensor.py loaded")
+
+def sensor_factory(device, config):
+    """Create the correct sensor implementation."""
+    mode = "absolute"
+ 
+    if hasattr(config, "_config") and isinstance(config._config, dict):
+        mode = config._config.get("mode", mode)
+ 
+    if mode == "delta":
+        return TuyaLocalDeltaSensor(device, config)
+
+    if mode != "absolute":
+        _LOGGER.warning(
+            "Unsupported sensor mode %s for %s, falling back to absolute",
+            mode,
+            getattr(config, "name", None),
+        )
+
+    return TuyaLocalSensor(device, config)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -25,7 +47,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         async_add_entities,
         config,
         "sensor",
-        TuyaLocalSensor,
+        sensor_factory,
     )
 
 
@@ -111,3 +133,195 @@ class TuyaLocalSensor(TuyaLocalEntity, SensorEntity):
             for val in values:
                 if isinstance(val, str):
                     return values
+
+
+class TuyaLocalDeltaSensor(TuyaLocalSensor, RestoreEntity):
+    """Sensor that handles interval/delta values."""
+
+    def __init__(self, device, config):
+        """Initialize the delta sensor."""
+        super().__init__(device, config)
+
+        # defaults
+        self._delta_function = "total"
+        self._averaging_window = 400
+
+        if hasattr(config, "_config") and isinstance(config._config, dict):
+            self._delta_function = config._config.get(
+                "delta_function",
+                self._delta_function,
+            )
+
+            if self._delta_function == "average":
+                self._averaging_window = int(
+                    config._config.get(
+                        "averaging_window",
+                        self._averaging_window,
+                    )
+                )
+        if self._delta_function not in ("total", "average"):
+            _LOGGER.warning(
+                "Unsupported delta_function %s for %s, falling back to total",
+                self._delta_function,
+                getattr(config, "name", None),
+            )
+            self._delta_function = "total"
+
+
+        # debug variables
+        self._debug_last_logged_start_key = None
+        self._debug_last_logged_key = None
+        self._debug_last_logged_delta = None
+
+        # for delta_function=total
+        self._total = 0.0
+        self._counted_for_key = 0.0
+
+        # for delta_function=average
+        self._samples = deque()
+
+        # common variables
+        self._last_processed_key = None
+
+
+    async def async_added_to_hass(self):
+        """Restore previous total after Home Assistant restart."""
+        await super().async_added_to_hass()
+
+        if self._delta_function != "total":
+            return
+
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            return
+
+        try:
+            self._total = float(last_state.state)
+        except (TypeError, ValueError):
+            self._total = 0.0
+
+    def _log_raw_change(self, start_key, key, delta):
+        """Log raw delta value changes."""
+        if (
+            start_key == self._debug_last_logged_start_key
+            and key == self._debug_last_logged_key
+            and delta == self._debug_last_logged_delta
+        ):
+            return
+
+        _LOGGER.debug(
+            "Raw change: start=%s end=%s delta=%s "
+            "prev_start=%s prev_end=%s prev_delta=%s total=%s",
+            start_key,
+            key,
+            delta,
+            self._debug_last_logged_start_key,
+            self._debug_last_logged_key,
+            self._debug_last_logged_delta,
+            self._total,
+        )
+
+        self._debug_last_logged_start_key = start_key
+        self._debug_last_logged_key = key
+        self._debug_last_logged_delta = delta
+
+    def _native_total_value(self, key, delta):
+        """Return accumulated total from interval deltas."""
+        if key != self._last_processed_key:
+            self._last_processed_key = key
+            self._counted_for_key = 0.0
+
+        if delta > self._counted_for_key:
+            self._total += delta - self._counted_for_key
+            self._counted_for_key = delta
+
+        return self._total
+
+    def _native_average_value(self, start_key, key, delta, interval_seconds):
+        """Return average value over the configured time window."""
+        if key != self._last_processed_key:
+            self._last_processed_key = key
+            self._samples.append(
+                (start_key, key, delta, interval_seconds)
+            )
+
+        if self._averaging_window > 0:
+            self._purge_old_samples(key)
+        else:
+            while len(self._samples) > 1:
+                self._samples.popleft()
+
+        total_delta = sum(sample[2] for sample in self._samples)
+        total_seconds = sum(sample[3] for sample in self._samples)
+
+        if total_seconds <= 0:
+            return None
+
+        # kWh over seconds -> W
+        return round(total_delta * 3600000 / total_seconds, 1)
+
+    def _purge_old_samples(self, newest_key):
+        """Remove samples outside the averaging window."""
+        cutoff = newest_key - self._averaging_window
+
+        while self._samples and self._samples[0][1] <= cutoff:
+            self._samples.popleft()
+
+    @property
+    def native_value(self):
+        """Return the delta sensor value."""
+        start_key = self._get_dp_value("delta_start_key")
+        key = self._get_dp_value("delta_key")
+        delta = self._get_dp_value("sensor")
+
+        if delta is None or start_key is None or key is None:
+            return None
+
+        try:
+            delta = float(delta)
+            start_key = int(start_key)
+            key = int(key)
+        except (TypeError, ValueError):
+            return None
+
+        interval_seconds = key - start_key
+        if interval_seconds <= 0:
+            return None
+
+        self._log_raw_change(start_key, key, delta)
+
+        if self._delta_function == "average":
+            return self._native_average_value(
+                start_key,
+                key,
+                delta,
+                interval_seconds,
+            )
+        return self._native_total_value(key, delta)
+
+    @property
+    def extra_state_attributes(self):
+        attrs = super().extra_state_attributes or {}
+        attrs.update(
+            {
+                "delta_function": self._delta_function,
+                "delta_key": self._last_processed_key,
+            }
+        )
+
+        if self._delta_function == "total":
+            attrs["counted_for_key"] = self._counted_for_key
+
+        if self._delta_function == "average":
+            attrs["averaging_window"] = self._averaging_window
+            attrs["samples"] = len(self._samples)
+
+        return attrs
+
+    def _get_dp_value(self, name):
+        """Get a configured DP value by dps name."""
+        dp = self._config.find_dps(name)
+        if dp is None:
+            return None
+        return dp.get_value(self._device)
+

--- a/tests/test_sensor_delta.py
+++ b/tests/test_sensor_delta.py
@@ -1,0 +1,161 @@
+"""Tests for delta sensor entity."""
+
+from unittest.mock import Mock
+
+from custom_components.tuya_local.helpers.device_config import TuyaEntityConfig
+from custom_components.tuya_local.sensor import TuyaLocalDeltaSensor
+
+
+def make_delta_sensor(delta_function=None, averaging_window=None):
+    """Create a delta sensor with real TuyaEntityConfig."""
+    mock_device = Mock()
+
+    config_dict = {
+        "entity": "sensor",
+        "mode": "delta",
+        "dps": [
+            {
+                "id": 127,
+                "name": "sensor",
+                "type": "integer",
+                "unit": "kWh",
+                "mapping": [{"scale": 100}],
+            },
+            {
+                "id": 128,
+                "name": "delta_start_key",
+                "type": "integer",
+            },
+            {
+                "id": 129,
+                "name": "delta_key",
+                "type": "integer",
+            },
+        ],
+    }
+
+    if delta_function is not None:
+        config_dict["delta_function"] = delta_function
+
+    if averaging_window is not None:
+        config_dict["averaging_window"] = averaging_window
+
+    config = TuyaEntityConfig(mock_device, config_dict)
+    sensor = TuyaLocalDeltaSensor(mock_device, config)
+
+    return sensor
+
+
+def patch_dp_values(monkeypatch, sensor):
+    """Patch sensor DP reads and return mutable value storage."""
+    values = {
+        "sensor": None,
+        "delta_start_key": None,
+        "delta_key": None,
+    }
+
+    monkeypatch.setattr(sensor, "_get_dp_value", lambda name: values.get(name))
+
+    return values
+
+
+def set_dp_values(values, delta, start, end):
+    """Set current mocked DP values.
+
+    delta is already the scaled value in kWh, as returned by _get_dp_value().
+    """
+    values["sensor"] = delta
+    values["delta_start_key"] = start
+    values["delta_key"] = end
+
+
+def test_delta_total_accumulates_intervals(monkeypatch):
+    """Test that delta_function=total accumulates interval deltas."""
+    sensor = make_delta_sensor("total")
+    values = patch_dp_values(monkeypatch, sensor)
+
+    result = []
+
+    for delta, start, end in [
+        (0.01, 0, 120),
+        (0.02, 120, 240),
+        (0.01, 240, 360),
+    ]:
+        set_dp_values(values, delta, start, end)
+        result.append(sensor.native_value)
+
+    assert result == [0.01, 0.03, 0.04]
+
+
+def test_delta_total_does_not_count_same_key_twice(monkeypatch):
+    """Test that repeated reads of the same interval are not counted twice."""
+    sensor = make_delta_sensor("total")
+    values = patch_dp_values(monkeypatch, sensor)
+
+    set_dp_values(values, 0.01, 0, 120)
+
+    assert sensor.native_value == 0.01
+    assert sensor.native_value == 0.01
+    assert sensor.native_value == 0.01
+
+
+def test_delta_defaults_to_total_function(monkeypatch):
+    """Test that delta_function defaults to total."""
+    sensor = make_delta_sensor()
+    values = patch_dp_values(monkeypatch, sensor)
+
+    set_dp_values(values, 0.01, 0, 120)
+
+    assert sensor._delta_function == "total"
+    assert sensor.native_value == 0.01
+
+
+def test_delta_average_power_uses_averaging_window(monkeypatch):
+    """Test average power calculation over configured averaging window."""
+    sensor = make_delta_sensor("average", averaging_window=600)
+    values = patch_dp_values(monkeypatch, sensor)
+
+    result = []
+
+    for delta, start, end in [
+        (0.01, 0, 120),
+        (0.02, 120, 240),
+        (0.01, 240, 360),
+        (0.00, 360, 480),
+        (0.01, 480, 600),
+        (0.00, 600, 720),
+    ]:
+        set_dp_values(values, delta, start, end)
+        result.append(sensor.native_value)
+
+    assert result == [
+        300.0,  # 0.01 kWh / 120 s
+        450.0,  # 0.03 kWh / 240 s
+        400.0,  # 0.04 kWh / 360 s
+        300.0,  # 0.04 kWh / 480 s
+        300.0,  # 0.05 kWh / 600 s
+        240.0,  # first sample purged: 0.04 kWh / 600 s
+    ]
+
+
+def test_delta_average_zero_window_uses_last_interval_only(monkeypatch):
+    """Test averaging_window=0 returns only the last interval average."""
+    sensor = make_delta_sensor("average", averaging_window=0)
+    values = patch_dp_values(monkeypatch, sensor)
+
+    set_dp_values(values, 0.01, 0, 120)
+    assert sensor.native_value == 300.0
+
+    set_dp_values(values, 0.02, 120, 240)
+    assert sensor.native_value == 600.0
+
+
+def test_invalid_delta_function_falls_back_to_total(monkeypatch):
+    """Test invalid delta_function fallback."""
+    sensor = make_delta_sensor("invalid")
+    values = patch_dp_values(monkeypatch, sensor)
+
+    set_dp_values(values, 0.01, 0, 120)
+
+    assert sensor._delta_function == "total"
+    assert sensor.native_value == 0.01


### PR DESCRIPTION
## Summary

This PR adds support for delta-based sensor processing.

Some Tuya devices report energy consumption as interval/delta values instead of a continuously increasing total. This change allows such values to be handled in two ways:

* `delta_function: total` accumulates interval deltas into a `total_increasing` sensor.
* `delta_function: average` converts interval energy deltas into an average power value over a configurable time window.

The default behavior remains unchanged: delta sensors use `delta_function: total` unless configured otherwise.

## Related issues
The following issues may be related, and this PR could improve processing for the mentioned devices. I have not changed their YAML files because I do not have those devices available for testing.

* [#4623 Request support for Pioneer Quantum Wall AC - WYT-25 Quantum Series](https://github.com/make-all/tuya-local/issues/4623)
* [#4634 Request support for Pioneer Quantum Wall AC](https://github.com/make-all/tuya-local/issues/4634)
* [#5270 power usage for ev charger Afyeev 16A](https://github.com/make-all/tuya-local/issues/5270)

## Testing environment

Tested with:

* Kaisai Pro Heat+ AC
* Device config: `kaisai_proheat_airconditioner.yaml`

## Example

```yaml
- entity: sensor
  mode: delta
  delta_function: total
  name: Total energy
  class: energy
  dps:
    - id: 127
      name: sensor
      type: integer
      unit: kWh
      class: total_increasing
      mapping:
        - scale: 100
    - id: 128
      name: delta_start_key
      type: integer
    - id: 129
      name: delta_key
      type: integer

- entity: sensor
  mode: delta
  delta_function: average
  averaging_window: 600
  name: Power
  class: power
  dps:
    - id: 127
      name: sensor
      type: integer
      unit: W
      class: measurement
      mapping:
        - scale: 100
    - id: 128
      name: delta_start_key
      type: integer
    - id: 129
      name: delta_key
      type: integer
```

For the `average` function, the source DP is still an interval energy value, but the resulting sensor value is average power, so the entity uses `unit: W` and `class: power`.

## Testing

Added unit tests covering:

* total accumulation from delta intervals
* duplicate `delta_key` protection
* default `delta_function: total`
* rolling average power calculation
* `averaging_window: 0` behavior
* fallback for invalid `delta_function`

Tested with:

```bash
pytest -vv tests/test_sensor_delta.py
```

Result:

```text
6 passed
```
