### PR TITLE
Add NEO Coolcam 16-zone sprinkler controller

### DIFF
--- a/custom_components/tuya_local/devices/neo_coolcam_16zone_sprinkler_controller.yaml
+++ b/custom_components/tuya_local/devices/neo_coolcam_16zone_sprinkler_controller.yaml
@@ -1,4 +1,4 @@
-name: 16-zone sprinkler controller
+name: Sprinkler controller
 products:
   - id: ajg67sq0tpjxgd40
     manufacturer: NEO Coolcam
@@ -166,6 +166,7 @@ entities:
 
   - entity: select
     name: Weather delay
+    translation_key: timer
     icon: "mdi:weather-pouring"
     category: config
     dps:
@@ -238,9 +239,9 @@ entities:
         optional: true
         mapping:
           - dps_val: Order1
-            value: Mode 1
+            value: Independent valves
           - dps_val: Order2
-            value: Mode 2
+            value: Master valve
 
   - entity: text
     name: Irrigation restriction schedule
@@ -298,18 +299,17 @@ entities:
         class: measurement
         optional: true
 
-  - entity: sensor
+  - entity: event
     name: Fault
-    class: enum
     category: diagnostic
     dps:
       - id: 107
         type: string
-        name: sensor
+        name: event
         optional: true
         mapping:
           - dps_val: normal
-            value: Clear
+            value: clear
           - dps_val: alram1
             value: Valve 1
           - dps_val: alram2

--- a/custom_components/tuya_local/devices/neo_coolcam_16zone_sprinkler_controller.yaml
+++ b/custom_components/tuya_local/devices/neo_coolcam_16zone_sprinkler_controller.yaml
@@ -1,4 +1,4 @@
-name: 16 zone sprinkler controller
+name: 16-zone sprinkler controller
 products:
   - id: ajg67sq0tpjxgd40
     manufacturer: NEO Coolcam
@@ -167,7 +167,6 @@ entities:
   - entity: select
     name: Weather delay
     icon: "mdi:weather-pouring"
-    translation_key: timer
     category: config
     dps:
       - id: 37
@@ -299,13 +298,14 @@ entities:
         class: measurement
         optional: true
 
-  - entity: event
+  - entity: sensor
     name: Fault
+    class: enum
     category: diagnostic
     dps:
       - id: 107
         type: string
-        name: event
+        name: sensor
         optional: true
         mapping:
           - dps_val: normal

--- a/custom_components/tuya_local/devices/neo_coolcam_16zone_sprinkler_controller.yaml
+++ b/custom_components/tuya_local/devices/neo_coolcam_16zone_sprinkler_controller.yaml
@@ -1,0 +1,344 @@
+name: 16 zone sprinkler controller
+products:
+  - id: ajg67sq0tpjxgd40
+    manufacturer: NEO Coolcam
+    model: Smart Sprinkler Controller v1.1
+entities:
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "1"
+    dps:
+      - id: 1
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "2"
+    dps:
+      - id: 2
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "3"
+    dps:
+      - id: 3
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "4"
+    dps:
+      - id: 4
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "5"
+    dps:
+      - id: 5
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "6"
+    dps:
+      - id: 6
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "7"
+    dps:
+      - id: 7
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "8"
+    dps:
+      - id: 8
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "9"
+    dps:
+      - id: 9
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "10"
+    dps:
+      - id: 10
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "11"
+    dps:
+      - id: 11
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "12"
+    dps:
+      - id: 12
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "13"
+    dps:
+      - id: 101
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "14"
+    dps:
+      - id: 102
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "15"
+    dps:
+      - id: 103
+        type: boolean
+        name: valve
+
+  - entity: valve
+    class: water
+    translation_key: valve_x
+    translation_placeholders:
+      x: "16"
+    dps:
+      - id: 104
+        type: boolean
+        name: valve
+
+  - entity: select
+    name: Weather delay
+    icon: "mdi:weather-pouring"
+    translation_key: timer
+    category: config
+    dps:
+      - id: 37
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: "24h"
+            value: "1d"
+          - dps_val: "48h"
+            value: "2d"
+          - dps_val: "72h"
+            value: "3d"
+
+  - entity: text
+    translation_key: schedule
+    category: config
+    hidden: true
+    dps:
+      - id: 38
+        type: string
+        name: value
+        optional: true
+
+  - entity: sensor
+    translation_key: status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 39
+        type: string
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: idle
+            value: idle
+          - dps_val: auto
+            value: auto
+          - dps_val: manual
+            value: manual
+
+  - entity: switch
+    name: Weather
+    category: config
+    dps:
+      - id: 42
+        type: boolean
+        name: switch
+        optional: true
+
+  - entity: button
+    name: Skip
+    dps:
+      - id: 43
+        type: boolean
+        name: button
+        optional: true
+
+  - entity: select
+    name: Irrigation mode
+    icon: "mdi:sprinkler-variant"
+    category: config
+    dps:
+      - id: 44
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: Order1
+            value: Mode 1
+          - dps_val: Order2
+            value: Mode 2
+
+  - entity: text
+    name: Irrigation restriction schedule
+    category: config
+    hidden: true
+    dps:
+      - id: 46
+        type: string
+        name: value
+        optional: true
+
+  - entity: sensor
+    name: Countdown valve
+    category: diagnostic
+    dps:
+      - id: 105
+        type: base64
+        mask: "FF000000"
+        name: sensor
+        optional: true
+
+  - entity: sensor
+    name: Countdown remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 105
+        type: base64
+        mask: "00FFFFFF"
+        name: sensor
+        unit: s
+        class: measurement
+        optional: true
+
+  - entity: sensor
+    name: Last used valve
+    category: diagnostic
+    dps:
+      - id: 106
+        type: base64
+        mask: "FF000000"
+        name: sensor
+        optional: true
+
+  - entity: sensor
+    name: Last irrigation duration
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 106
+        type: base64
+        mask: "00FFFFFF"
+        name: sensor
+        unit: s
+        class: measurement
+        optional: true
+
+  - entity: event
+    name: Fault
+    category: diagnostic
+    dps:
+      - id: 107
+        type: string
+        name: event
+        optional: true
+        mapping:
+          - dps_val: normal
+            value: Clear
+          - dps_val: alram1
+            value: Valve 1
+          - dps_val: alram2
+            value: Valve 2
+          - dps_val: alram3
+            value: Valve 3
+          - dps_val: alram4
+            value: Valve 4
+          - dps_val: alram5
+            value: Valve 5
+          - dps_val: alram6
+            value: Valve 6
+          - dps_val: alram7
+            value: Valve 7
+          - dps_val: alram8
+            value: Valve 8
+          - dps_val: alram9
+            value: Valve 9
+          - dps_val: alram10
+            value: Valve 10
+          - dps_val: alram11
+            value: Valve 11
+          - dps_val: alram12
+            value: Valve 12
+          - dps_val: alram13
+            value: Valve 13
+          - dps_val: alram14
+            value: Valve 14
+          - dps_val: alram15
+            value: Valve 15
+          - dps_val: alram16
+            value: Valve 16


