### PR TITLE
Add Aqua Plus APAIO270 heat pump water heater

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -218,6 +218,7 @@
 
 - Apricus heat pump water heater
 - A.O. Smith HeatBot 15L electric water heater
+- Aqua Plus APAIO270 heat pump water heater
 - Aquatech Rapid/X6 heat pump water heater
 - Aquaviva AVH15S combo air-water heat pump
 - Arçelik AHPH-MM series combo air-water heat pump

--- a/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
+++ b/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
@@ -1,0 +1,317 @@
+name: Heat pump water heater
+products:
+  - id: zcuzgqkr3aef1hap
+    manufacturer: Aqua Plus
+    model: APAIO270
+entities:
+  - entity: water_heater
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: Stand
+                value: heat_pump
+              - dps_val: Boost
+                value: performance
+              - dps_val: ELE
+                value: electric
+      - id: 2
+        type: string
+        name: mode
+        hidden: true
+      - id: 4
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 15
+          max: 75
+      - id: 21
+        type: integer
+        name: current_temperature
+        unit: C
+  # Target/tank temperature are intentionally not duplicated as standalone
+  # sensors here (see PR #5548 discussion) - only the current/measured value
+  # convention has precedent elsewhere in this repo, and even that was
+  # rejected upstream. If long-term statistics for these values are wanted,
+  # add `template:` sensors in your own HA config instead.
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 7
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Expansion valve position
+    icon: "mdi:pipe-valve"
+    category: diagnostic
+    dps:
+      - id: 14
+        type: integer
+        name: sensor
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 15
+        type: bitfield
+        name: fault_code
+  - entity: sensor
+    name: Phase sequence module
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 17
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "NO"
+            value: Nothing
+          # "normal" and "ERR" are unconfirmed guesses - never observed live
+          - dps_val: normal
+            value: Normal
+          - dps_val: ERR
+            value: Error
+  - entity: sensor
+    name: Energy today
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 18
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Fan speed
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 19
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "OFF"
+            value: "Off"
+          - dps_val: LOW
+            value: Low
+          - dps_val: High
+            value: High
+  - entity: sensor
+    name: Suction (return gas) temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Return water temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Coil temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    name: Discharge temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: sensor
+    translation_key: ambient_temperature
+    class: temperature
+    dps:
+      - id: 26
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+  - entity: binary_sensor
+    name: Compressor
+    class: running
+    category: diagnostic
+    dps:
+      - id: 27
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Four-way valve
+    class: opening
+    category: diagnostic
+    dps:
+      - id: 28
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Circulation mode
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 30
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Fluorine
+          - dps_val: false
+            value: Water
+  - entity: sensor
+    name: Low pressure switch
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 29
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Close
+          - dps_val: false
+            value: Open
+  - entity: binary_sensor
+    name: Water pump
+    class: running
+    category: diagnostic
+    dps:
+      - id: 31
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Electric heating element
+    class: running
+    category: diagnostic
+    dps:
+      - id: 32
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: High pressure switch
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 33
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: false
+            value: Close
+          - dps_val: true
+            value: Open
+  - entity: sensor
+    name: Linked switch
+    class: enum
+    category: diagnostic
+    dps:
+      # true/false to Close/Open confirmed via app; significance of the
+      # linkage feature itself (likely PV/solar interlock) is unconfirmed
+      - id: 106
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Close
+          - dps_val: false
+            value: Open
+  - entity: sensor
+    name: Compressor runtime before defrost
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 41
+        type: integer
+        name: sensor
+        unit: min
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: V
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: W
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: Total energy
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Water flow switch
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 107
+        type: boolean
+        name: sensor
+        mapping:
+          - dps_val: true
+            value: Close
+          - dps_val: false
+            value: Open

--- a/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
+++ b/custom_components/tuya_local/devices/aquaplus_apaio270_waterheater.yaml
@@ -87,20 +87,9 @@ entities:
           - dps_val: ERR
             value: Error
   - entity: sensor
