### PR TITLE
Add support for AirSensor MT13W multi-function air quality sensor

### DIFF
--- a/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
+++ b/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
@@ -34,7 +34,6 @@ products:
     name: AirSensor MT13W
 entities:
   - entity: sensor
-    name: Carbon Dioxide
     class: carbon_dioxide
     dps:
       - id: 4
@@ -44,7 +43,6 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Temperature
     class: temperature
     dps:
       - id: 2
@@ -54,7 +52,6 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: Humidity
     class: humidity
     dps:
       - id: 3
@@ -64,7 +61,6 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: PM2.5
     class: pm25
     dps:
       - id: 7
@@ -74,7 +70,6 @@ entities:
         class: measurement
 
   - entity: sensor
-    name: PM10
     class: pm10
     dps:
       - id: 9

--- a/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
+++ b/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
@@ -1,27 +1,32 @@
-# Configurazione device custom per Tuya Local (make-all/tuya-local)
-# Device: Multi-function Air Quality Sensor (venduto anche come "AirSensor MT13W")
-# Product ID confermato: tf5vafuyq3hiibs4
+# Custom device config for Tuya Local (make-all/tuya-local)
+# Device: Multi-function Air Quality Sensor
+# (also sold as "AirSensor MT13W")
+# Confirmed product ID: tf5vafuyq3hiibs4
 #
-# Mappatura DPS confermata confrontando i valori raw con il display fisico del device:
-#   DPS 1   -> livello qualita' aria complessivo (stringa enum: level_1, level_2...)
-#   DPS 2   -> temperatura (C, valore diretto senza scala)
-#   DPS 3   -> umidita' (%, valore diretto senza scala)
-#   DPS 4   -> CO2 (ppm, valore diretto)
-#   DPS 5   -> HCHO/formaldeide (mg/m3, valore diviso 1000)
-#   DPS 7   -> PM2.5 (ug/m3, valore diretto)
-#   DPS 9   -> PM10 (ug/m3, valore diretto)
-#   DPS 23  -> stato schermo (booleano, acceso/spento)
-#   DPS 101 -> TVOC (mg/m3, valore diviso 1000)
+# DPS mapping confirmed by comparing raw values against the device's
+# physical LCD display, side by side, for each metric:
+#   DPS 1   -> overall air quality level
+#              (string enum: level_1, level_2...)
+#   DPS 2   -> temperature (C, direct value, no scale)
+#   DPS 3   -> humidity (%, direct value, no scale)
+#   DPS 4   -> CO2 (ppm, direct value)
+#   DPS 5   -> HCHO/formaldehyde (mg/m3, value divided by 1000)
+#   DPS 7   -> PM2.5 (ug/m3, direct value)
+#   DPS 9   -> PM10 (ug/m3, direct value)
+#   DPS 23  -> display on/off (boolean)
+#   DPS 101 -> TVOC (mg/m3, value divided by 1000)
 #
-# DPS ancora non identificati con certezza (visti nel dump ma non mappati qui):
+# DPS observed in the raw dump but not confidently identified yet:
 #   102, 104, 105, 106, 107, 112, 113, 114, 115
-#   (104 e' probabile tensione batteria in mV, ma il device sembra alimentato via USB
-#    quindi non confermato; 112="c" probabile flag unita' di misura Celsius/Fahrenheit)
+#   (104 is possibly battery voltage in mV, but the device appears to
+#   be USB powered so this is unconfirmed; 112="c" is possibly a
+#   Celsius/Fahrenheit unit flag)
 #
-# Per installare: copiare questo file in
-#   /config/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
-# poi riavviare Home Assistant (o ricaricare l'integrazione Tuya Local) prima di
-# aggiungere il device.
+# To install: copy this file to
+#   /config/custom_components/tuya_local/devices/
+#   multi_air_quality_mt13w.yaml
+# then restart Home Assistant (or reload the Tuya Local integration)
+# before adding the device.
 
 name: Multi-function Air Quality Sensor
 products:

