### PR TITLE
Add Woods MRD20GW dehumidifier device config

### DIFF
--- a/custom_components/tuya_local/devices/woods_mrd20gw_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/woods_mrd20gw_dehumidifier.yaml
@@ -1,0 +1,91 @@
+name: Dehumidifier
+products:
+  - id: g5nx6i7qxfale9t7
+    manufacturer: Woods
+    model: MRD20GW
+entities:
+  - entity: humidifier
+    class: dehumidifier
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+      # Target humidity (MRD20GW supports 40-70%)
+      - id: 3
+        name: humidity
+        type: string
+        mapping:
+          - dps_val: "40"
+            value: 40
+            step: 10
+          - dps_val: "50"
+            value: 50
+            step: 10
+          - dps_val: "60"
+            value: 60
+            step: 10
+          - dps_val: "70"
+            value: 70
+            step: 10
+        range:
+          min: 40
+          max: 70
+      # Fan speed as mode (Low/High)
+      - id: 4
+        name: mode
+        type: string
+        mapping:
+          - dps_val: low
+            value: eco
+          - dps_val: high
+            value: boost
+      # Current humidity measurement
+      - id: 6
+        name: sensor
+        type: integer
+
+  # Swing flap
+  - entity: switch
+    name: Swing
+    icon: "mdi:unfold-more-horizontal"
+    dps:
+      - id: 8
+        name: switch
+        type: boolean
+
+  # Child lock
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 16
+        name: lock
+        type: boolean
+
+  # Fault / Tank / Error indicator (true if any bit set)
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 19
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 19
+        type: bitfield
+        name: fault_code
+
+  # Tank full indicator (bit 4 = value 16)
+  - entity: binary_sensor
+    translation_key: tank_full
+    dps:
+      - id: 19
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 16
+            value: true
+          - value: false


### PR DESCRIPTION
The Woods MRD20GW is a variant of the MRD25GW with an extended humidity range (40-70% vs 40-50%).

This adds a separate device config for the MRD20GW with:
- Humidity target range 40-70%
- Dedicated tank full binary sensor (DP19 bit 4, confirmed on hardware: fault_code=16 when tank is full)

Product ID: `g5nx6i7qxfale9t7`

Tested on a live MRD20GW unit.