### PR TITLE
feat(devices): Add Olimpia Splendid Unico Pro air conditioner

### DIFF
--- a/custom_components/tuya_local/devices/olimpia_splendid_unico_pro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/olimpia_splendid_unico_pro_airconditioner.yaml
@@ -1,0 +1,144 @@
+name: Air conditioner
+products:
+  - id: fzawbjqmucsvttvc
+    manufacturer: Olimpia Splendid
+    model: Unico Pro
+entities:
+  - entity: climate
+    translation_key: aircon_extra
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: auto
+                value: heat_cool
+              - dps_val: cool
+                value: cool
+              - dps_val: dehum
+                value: dry
+              - dps_val: fan
+                value: fan_only
+              - dps_val: heat
+                value: heat
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 16
+          max: 32
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 60
+                  max: 90
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_current_f
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: low
+            value: low
+          - dps_val: middle
+            value: medium
+          - dps_val: high
+            value: high
+      - id: 15
+        type: string
+        name: swing_mode
+        mapping:
+          - dps_val: "OFF"
+            value: "off"
+          - dps_val: "ON"
+            value: "on"
+      - id: 19
+        type: string
+        name: temperature_unit
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 24
+        type: integer
+        name: temp_set_f
+        hidden: true
+        optional: true
+        range:
+          min: 60
+          max: 90
+      - id: 115
+        type: integer
+        name: temp_current_f
+        hidden: true
+        optional: true
+  - entity: light
+    translation_key: display
+    category: config
+    dps:
+      - id: 36
+        type: boolean
+        name: switch
+        optional: true
+  - entity: switch
+    name: Eco
+    icon: "mdi:leaf"
+    category: config
+    dps:
+      - id: 8
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: sleep
+    category: config
+    dps:
+      - id: 25
+        type: boolean
+        name: switch
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code

--- a/custom_components/tuya_local/devices/olimpiasplendid_unicopro_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/olimpiasplendid_unicopro_airconditioner.yaml
@@ -76,10 +76,9 @@ entities:
         type: string
         name: temperature_unit
         mapping:
-          - dps_val: c
-            value: C
           - dps_val: f
             value: F
+          - value: C
       - id: 24
         type: integer
         name: temp_set_f
@@ -93,6 +92,14 @@ entities:
         name: temp_current_f
         hidden: true
         optional: true
+      - id: 8
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: eco
+          - dps_val: false
+            value: comfort
   - entity: light
     translation_key: display
     category: config
@@ -101,14 +108,6 @@ entities:
         type: boolean
         name: switch
         optional: true
-  - entity: switch
-    name: Eco
-    icon: "mdi:leaf"
-    category: config
-    dps:
-      - id: 8
-        type: boolean
-        name: switch
   - entity: switch
     translation_key: sleep
     category: config


### PR DESCRIPTION
Adds a device configuration for the Olimpia Splendid Unico Pro air conditioner (product id `fzawbjqmucsvttvc`).

Exposes:
- Climate: HVAC mode (auto/cool/dry/fan/heat), target & current temperature (°C/°F), fan mode, swing, temperature unit
- Config: display light, Eco, Sleep, temperature unit select
- Diagnostic: fault/problem binary sensor

The config validates against the schema in `test_device_config.py`.