### PR TITLE
Create CoreBox smart cat litter box support

### DIFF
--- a/custom_components/tuya_local/devices/corebox_litter_box.yaml
+++ b/custom_components/tuya_local/devices/corebox_litter_box.yaml
@@ -1,0 +1,189 @@
+name: CoreBox smart cat litter box
+products:
+  - id: xniit4zwcaqmzrl7
+    name: CoreBox Smart Cat Litter Box
+
+entities:
+  - entity: sensor
+    name: Status
+    class: enum
+    dps:
+      - id: 24
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: standby
+            value: Standby
+          - dps_val: waiting
+            value: Waiting (Delay)
+          - dps_val: cleaning
+            value: Cleaning
+          - dps_val: cat_get_in
+            value: Cat Inside
+          - dps_val: pause
+            value: Paused
+          - dps_val: garbage_box_full
+            value: Waste Drawer Full
+          - dps_val: Error
+            value: Fault Error
+          - dps_val: empty_done
+            value: Emptying Done
+          - dps_val: emptying
+            value: Emptying Litter
+          - dps_val: pause_2
+            value: Emptying Paused
+          - dps_val: clean_done
+            value: Cleaning Done
+
+  - entity: switch
+    name: Auto clean
+    icon: mdi:robot
+    dps:
+      - id: 4
+        type: boolean
+        name: switch
+
+  - entity: number
+    name: Delay clean time
+    icon: mdi:clock-start
+    category: config
+    dps:
+      - id: 5
+        type: integer
+        name: value
+        range:
+          min: 1
+          max: 60
+        unit: min
+
+  - entity: sensor
+    name: Today usage
+    icon: mdi:cat
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: times
+
+  - entity: switch
+    name: Sleep mode
+    icon: mdi:sleep
+    category: config
+    dps:
+      - id: 10
+        type: boolean
+        name: switch
+
+  - entity: number
+    name: Sleep start time
+    category: config
+    dps:
+      - id: 11
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 1435
+
+  - entity: number
+    name: Sleep end time
+    category: config
+    dps:
+      - id: 12
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 1435
+
+  - entity: sensor
+    name: Fault alert
+    category: diagnostic
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+
+  - entity: sensor
+    name: Motor current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: mA
+
+  - entity: switch
+    name: Child lock
+    icon: mdi:lock
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+
+  - entity: select
+    name: Empty litter command
+    icon: mdi:delete-variant
+    dps:
+      - id: 104
+        type: string
+        name: select
+        options:
+          - dps_val: standby1
+            value: Standby
+          - dps_val: empty
+            value: Empty Litter
+          - dps_val: pause1
+            value: Pause
+
+  - entity: switch
+    name: Buzzer
+    icon: mdi:volume-high
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+
+  - entity: select
+    name: Manual clean command
+    icon: mdi:broom
+    dps:
+      - id: 106
+        type: string
+        name: select
+        options:
+          - dps_val: standby
+            value: Standby
+          - dps_val: cleaning
+            value: Clean Now
+          - dps_val: pause
+            value: Pause
+
+  - entity: sensor
+    name: History record
+    category: diagnostic
+    dps:
+      - id: 107
+        type: string
+        name: sensor
+
+  - entity: switch
+    name: Indicator light
+    icon: mdi:led-on
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+
+  - entity: switch
+    name: Deodorizer reminder
+    icon: mdi:air-filter
+    category: config
+    dps:
+      - id: 111
+        type: boolean
+        name: switch


### PR DESCRIPTION
I Recently got a smart kitty litter and wanted to add support, its set up in Tuya, I created this a few days back and its running good sofar. It detects it as a type when adding it, only issue I see it Visits today is not updating it seems to be from a hardware side of things i can see in the logs that its coming from the cloud itself as the out dated value.

Here is my DPS If needed for testing/confirming on your end


## Device Information
* **Brand/Model:** CoreBox Smart Cat Litter Box
* **Product ID:** xniit4zwcaqmzrl7

## Diagnostic Data
```json
// Paste the "cached_state" block from your downloaded JSON file here:
"cached_state": {
  "4": false,
  "5": 5,
  "7": 1,
  "10": false,
  "11": 1320,
  "12": 480,
  "22": 0,
  "24": "standby",
  "101": 290,
  "103": true,
  "104": "standby1",
  "105": false,
  "106": "standby",
  "107": "finish_clean",
  "109": false,
  "111": true
}