### PR TITLE
feat(devices): add Goldair GPCV405 convection heater

### DIFF
--- a/custom_components/tuya_local/devices/goldair_gpcv405_heater.yaml
+++ b/custom_components/tuya_local/devices/goldair_gpcv405_heater.yaml
@@ -1,0 +1,74 @@
+name: Convection heater
+# products: Goldair GPCV405 (model CV1150), 2400W
+# A newer generation than goldair_gpcv_heater: the datapoints differ, so that
+# config does not match this unit (its dp7 is a string preset, here it is a
+# boolean child lock).
+# dp4 is the "Speed" control on the panel: H1 = Lo, H2 = Mid, H3 = Hi.
+# Mapped to fan_mode, as in taurus_agadir_heater which uses the same dialect.
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+      - id: 2
+        name: temperature
+        type: integer
+        unit: C
+        range:
+          min: 5
+          max: 35
+      - id: 3
+        name: current_temperature
+        type: integer
+      - id: 4
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: H1
+            value: low
+          - dps_val: H2
+            value: medium
+          - dps_val: H3
+            value: high
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: "1h"
+            value: "1h"
+          - dps_val: "2h"
+            value: "2h"
+          - dps_val: "3h"
+            value: "3h"
+          - dps_val: "4h"
+            value: "4h"
+          - dps_val: "5h"
+            value: "5h"
+          - dps_val: "6h"
+            value: "6h"
+  - entity: light
+    translation_key: backlight
+    dps:
+      - id: 10
+        type: boolean
+        name: switch


### PR DESCRIPTION
Adds a config for the Goldair GPCV405 (model CV1150) 2400W convection panel heater, sold in Australia/NZ.

The existing `goldair_gpcv_heater` config does not match this unit — it is a newer generation with different datapoints (here dp7 is a boolean child lock rather than a string preset, and dp101-106 are absent). Without this config the device falls back to `vonroc_wifi_heater`, which writes `"0"`/`"1"`/`"2"` to dp4 — values this heater ignores, so the heat level cannot be changed from Home Assistant.

On this unit dp4 is the panel's "Speed" control, with values `H1`/`H2`/`H3` (Lo/Mid/Hi). It is mapped to `fan_mode`, the same approach as `taurus_agadir_heater`, which uses the same dialect.

Datapoints confirmed on the device: dp1 power, dp2 setpoint, dp3 current temperature, dp4 speed, dp7 child lock, dp10 backlight, dp19 timer. All entities were tested on the physical heater, including setting Lo/Mid/Hi from Home Assistant and confirming the raw dp4 values echo back from the device.

No product id is included as it was not available from the device; it is declared as a comment, in the same style as the existing Goldair configs.