--- a/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
+++ b/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
@@ -1,0 +1,128 @@
+# Configurazione device custom per Tuya Local (make-all/tuya-local)
+# Device: Multi-function Air Quality Sensor (venduto anche come "AirSensor MT13W")
+# Product ID confermato: tf5vafuyq3hiibs4
+#
+# Mappatura DPS confermata confrontando i valori raw con il display fisico del device:
+#   DPS 1   -> livello qualita' aria complessivo (stringa enum: level_1, level_2...)
+#   DPS 2   -> temperatura (C, valore diretto senza scala)
+#   DPS 3   -> umidita' (%, valore diretto senza scala)
+#   DPS 4   -> CO2 (ppm, valore diretto)
+#   DPS 5   -> HCHO/formaldeide (mg/m3, valore diviso 1000)
+#   DPS 7   -> PM2.5 (ug/m3, valore diretto)
+#   DPS 9   -> PM10 (ug/m3, valore diretto)
+#   DPS 23  -> stato schermo (booleano, acceso/spento)
+#   DPS 101 -> TVOC (mg/m3, valore diviso 1000)
+#
+# DPS ancora non identificati con certezza (visti nel dump ma non mappati qui):
+#   102, 104, 105, 106, 107, 112, 113, 114, 115
+#   (104 e' probabile tensione batteria in mV, ma il device sembra alimentato via USB
+#    quindi non confermato; 112="c" probabile flag unita' di misura Celsius/Fahrenheit)
+#
+# Per installare: copiare questo file in
+#   /config/custom_components/tuya_local/devices/multi_air_quality_mt13w.yaml
+# poi riavviare Home Assistant (o ricaricare l'integrazione Tuya Local) prima di
+# aggiungere il device.
+
+name: Multi-function Air Quality Sensor
+products:
+  - id: tf5vafuyq3hiibs4
+    name: AirSensor MT13W
+entities:
+  - entity: sensor
+    name: Carbon Dioxide
+    class: carbon_dioxide
+    dps:
+      - id: 4
+        type: integer
+        name: sensor
+        unit: ppm
+        class: measurement
+
+  - entity: sensor
+    name: Temperature
+    class: temperature
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+
+  - entity: sensor
+    name: Humidity
+    class: humidity
+    dps:
+      - id: 3
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+
+  - entity: sensor
+    name: PM2.5
+    class: pm25
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: "µg/m³"
+        class: measurement
+
+  - entity: sensor
+    name: PM10
+    class: pm10
+    dps:
+      - id: 9
+        type: integer
+        name: sensor
+        unit: "µg/m³"
+        class: measurement
+
+  - entity: sensor
+    name: Formaldehyde
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: "mg/m³"
+        class: measurement
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: TVOC
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: "mg/m³"
+        class: measurement
+        mapping:
+          - scale: 1000
+
+  - entity: sensor
+    name: Air Quality Level
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 1
+        type: string
+        name: sensor
+        force: true
+        mapping:
+          - dps_val: level_1
+            value: Good
+          - dps_val: level_2
+            value: Slight
+          - dps_val: level_3
+            value: Moderate
+          - dps_val: level_4
+            value: Serious
+
+  - entity: binary_sensor
+    name: Display On
+    category: diagnostic
+    dps:
+      - id: 23
+        type: boolean
+        name: sensor


### PR DESCRIPTION
This adds support for a Tuya-based multi-function air quality sensor, sold as "AirSensor MT13W" (product_id: `tf5vafuyq3hiibs4`).
The device is a desktop air quality monitor with an LCD display showing temperature, humidity, CO2, PM2.5, PM10, HCHO (formaldehyde), TVOC, and an overall air quality level indicator.
Testing:
This config has been tested and is working correctly on real hardware.
DPS values were confirmed by cross-referencing the raw DPS dump against the values shown on the device's physical LCD display side by side.
Mapped and verified DPS:
`1`  -> overall air quality level (enum: level_1-4, mapped to Good/Slight/Moderate/Serious)
`2`  -> temperature (°C, direct value)
`3`  -> humidity (%, direct value)
`4`  -> CO2 (ppm, direct value)
`5`  -> formaldehyde/HCHO (mg/m³, scale 1000)
`7`  -> PM2.5 (µg/m³, direct value)
`9`  -> PM10 (µg/m³, direct value)
`23` -> display on/off (boolean)
`101` -> TVOC (mg/m³, scale 1000)

Note: DPS `1` (air quality level) required `force: true` since the device does not proactively resend this value once connected if it stays stable, causing the entity to remain unavailable after a fresh connection/restart until explicitly polled.
Other DPS observed in the raw dump but not yet confidently identified (left unmapped for now): `102`, `104`-`107`, `112`-`115`. Happy to look into these further if useful.
Test file:
I don't currently have a test file for this config — I wasn't able to confirm the exact test harness pattern used in the current version of the repo. Happy to add one if you can point me to a recent example to follow, or feel free to add it during review.
Let me know if any changes are needed!