### PR DESCRIPTION
Adds support for the NEO Coolcam Smart Sprinkler Controller v1.1.

Related support request: #3241

The value `1743327412391oZJwZg` shown in the issue's "Product ID"
section is actually the `terminal_id` from the submitted diagnostics.

The actual device Product ID in those diagnostics is:

`ajg67sq0tpjxgd40`

This matches the Product ID tested with this configuration. The issue
device also has the same Tuya category (`ggq`), product name, standard
DP set, and 16-zone hardware behaviour.

Vendor product page:
https://www.szneo.com/en/products/show.php?id=272

Brand information:
https://www.szneo.com/en/about/index.php?id=9

The vendor identifies NEO Coolcam as the product brand. The company website
also uses the names NEO Smart Technology (Guangdong) Co., Ltd. and
Shenzhen NEO Electronic Co., Ltd.

Tested environment:

- Home Assistant 2026.7.2
- Tuya Local 2026.7.1
- TinyTuya 1.20.0
- Local Tuya protocol 3.4

Product identification:

- Product ID / productKey: ajg67sq0tpjxgd40
- Tuya category: ggq
- Product name: Smart Sprinkler Controller
- Hardware variant: 16 zones

Verified local DP mapping:

- DP 1-12: valves 1-12
- DP 101-104: valves 13-16
- DP 37: weather delay
- DP 38: irrigation schedule, raw/hidden
- DP 39: work state
- DP 42: weather switch
- DP 43: skip control
- DP 44: irrigation mode
- DP 46: irrigation restriction schedule, raw/hidden
- DP 105: countdown
- DP 106: irrigation use time
- DP 107: valve fault event

DP 105 and DP 106 contain four Base64-encoded bytes:

- byte 1: valve number
- bytes 2-4: duration in seconds, big-endian

Examples verified against actual operation:

- BQAABw== -> valve 5, 7 seconds
- CAAAOw== -> valve 8, 59 seconds remaining
- CAAABQ== -> valve 8, 5 seconds used

Valves 1-12 were tested with physically connected irrigation valves.
DP 101-104 were verified as valves 13-16; unconnected outputs produced
the expected alram13-alram16 fault events.

Known device behaviour:

The controller physically energizes only one valve at a time, but when
multiple valves are commanded directly, some boolean DP states may remain true. This configuration reports the DP states provided by the device.


<img width="1448" height="1086" alt="Neo1" src="https://github.com/user-attachments/assets/84e12ed6-ba82-4fda-8570-b83facba70df" />
<img width="941" height="1672" alt="Neo2" src="https://github.com/user-attachments/assets/904613d3-eb08-4ab7-a438-3bdab005f5b1" />
<img width="941" height="1672" alt="Neo3" src="https://github.com/user-attachments/assets/8bf64acf-112c-4b5a-9c58-d66a217f1915" />
