### PR TITLE
Add TOMPD-63SW label and measurement state class to TOMPD-63LW breaker

### DIFF
--- a/custom_components/tuya_local/devices/tompd_63lw_breaker.yaml
+++ b/custom_components/tuya_local/devices/tompd_63lw_breaker.yaml
@@ -5,7 +5,7 @@ products:
   - id: psjg8ldomxnelfp5
     model: TOMZN-63A
   - id: u0cxoxtfelys3ufx
-    model: TOMPD-63LW
+    model: TOMPD-63LW/63SW
 entities:
   - entity: switch
     icon: "mdi:fuse"
@@ -121,6 +121,7 @@ entities:
         optional: true
         name: sensor
         unit: V
+        class: measurement
         mapping:
           - dps_val: null
             value_redirect: phase_a
@@ -141,6 +142,7 @@ entities:
         optional: true
         name: sensor
         unit: A
+        class: measurement
         mapping:
           - dps_val: null
             value_redirect: phase_a
@@ -161,6 +163,7 @@ entities:
         optional: true
         name: sensor
         unit: kW
+        class: measurement
         mapping:
           - dps_val: null
             value_redirect: phase_a


### PR DESCRIPTION
## What

Two small changes to `custom_components/tuya_local/devices/tompd_63lw_breaker.yaml`, verified against a live device:

1. **Combined model label**: `u0cxoxtfelys3ufx` → `TOMPD-63LW/63SW`. A physical TOMZN **TOMPD-63SW** (2P 63A WiFi DIN-rail breaker with energy meter, LCD, leakage measurement, prepayment) broadcasts exactly this productKey in its UDP discovery packet (protocol 3.4). This id was originally added as "TOMPD-63LW v2" (#2619, commit 41b83f7e) and has also been reported for a Dewin breaker (#4731), so it clearly ships under several retail labels — the combined label keeps the existing one and adds the new one, following the `MODEL1/MODEL2` pattern already used by ~50 configs.
2. **State class**: added `class: measurement` to the voltage (dp 116), current (dp 117) and power (dp 118) sensors. The leakage (dp 15), power factor (dp 104) and frequency (dp 105) sensors in the same file already have it; without it Home Assistant records no long-term statistics for V/A/W.

No other entity, dp, scale, unit or name was touched. In particular dp 118 keeps its existing `scale: 1000` / `kW` mapping, so recorded statistics units for existing users are unchanged. DEVICES.md deliberately not touched per the PR template; the supported-models line could gain "63SW" whenever you next regenerate it.

## Evidence (live TOMPD-63SW, protocol 3.4, 2026-07-12)

productKey from the device's UDP discovery broadcast: `u0cxoxtfelys3ufx`

Live DPS status:

```
{"1":388848,"9":0,"11":false,"13":0,"15":0,"16":true,"19":"1234","104":928,"105":504,"116":2323,"117":1320,"118":284}
```

`tinytuya detect_available_dps` returned exactly these 12 dps: 1, 9, 11, 13, 15, 16, 19, 104, 105, 116, 117, 118. The remaining dps in the config (6, 12, 14, 17, 18, 21, 34, 101, 106) are not reported by this variant and are already marked `optional: true`, so matching is unaffected.

Physical cross-check that the existing mapping is self-consistent on this hardware: 232.3 V (dp116, scale 10) × 1.320 A (dp117, scale 1000) × PF 0.928 (dp104 = 928, i.e. 92.8 %) = 284.6 W, matching dp118 = 284 (displayed as 0.284 kW by the existing scale-1000 mapping).

## Validation

- `uv run yamllint custom_components/tuya_local/devices` — clean
- `uv run pytest tests/test_device_config.py` — 32 passed (run with `-p no:homeassistant` on Windows, where the HA pytest plugin cannot import `fcntl`; the file uses no hass fixtures)
- No Python or translation files touched