-    name: Energy today
-    class: energy
-    category: diagnostic
-    dps:
-      - id: 18
-        type: integer
-        name: sensor
-        unit: kWh
-        class: total_increasing
-        mapping:
-          - scale: 100
-  - entity: sensor
     name: Fan speed
     class: enum
+    translation_key: status
     category: diagnostic
     dps:
       - id: 19
@@ -108,13 +97,13 @@ entities:
         name: sensor
         mapping:
           - dps_val: "OFF"
-            value: "Off"
+            value: "off"
           - dps_val: LOW
-            value: Low
+            value: low
           - dps_val: High
-            value: High
+            value: high
   - entity: sensor
-    name: Suction (return gas) temperature
+    name: Suction temperature
     class: temperature
     category: diagnostic
     dps:
@@ -191,9 +180,9 @@ entities:
             value: Fluorine
           - dps_val: false
             value: Water
-  - entity: sensor
+  - entity: binary_sensor
     name: Low pressure switch
-    class: enum
+    class: opening
     category: diagnostic
     dps:
       - id: 29
@@ -201,9 +190,9 @@ entities:
         name: sensor
         mapping:
           - dps_val: true
-            value: Close
+            value: false
           - dps_val: false
-            value: Open
+            value: true
   - entity: binary_sensor
     name: Water pump
     class: running
@@ -220,22 +209,17 @@ entities:
       - id: 32
         type: boolean
         name: sensor
-  - entity: sensor
+  - entity: binary_sensor
     name: High pressure switch
-    class: enum
+    class: opening
     category: diagnostic
     dps:
       - id: 33
         type: boolean
         name: sensor
-        mapping:
-          - dps_val: false
-            value: Close
-          - dps_val: true
-            value: Open
-  - entity: sensor
+  - entity: binary_sensor
     name: Linked switch
-    class: enum
+    class: opening
     category: diagnostic
     dps:
       # true/false to Close/Open confirmed via app; significance of the
@@ -245,9 +229,9 @@ entities:
         name: sensor
         mapping:
           - dps_val: true
-            value: Close
+            value: false
           - dps_val: false
-            value: Open
+            value: true
   - entity: sensor
     name: Compressor runtime before defrost
     class: duration
@@ -302,9 +286,14 @@ entities:
         class: total_increasing
         mapping:
           - scale: 100
-  - entity: sensor
+      - id: 18
+        type: integer
+        name: daily
+        mapping:
+          - scale: 100
+  - entity: binary_sensor
     name: Water flow switch
-    class: enum
+    class: opening
     category: diagnostic
     dps:
       - id: 107
@@ -312,6 +301,6 @@ entities:
         name: sensor
         mapping:
           - dps_val: true
-            value: Close
+            value: false
           - dps_val: false
-            value: Open
+            value: true


### PR DESCRIPTION
## Summary

Re-submission of #5548, which was closed over the two standalone "Target temperature" / "Tank temperature" sensors duplicating DP4/DP21 already exposed as `water_heater` attributes.

Per the discussion on #5548 ([comment](https://github.com/make-all/tuya-local/pull/5548#issuecomment-4950005687)), the precedent I'd found for duplicating a current-value DP as a standalone sensor no longer holds in the current device set (most of those configs have since been deprecated, and the rest weren't true duplicates). This PR drops both duplicate sensors entirely - DP4 and DP21 are only exposed via the `water_heater` entity now.

- Adds `Aqua Plus APAIO270` heat pump water heater as a `water_heater` entity (Standard/Booster/E-Heater modes) plus diagnostic sensors for temperatures, pressure switches, fan speed, and electrical readings.
- DP map recovered via the Tuya Cloud API thing-model endpoint and cross-verified live against the manufacturer's app across all three modes.
- No duplicate sensors this time - see note in the yaml for anyone wanting long-term statistics on target/tank temperature, they'll need a `template:` sensor in their own HA config.

## Test plan

- [x] `yamllint` on the device config
- [x] `ruff check` / `ruff check --select I` / `ruff format --check` (project-wide)
- [x] `pytest tests/test_device_config.py` (32/32 passing)
- [x] Verified live against the physical unit across all operation modes