### PR TITLE
fix(bht002_gblw): map Warming hvac action to idle

### DIFF
--- a/custom_components/tuya_local/devices/bht002_gblw_thermostat.yaml
+++ b/custom_components/tuya_local/devices/bht002_gblw_thermostat.yaml
@@ -27,7 +27,7 @@ entities:
         optional: true
         mapping:
           - dps_val: Warming
-            value: heating
+            value: idle
           - dps_val: Heat
             value: heating
           - dps_val: "Off"


### PR DESCRIPTION
Correct the hvac_action mapping for the BHT-002 GBLW thermostat.

The thermostat reports DP 3 as:

Warming when heating is idle
Heat when heating is actively running

Currently, both values are mapped to heating, causing Home Assistant to show active heating while the thermostat output is off.

Observed states:

Warming: target 16.0 °C, current 21.5 °C, heating output off
Heat: target 26.0 °C, current 21.5 °C, heating output on

This changes the Warming mapping from heating to idle. The Heat mapping remains heating.

Tested with Tuya Local 2026.7.1 and Home Assistant 2026.7.1.