### PR TITLE
Kaisai energy attribs

### DIFF
--- a/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kaisai_proheat_airconditioner.yaml
@@ -153,16 +153,26 @@ entities:
           - scale: 100
 
   - entity: sensor
-    class: energy
+    name: Add electricity
+    category: diagnostic
+    hidden: true
     dps:
       - id: 127
-        name: sensor
         type: integer
-        unit: kWh
-        class: total_increasing
         optional: true
+        persist: false
+        name: sensor
+        unit: kWh
         mapping:
           - scale: 100
+      - id: 128
+        type: integer
+        optional: true
+        name: starttime
+      - id: 129
+        type: integer
+        optional: true
+        name: endtime
 
   - entity: sensor
     name: External fan speed


### PR DESCRIPTION
Follow-up to #5552, based on the discussion there.

I’ve moved the timestamps to attributes of the energy sensor, as suggested. This YAML-only change also renames the sensor to `Add electricity` for consistency with other devices, sets it as diagnostic and hidden by default, and removes the `total_increasing` state class because the raw value is difficult to use directly.

The related `delta_energy` integration is available here: https://github.com/camel1cz/delta_energy


