### PR TITLE
Add IMAGINE 3+1 WiFi Switch device config

### DIFF
--- a/custom_components/tuya_local/devices/imagine3+1_switch.yaml
+++ b/custom_components/tuya_local/devices/imagine3+1_switch.yaml
@@ -3,7 +3,6 @@ products:
   - id: haqyilpinwntqgzj
     manufacturer: Imagine
     model: IT31LFW
-    name: IMAGINE 3+1 WiFi Switch
 
 # Built from real diagnostics dump:
 #   1,2,3   = switch relays (boolean)
@@ -68,7 +67,7 @@ entities:
         name: second
         range:
           min: 0
-          max: 86400
+          max: 86399
 
   - entity: time
     category: config
@@ -80,7 +79,7 @@ entities:
         name: second
         range:
           min: 0
-          max: 86400
+          max: 86399
 
   - entity: time
     category: config
@@ -92,7 +91,7 @@ entities:
         name: second
         range:
           min: 0
-          max: 86400
+          max: 86399
 
   - entity: time
     category: config
@@ -103,4 +102,4 @@ entities:
         name: second
         range:
           min: 0
-          max: 86400
+          max: 86399

--- a/custom_components/tuya_local/devices/imagine3+1_switch.yaml
+++ b/custom_components/tuya_local/devices/imagine3+1_switch.yaml
@@ -1,0 +1,106 @@
+name: Switchboard with fan
+products:
+  - id: haqyilpinwntqgzj
+    manufacturer: Imagine
+    model: IT31LFW
+    name: IMAGINE 3+1 WiFi Switch
+
+# Built from real diagnostics dump:
+#   1,2,3   = switch relays (boolean)
+#   9,10,11 = per-switch auto-off timers, seconds (paired with 1,2,3)
+#   101     = fan power (boolean)
+#   102     = fan speed, string enum: off/level_1/level_2/level_3/level_4
+#   103     = fan auto-off timer, seconds
+
+entities:
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: {x: "1"}
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: {x: "2"}
+    dps:
+      - id: 2
+        type: boolean
+        name: switch
+
+  - entity: switch
+    translation_key: switch_x
+    translation_placeholders: {x: "3"}
+    dps:
+      - id: 3
+        type: boolean
+        name: switch
+
+  - entity: fan
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+      - id: 102
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "off"
+            value: 0
+          - dps_val: level_1
+            value: 25
+          - dps_val: level_2
+            value: 50
+          - dps_val: level_3
+            value: 75
+          - dps_val: level_4
+            value: 100
+
+  # --- Optional: auto-off timers, one per switch/fan ---
+  - entity: time
+    category: config
+    translation_key: timer_x
+    translation_placeholders: {x: "1"}
+    dps:
+      - id: 9
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+
+  - entity: time
+    category: config
+    translation_key: timer_x
+    translation_placeholders: {x: "2"}
+    dps:
+      - id: 10
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+
+  - entity: time
+    category: config
+    translation_key: timer_x
+    translation_placeholders: {x: "3"}
+    dps:
+      - id: 11
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400
+
+  - entity: time
+    category: config
+    name: Fan timer
+    dps:
+      - id: 103
+        type: integer
+        name: second
+        range:
+          min: 0
+          max: 86400

--- a/custom_components/tuya_local/devices/imagine_it31lfw_switchfan.yaml
+++ b/custom_components/tuya_local/devices/imagine_it31lfw_switchfan.yaml
@@ -14,7 +14,8 @@ products:
 entities:
   - entity: switch
     translation_key: switch_x
-    translation_placeholders: {x: "1"}
+    translation_placeholders:
+      x: "1"
     dps:
       - id: 1
         type: boolean
@@ -22,7 +23,8 @@ entities:
 
   - entity: switch
     translation_key: switch_x
-    translation_placeholders: {x: "2"}
+    translation_placeholders:
+      x: "2"
     dps:
       - id: 2
         type: boolean
@@ -30,7 +32,8 @@ entities:
 
   - entity: switch
     translation_key: switch_x
-    translation_placeholders: {x: "3"}
+    translation_placeholders:
+      x: "3"
     dps:
       - id: 3
         type: boolean
@@ -60,7 +63,8 @@ entities:
   - entity: time
     category: config
     translation_key: timer_x
-    translation_placeholders: {x: "1"}
+    translation_placeholders:
+      x: "1"
     dps:
       - id: 9
         type: integer
@@ -72,7 +76,8 @@ entities:
   - entity: time
     category: config
     translation_key: timer_x
-    translation_placeholders: {x: "2"}
+    translation_placeholders:
+      x: "2"
     dps:
       - id: 10
         type: integer
@@ -84,7 +89,8 @@ entities:
   - entity: time
     category: config
     translation_key: timer_x
-    translation_placeholders: {x: "3"}
+    translation_placeholders:
+      x: "3"
     dps:
       - id: 11
         type: integer


### PR DESCRIPTION
Adds support for the IMAGINE 3+1 WiFi Switch (model IT31LFW, product_id haqyilpinwntqgzj), a 3-gang switchboard with an integrated fan speed regulator.

Dp mapping confirmed directly from the device's live diagnostics dump (not guessed): dps 1, 2 and 3 are the switch relays (boolean); dps 9, 10 and 11 are the matching per-switch auto-off timers in seconds; dp 101 is fan power (boolean); dp 102 is fan speed as a string enum (off/level_1/level_2/level_3/level_4), mapped here to 0/25/50/75/100; dp 103 is the fan's own auto-off timer in seconds.

Single device, single branch, no changes to DEVICES.md or ACKNOWLEDGEMENTS.md.