### PR TITLE
Add KGM 12000-58 Portable Air Conditioner (OBI)

### DIFF
--- a/custom_components/tuya_local/devices/JWBR2S-5V-CH_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/JWBR2S-5V-CH_portable_air_conditioner.yaml
@@ -1,0 +1,126 @@
+name: Air conditioner
+products:
+  - id: JWBR2S-5V-CH
+    manufacturer: OBI
+    model: JWBR2S-5V-CH
+    name: Portable air conditioner
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "1"
+                value: cool
+              - dps_val: "2"
+                value: heat
+              - dps_val: "3"
+                value: dry
+              - dps_val: "5"
+                value: fan_only
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 16
+          max: 31
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: true
+                value_redirect: temp_set_f
+                range:
+                  min: 62
+                  max: 90
+      - id: 3
+        type: integer
+        name: current_temperature
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: true
+                value_redirect: temp_current_f
+      - id: 101
+        name: mode
+        type: string
+        hidden: true
+      - id: 103
+        name: preset_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: none
+          - dps_val: true
+            value: sleep
+      - id: 104
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: "1"
+            value: high
+          - dps_val: "3"
+            value: low
+      - id: 109
+        type: boolean
+        name: temperature_unit
+        mapping:
+          - dps_val: true
+            value: F
+          - value: C
+      - id: 110
+        type: integer
+        name: temp_set_f
+        range:
+          min: 62
+          max: 90
+        hidden: true
+        optional: true
+      - id: 111
+        type: integer
+        name: temp_current_f
+        hidden: true
+        optional: true
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 24
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: option
+        mapping:
+          - dps_val: false
+            value: celsius
+          - dps_val: true
+            value: fahrenheit

--- a/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
@@ -2,7 +2,7 @@ name: Air conditioner
 products:
   - id: JWBR2S-5V-CH
     manufacturer: OBI
-    model: JWBR2S-5V-CH
+    model: KGM 12000-58
     name: Portable air conditioner
 entities:
   - entity: climate

--- a/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
@@ -46,13 +46,13 @@ entities:
             conditions:
               - dps_val: true
                 value_redirect: temp_current_f
-      # Present as datapoint (maybe humidity), but reported as a fixed value on this model.
+      # Present as dp (hum), but not on this model.
       - id: 17
         type: integer
         name: unknown_17
         hidden: true
         optional: true
-        # Present as datapoint (maybe humidity), but reported as a fixed value on this model.
+        # Present as dp (hum), but not on this model.
       - id: 112
         type: integer
         name: unknown_112
@@ -78,7 +78,7 @@ entities:
             value: high
           - dps_val: "3"
             value: low
-      # Present as datapoint, but not functionally supported on this model.
+      # Present as dp, but not supported on this model.
       - id: 106
         type: boolean
         name: unknown_106

--- a/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
@@ -1,6 +1,6 @@
 name: Air conditioner
 products:
-  - id: JWBR2S-5V-CH
+  - id: h1afb3lohjefjmmb
     manufacturer: OBI
     model: KGM 12000-58
     name: Portable air conditioner
@@ -73,19 +73,6 @@ entities:
           - dps_val: true
             value: F
           - value: C
-      - id: 110
-        type: integer
-        name: temp_set_f
-        range:
-          min: 62
-          max: 90
-        hidden: true
-        optional: true
-      - id: 111
-        type: integer
-        name: temp_current_f
-        hidden: true
-        optional: true
   - entity: binary_sensor
     class: problem
     category: diagnostic

--- a/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
+++ b/custom_components/tuya_local/devices/KGM_12000-58_OBI_portable_air_conditioner.yaml
@@ -46,6 +46,18 @@ entities:
             conditions:
               - dps_val: true
                 value_redirect: temp_current_f
+      # Present as datapoint (maybe humidity), but reported as a fixed value on this model.
+      - id: 17
+        type: integer
+        name: unknown_17
+        hidden: true
+        optional: true
+        # Present as datapoint (maybe humidity), but reported as a fixed value on this model.
+      - id: 112
+        type: integer
+        name: unknown_112
+        hidden: true
+        optional: true
       - id: 101
         name: mode
         type: string
@@ -66,6 +78,12 @@ entities:
             value: high
           - dps_val: "3"
             value: low
+      # Present as datapoint, but not functionally supported on this model.
+      - id: 106
+        type: boolean
+        name: unknown_106
+        hidden: true
+        optional: true
       - id: 109
         type: boolean
         name: temperature_unit
@@ -73,6 +91,19 @@ entities:
           - dps_val: true
             value: F
           - value: C
+      - id: 110
+        type: integer
+        name: temp_set_f
+        range:
+          min: 62
+          max: 90
+        hidden: true
+        optional: true
+      - id: 111
+        type: integer
+        name: temp_current_f
+        hidden: true
+        optional: true
   - entity: binary_sensor
     class: problem
     category: diagnostic


### PR DESCRIPTION
Added KGM 12000-58 Portable Air Conditioner which is sold by OBI in DACH region: 
https://www.obi.at/p/3795747/mobiles-klimageraet-kgm-12000-58-inkl-fernbedienung-mit-wifi-und-heizfunktion
Internal Name from iot.tuya.com: JWBR2S-5V-CH
