### PR TITLE
feat(devices): add TION Breezer 4S breezer

### DIFF
--- a/custom_components/tuya_local/devices/tion_breezer_4s.yaml
+++ b/custom_components/tuya_local/devices/tion_breezer_4s.yaml
@@ -1,0 +1,124 @@
+name: Breezer
+products:
+  - id: rllylqfcd3lfe3s3
+    manufacturer: TION
+    model: Breezer 4S
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+            constraint: temperature
+            conditions:
+              - dps_val: 0
+                value: fan_only
+      - id: 109
+        name: temperature
+        type: integer
+        unit: C
+        range:
+          min: 0
+          max: 25
+      - id: 9
+        name: current_temperature
+        type: integer
+        unit: C
+      - id: 108
+        name: fan_mode
+        type: integer
+        mapping:
+          - dps_val: 1
+            value: "1"
+          - dps_val: 2
+            value: "2"
+          - dps_val: 3
+            value: "3"
+          - dps_val: 4
+            value: "4"
+          - dps_val: 5
+            value: "5"
+          - dps_val: 6
+            value: "6"
+      - id: 111
+        name: hvac_action
+        type: string
+        mapping:
+          - dps_val: Heating
+            value: heating
+          - dps_val: Support
+            value: idle
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 102
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Backlight
+    icon: "mdi:led-on"
+    category: config
+    dps:
+      - id: 101
+        name: switch
+        type: boolean
+  - entity: switch
+    name: Recirculation
+    icon: "mdi:air-conditioner"
+    category: config
+    dps:
+      - id: 112
+        name: switch
+        type: string
+        mapping:
+          - dps_val: Recirc
+            value: true
+          - dps_val: Inflow
+            value: false
+  - entity: sensor
+    name: Outdoor temperature
+    class: temperature
+    dps:
+      - id: 10
+        name: sensor
+        type: integer
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Heater power
+    class: power
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        unit: W
+        class: measurement
+  - entity: sensor
+    translation_key: filter_life
+    category: diagnostic
+    dps:
+      - id: 105
+        name: sensor
+        type: integer
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 113
+        name: sensor
+        type: string
+        mapping:
+          - dps_val: "None"
+            value: false
+          - value: true
+      - id: 113
+        name: description
+        type: string


### PR DESCRIPTION
Adds a local config for the **TION Breezer 4S** air breezer (Tuya Wi-Fi module, protocol 3.5).

### Entities
- **climate** — `off` / `fan_only` / `heat` (heat = target temp > 0), fan speeds 1–6, target + current temperature, heating/idle action
- **switch** — sound, backlight, recirculation
- **sensor** — outdoor temperature, heater power, filter life
- **binary_sensor** — problem (raw fault code exposed as the `description` attribute)

### Notes
- DPs were verified against a physical device via local polling and cross-checked with the esphome-tion (BLE) controller.
- `product_id` (`rllylqfcd3lfe3s3`) obtained from local discovery.
- Presets, boost / boost-time, the filter-reset command and energy metering are handled BLE-side by the firmware and are not exposed as Tuya data points, so they are intentionally omitted.

Checked with `uv run yamllint custom_components/tuya_local/devices` and `uv run pytest tests/test_device_config.py` (green for the new config).
