### PR TITLE
Add support for Tuya SC420W-EU Dual Curtain module

### DIFF
--- a/custom_components/tuya_local/devices/sc420w_dual_curtain.yaml
+++ b/custom_components/tuya_local/devices/sc420w_dual_curtain.yaml
@@ -1,0 +1,108 @@
+name: SC420W Dual Curtain Custom
+products:
+  - id: i382gszua2beohty
+    model: SC420W-EU
+entities:
+  - entity: cover
+    class: curtain
+    name: Curtain 1
+    dps:
+      - id: 1
+        name: control
+        type: string
+        mapping:
+          - dps_val: open
+            value: open
+          - dps_val: close
+            value: close
+          - dps_val: stop
+            value: stop
+      - id: 2
+        name: position
+        type: integer
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: cover
+    class: curtain
+    name: Curtain 2
+    dps:
+      - id: 4
+        name: control
+        type: string
+        mapping:
+          - dps_val: open
+            value: open
+          - dps_val: close
+            value: close
+          - dps_val: stop
+            value: stop
+      - id: 5
+        name: position
+        type: integer
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+  - entity: select
+    name: Direction 1
+    category: config
+    icon: "mdi:sign-direction"
+    dps:
+      - id: 8
+        name: option
+        type: string
+        mapping:
+          - dps_val: forward
+            value: Forward
+          - dps_val: back
+            value: Back
+  - entity: select
+    name: Direction 2
+    category: config
+    icon: "mdi:sign-direction"
+    dps:
+      - id: 9
+        name: option
+        type: string
+        mapping:
+          - dps_val: forward
+            value: Forward
+          - dps_val: back
+            value: Back
+  - entity: number
+    name: Travel time 1
+    category: config
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 10
+        name: value
+        type: integer
+        unit: s
+        range:
+          min: 1
+          max: 120
+  - entity: number
+    name: Travel time 2
+    category: config
+    class: duration
+    icon: "mdi:timer"
+    dps:
+      - id: 11
+        name: value
+        type: integer
+        unit: s
+        range:
+          min: 1
+          max: 120
+  - entity: sensor
+    name: Relay Status
+    category: diagnostic
+    icon: "mdi:electric-switch"
+    dps:
+      - id: 14
+        name: sensor
+        type: string
+        


### PR DESCRIPTION
Adding device configuration for Lora Tap SC420W-EU Dual Curtain module.

Mapped entities:
- 2x Cover (control: open/close/stop, position: 0-100%)
- 2x Config (direction: forward/back)
- 2x Config (travel time: 1-120s)
- 1x Diagnostic (relay status)

Diagnostic JSON dump from Home Assistant attached below.