### PR TITLE
Add CONOW CBE2000 Pro Solar Battery device definition file

### DIFF
--- a/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
@@ -149,7 +149,7 @@ entities:
     class: power
     dps:
       - id: 20
-        type: float
+        type: integer
         name: sensor
         unit: W
   - entity: sensor
@@ -157,7 +157,7 @@ entities:
     class: power
     dps:
       - id: 21
-        type: float
+        type: integer
         name: sensor
         unit: W
   - entity: sensor
@@ -165,7 +165,7 @@ entities:
     class: power
     dps:
       - id: 22
-        type: float
+        type: integer
         name: sensor
         unit: W
   - entity: sensor
@@ -173,7 +173,7 @@ entities:
     class: power
     dps:
       - id: 36
-        type: float
+        type: integer
         name: sensor
         unit: W
   - entity: sensor
@@ -181,7 +181,7 @@ entities:
     class: power
     dps:
       - id: 37
-        type: float
+        type: integer
         name: sensor
         unit: W
   - entity: sensor

--- a/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
@@ -20,6 +20,7 @@ entities:
     class: problem
     dps:
       - id: 11
+        optional: true
         type: bitfield
         name: sensor
         mapping:
@@ -30,9 +31,11 @@ entities:
         type: string
         name: error_code
       - id: 11
+        optional: true
         type: bitfield
         name: fault_code
       - id: 11
+        optional: true
         type: bitfield
         name: description
         mapping:
@@ -145,6 +148,7 @@ entities:
     class: occupancy
     dps:
       - id: 18
+        optional: true
         type: boolean
         name: sensor
   - entity: sensor
@@ -242,6 +246,7 @@ entities:
     class: power
     dps:
       - id: 28
+        optional: true
         type: integer
         name: sensor
         unit: W
@@ -250,6 +255,7 @@ entities:
     class: power
     dps:
       - id: 29
+        optional: true
         type: integer
         name: sensor
         unit: W
@@ -397,6 +403,7 @@ entities:
     class: energy
     dps:
       - id: 47
+        optional: true
         type: integer
         name: sensor
         unit: kWh
@@ -530,6 +537,7 @@ entities:
     category: config
     dps:
       - id: 65
+        optional: true
         type: string
         name: option
         mapping:
@@ -555,6 +563,7 @@ entities:
     category: config
     dps:
       - id: 69
+        optional: true
         type: integer
         name: value
         unit: W
@@ -566,6 +575,7 @@ entities:
     category: config
     dps:
       - id: 70
+        optional: true
         type: boolean
         name: switch
   - entity: select
@@ -573,6 +583,7 @@ entities:
     category: config
     dps:
       - id: 73
+        optional: true
         type: string
         name: option
         mapping:
@@ -587,6 +598,7 @@ entities:
     category: config
     dps:
       - id: 78
+        optional: true
         type: string
         name: option
         mapping:
@@ -599,6 +611,7 @@ entities:
     category: diagnostic
     dps:
       - id: 84
+        optional: true
         type: integer
         name: sensor
         unit: W
@@ -611,6 +624,7 @@ entities:
     hidden: true
     dps:
       - id: 85
+        optional: true
         type: boolean
         name: switch
   - entity: number
@@ -619,6 +633,7 @@ entities:
     category: config
     dps:
       - id: 91
+        optional: true
         type: integer
         name: value
         unit: W

--- a/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
@@ -7,6 +7,7 @@ entities:
   - entity: sensor
     category: diagnostic
     name: Battery capacity
+    class: energy_storage
     dps:
       - id: 2
         type: integer
@@ -15,7 +16,6 @@ entities:
         mapping:
           - scale: 1000
   - entity: binary_sensor
-    name: Fault
     category: diagnostic
     class: problem
     dps:

--- a/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
@@ -5,15 +5,8 @@ products:
     model: CBE2000 Pro
 entities:
   - entity: sensor
-    name: Serial Number
     category: diagnostic
-    dps:
-      - id: 1
-        type: string
-        name: sensor
-  - entity: sensor
-    category: diagnostic
-    name: Battery Capacity
+    name: Battery capacity
     dps:
       - id: 2
         type: integer
@@ -21,21 +14,27 @@ entities:
         unit: kWh
         mapping:
           - scale: 1000
-  - entity: sensor
-    name: Error Code
-    category: diagnostic
-    dps:
-      - id: 10
-        type: string
-        name: sensor
-  - entity: sensor
+  - entity: binary_sensor
     name: Fault
     category: diagnostic
-    class: enum
+    class: problem
     dps:
       - id: 11
         type: bitfield
         name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 10
+        type: string
+        name: error_code
+      - id: 11
+        type: bitfield
+        name: fault_code
+      - id: 11
+        type: bitfield
+        name: description
         mapping:
           - dps_val: 0
             value: No Fault
@@ -83,8 +82,11 @@ entities:
             value: meter_comm_failure
           - dps_val: 2097152
             value: system_temp_diff_protection
+      - id: 1
+        type: string
+        name: serial_number
   - entity: sensor
-    name: Connection State
+    name: Connection state
     category: diagnostic
     class: enum
     hidden: true
@@ -100,7 +102,7 @@ entities:
           - dps_val: paired_uncon
             value: Paired and not connected
   - entity: sensor
-    name: Signal Strength
+    class: signal_strength
     category: diagnostic
     hidden: true
     dps:
@@ -109,7 +111,7 @@ entities:
         name: sensor
         unit: dBm
   - entity: sensor
-    name: Hardware Version
+    name: Hardware version
     category: diagnostic
     hidden: true
     dps:
@@ -117,35 +119,36 @@ entities:
         type: string
         name: sensor
   - entity: sensor
-    name: System Version
+    name: System version
     category: diagnostic
     hidden: true
     dps:
       - id: 15
         type: string
         name: sensor
-  - entity: sensor
-    name: Cell Heating
+  - entity: binary_sensor
+    name: Cell heating
     category: diagnostic
     dps:
       - id: 16
         type: boolean
         name: sensor
   - entity: sensor
-    name: Expansion Pack Count
+    name: Expansion pack count
     category: diagnostic
     dps:
       - id: 17
         type: integer
         name: sensor
-  - entity: sensor
-    name: Human Presence
+  - entity: binary_sensor
+    name: Human presence
+    class: occupancy
     dps:
       - id: 18
         type: boolean
         name: sensor
   - entity: sensor
-    name: PV Power Total
+    name: PV power total
     class: power
     dps:
       - id: 20
@@ -153,7 +156,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: PV Power Port 1
+    name: PV power port 1
     class: power
     dps:
       - id: 21
@@ -161,7 +164,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: PV Power Port 2
+    name: PV power port 2
     class: power
     dps:
       - id: 22
@@ -169,7 +172,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: PV Power Port 3
+    name: PV power port 3
     class: power
     dps:
       - id: 36
@@ -177,7 +180,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: PV Power Port 4
+    name: PV power port 4
     class: power
     dps:
       - id: 37
@@ -193,7 +196,8 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Load State
+    name: Load state
+    translation_key: status
     class: enum
     dps:
       - id: 24
@@ -201,13 +205,13 @@ entities:
         name: sensor
         mapping:
           - dps_val: charging
-            value: Charging
+            value: charging
           - dps_val: discharging
-            value: Discharging
+            value: discharging
           - dps_val: idle
-            value: Idle
+            value: idle
   - entity: sensor
-    name: Battery Power
+    name: Battery power
     class: power
     dps:
       - id: 25
@@ -215,7 +219,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: Grid Power
+    name: Grid power
     class: power
     dps:
       - id: 26
@@ -223,7 +227,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: Inverter Output Power
+    name: Inverter output power
     class: power
     dps:
       - id: 27
@@ -234,7 +238,7 @@ entities:
           min: -20000
           max: 20000
   - entity: sensor
-    name: Battery Charging Power PV
+    name: Battery charging power pv
     class: power
     dps:
       - id: 28
@@ -242,7 +246,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: Battery Charging Power Grid
+    name: Battery charging power grid
     class: power
     dps:
       - id: 29
@@ -250,7 +254,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: SoC Battery Array
+    name: SoC battery array
     class: battery
     hidden: true
     dps:
@@ -259,7 +263,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion Pack 1 SoC
+    name: Expansion pack 1 soc
     class: battery
     hidden: true
     dps:
@@ -268,7 +272,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion Pack 2 SoC
+    name: Expansion pack 2 soc
     class: battery
     hidden: true
     dps:
@@ -277,7 +281,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion Pack 3 SoC
+    name: Expansion pack 3 soc
     class: battery
     hidden: true
     dps:
@@ -286,7 +290,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion Pack 4 SoC
+    name: Expansion pack 4 soc
     class: battery
     hidden: true
     dps:
@@ -295,7 +299,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion Pack 5 SoC
+    name: Expansion pack 5 soc
     class: battery
     hidden: true
     dps:
@@ -304,7 +308,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Offgrid Export Power
+    name: Offgrid export power
     class: power
     dps:
       - id: 38
@@ -312,7 +316,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: Cumulative Energy Generated PV
+    name: Cumulative energy generated pv
     class: energy
     dps:
       - id: 40
@@ -323,7 +327,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Output Inverter
+    name: Cumulative energy output inverter
     class: energy
     dps:
       - id: 41
@@ -334,7 +338,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Discharged
+    name: Cumulative energy discharged
     class: energy
     dps:
       - id: 42
@@ -345,7 +349,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Charged
+    name: Cumulative energy charged
     class: energy
     dps:
       - id: 43
@@ -356,7 +360,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Charged PV
+    name: Cumulative energy charged pv
     class: energy
     dps:
       - id: 44
@@ -367,7 +371,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Charged Grid
+    name: Cumulative energy charged grid
     class: energy
     dps:
       - id: 45
@@ -378,7 +382,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Exported Offgrid
+    name: Cumulative energy exported offgrid
     class: energy
     dps:
       - id: 46
@@ -389,7 +393,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative Energy Imported Offgrid
+    name: Cumulative energy imported offgrid
     class: energy
     dps:
       - id: 47
@@ -400,7 +404,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: number
-    name: Backup Reserve
+    name: Backup reserve
     mode: slider
     category: config
     dps:
@@ -411,10 +415,8 @@ entities:
         range:
           min: 0
           max: 100
-        mapping:
-          - step: 1
   - entity: select
-    name: Work Mode
+    translation_key: mode
     category: config
     dps:
       - id: 51
@@ -424,15 +426,15 @@ entities:
           - dps_val: self_powered
             value: Self Powered
           - dps_val: time_of_use
-            value: Time of Use
+            value: schedule
           - dps_val: manual
-            value: Manual
+            value: manual
           - dps_val: plug
             value: Plug
           - dps_val: diy
             value: Do It Yourself
   - entity: number
-    name: Output Power Limit
+    name: Output power limit
     mode: box
     category: config
     dps:
@@ -443,17 +445,15 @@ entities:
         range:
           min: 0
           max: 100000
-        mapping:
-          - step: 1
   - entity: switch
-    name: Feedin Power Limit Enable
+    name: Feedin power limit enable
     category: config
     dps:
       - id: 54
         type: boolean
         name: switch
   - entity: number
-    name: Feedin Power Limit
+    name: Feedin power limit
     mode: box
     category: config
     dps:
@@ -464,18 +464,8 @@ entities:
         range:
           min: 0
           max: 100000
-        mapping:
-          - step: 1
-  - entity: sensor
-    name: Country Code
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 56
-        type: integer
-        name: sensor
   - entity: select
-    name: Indicator Light Mode
+    translation_key: light_mode
     category: config
     dps:
       - id: 57
@@ -483,13 +473,13 @@ entities:
         name: option
         mapping:
           - dps_val: "eco"
-            value: Eco
+            value: "auto"
           - dps_val: "on"
-            value: "Always On"
+            value: "on"
           - dps_val: "off"
-            value: "Manual"
+            value: "off"
   - entity: sensor
-    name: Smart Meter Type
+    name: Smart meter type
     class: enum
     dps:
       - id: 58
@@ -502,29 +492,29 @@ entities:
             value: Lan
           - dps_val: ty_rs485
             value: RS485
-  - entity: switch
-    name: Recalibrate Battery
+  - entity: button
+    name: Recalibrate battery
     category: config
     dps:
       - id: 59
         type: boolean
-        name: switch
+        name: button
   - entity: switch
-    name: Offgrid Port Enable
+    name: Offgrid port enable
     category: config
     dps:
       - id: 60
         type: boolean
         name: switch
   - entity: switch
-    name: Peak Shaving Enable
+    name: Peak shaving enable
     category: config
     dps:
       - id: 63
         type: boolean
         name: switch
   - entity: number
-    name: Peak Shaving Threshold
+    name: Peak shaving threshold
     mode: box
     category: config
     dps:
@@ -535,10 +525,8 @@ entities:
         range:
           min: 0
           max: 30000
-        mapping:
-          - step: 1
   - entity: select
-    name: Vibe Light Mode
+    name: Vibe light mode
     category: config
     dps:
       - id: 65
@@ -550,7 +538,7 @@ entities:
           - dps_val: "off"
             value: "Off"
   - entity: select
-    name: Offgrid Mode
+    name: Offgrid mode
     category: config
     dps:
       - id: 68
@@ -562,7 +550,7 @@ entities:
           - dps_val: plugin
             value: Plugin
   - entity: number
-    name: Inverter Input Power Limit
+    name: Inverter input power limit
     mode: box
     category: config
     dps:
@@ -573,17 +561,15 @@ entities:
         range:
           min: 0
           max: 2500
-        mapping:
-          - step: 1
   - entity: switch
-    name: Reserve Priority
+    name: Reserve priority
     category: config
     dps:
       - id: 70
         type: boolean
         name: switch
   - entity: select
-    name: LED Items
+    name: LED items
     category: config
     dps:
       - id: 73
@@ -597,7 +583,7 @@ entities:
           - dps_val: led_bypass
             value: Bypass
   - entity: select
-    name: Baseline Strategy
+    name: Baseline strategy
     category: config
     dps:
       - id: 78
@@ -609,15 +595,18 @@ entities:
           - dps_val: pv_only
             value: PV Only
   - entity: sensor
-    name: Regulation Grid Export Power Limit
+    name: Regulation grid export power limit
     category: diagnostic
     dps:
       - id: 84
         type: integer
         name: sensor
         unit: W
+      - id: 56
+        type: integer
+        name: country_code
   - entity: switch
-    name: LP Sleep
+    name: LP sleep
     category: config
     hidden: true
     dps:
@@ -625,7 +614,7 @@ entities:
         type: boolean
         name: switch
   - entity: number
-    name: Base Load
+    name: Base load
     mode: box
     category: config
     dps:
@@ -636,5 +625,3 @@ entities:
         range:
           min: 0
           max: 99999
-        mapping:
-          - step: 1

--- a/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
@@ -1,0 +1,640 @@
+name: Battery storage
+products:
+  - id: c4ilzd7aybycece9
+    manufacturer: Conow
+    model: CBE2000 Pro
+entities:
+  - entity: sensor
+    name: Serial Number
+    category: diagnostic
+    dps:
+      - id: 1
+        type: string
+        name: sensor
+  - entity: sensor
+    category: diagnostic
+    name: Battery Capacity
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: kWh
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Error Code
+    category: diagnostic
+    dps:
+      - id: 10
+        type: string
+        name: sensor
+  - entity: sensor
+    name: Fault
+    category: diagnostic
+    class: enum
+    dps:
+      - id: 11
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: No Fault
+          - dps_val: 1
+            value: pack1_warning
+          - dps_val: 2
+            value: pack2_warning
+          - dps_val: 4
+            value: pack3_warning
+          - dps_val: 8
+            value: pack4_warning
+          - dps_val: 16
+            value: pack5_warning
+          - dps_val: 32
+            value: pack6_warning
+          - dps_val: 64
+            value: infrared_module_failure
+          - dps_val: 128
+            value: led_strip_comm_fault
+          - dps_val: 256
+            value: master_slave_comm_fault
+          - dps_val: 512
+            value: panel_comm_fault
+          - dps_val: 1024
+            value: inverter_comm_fault
+          - dps_val: 2048
+            value: inverter_failure
+          - dps_val: 4096
+            value: wifi_module_comm_fault
+          - dps_val: 8192
+            value: pv1_fault
+          - dps_val: 16384
+            value: pv2_fault
+          - dps_val: 32768
+            value: pv3_fault
+          - dps_val: 65536
+            value: pv4_fault
+          - dps_val: 131072
+            value: grid_failure
+          - dps_val: 262144
+            value: inverter_output_fault
+          - dps_val: 524288
+            value: inverter_other_fault
+          - dps_val: 1048576
+            value: meter_comm_failure
+          - dps_val: 2097152
+            value: system_temp_diff_protection
+  - entity: sensor
+    name: Connection State
+    category: diagnostic
+    class: enum
+    hidden: true
+    dps:
+      - id: 12
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: paired_connected
+            value: Paired and connected
+          - dps_val: unpaired_uncon
+            value: Unpaired and not connected
+          - dps_val: paired_uncon
+            value: Paired and not connected
+  - entity: sensor
+    name: Signal Strength
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: dBm
+  - entity: sensor
+    name: Hardware Version
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 14
+        type: string
+        name: sensor
+  - entity: sensor
+    name: System Version
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 15
+        type: string
+        name: sensor
+  - entity: sensor
+    name: Cell Heating
+    category: diagnostic
+    dps:
+      - id: 16
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: Expansion Pack Count
+    category: diagnostic
+    dps:
+      - id: 17
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Human Presence
+    dps:
+      - id: 18
+        type: boolean
+        name: sensor
+  - entity: sensor
+    name: PV Power Total
+    class: power
+    dps:
+      - id: 20
+        type: float
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: PV Power Port 1
+    class: power
+    dps:
+      - id: 21
+        type: float
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: PV Power Port 2
+    class: power
+    dps:
+      - id: 22
+        type: float
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: PV Power Port 3
+    class: power
+    dps:
+      - id: 36
+        type: float
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: PV Power Port 4
+    class: power
+    dps:
+      - id: 37
+        type: float
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Unit SoC
+    class: battery
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Load State
+    class: enum
+    dps:
+      - id: 24
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: charging
+            value: Charging
+          - dps_val: discharging
+            value: Discharging
+          - dps_val: idle
+            value: Idle
+  - entity: sensor
+    name: Battery Power
+    class: power
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Grid Power
+    class: power
+    dps:
+      - id: 26
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Inverter Output Power
+    class: power
+    dps:
+      - id: 27
+        type: integer
+        name: sensor
+        unit: W
+        range:
+          min: -20000
+          max: 20000
+  - entity: sensor
+    name: Battery Charging Power PV
+    class: power
+    dps:
+      - id: 28
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Battery Charging Power Grid
+    class: power
+    dps:
+      - id: 29
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: SoC Battery Array
+    class: battery
+    hidden: true
+    dps:
+      - id: 30
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Expansion Pack 1 SoC
+    class: battery
+    hidden: true
+    dps:
+      - id: 31
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Expansion Pack 2 SoC
+    class: battery
+    hidden: true
+    dps:
+      - id: 32
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Expansion Pack 3 SoC
+    class: battery
+    hidden: true
+    dps:
+      - id: 33
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Expansion Pack 4 SoC
+    class: battery
+    hidden: true
+    dps:
+      - id: 34
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Expansion Pack 5 SoC
+    class: battery
+    hidden: true
+    dps:
+      - id: 35
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Offgrid Export Power
+    class: power
+    dps:
+      - id: 38
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Cumulative Energy Generated PV
+    class: energy
+    dps:
+      - id: 40
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Output Inverter
+    class: energy
+    dps:
+      - id: 41
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Discharged
+    class: energy
+    dps:
+      - id: 42
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Charged
+    class: energy
+    dps:
+      - id: 43
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Charged PV
+    class: energy
+    dps:
+      - id: 44
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Charged Grid
+    class: energy
+    dps:
+      - id: 45
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Exported Offgrid
+    class: energy
+    dps:
+      - id: 46
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    name: Cumulative Energy Imported Offgrid
+    class: energy
+    dps:
+      - id: 47
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 1000
+  - entity: number
+    name: Backup Reserve
+    mode: slider
+    category: config
+    dps:
+      - id: 50
+        type: integer
+        name: value
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - step: 1
+  - entity: select
+    name: Work Mode
+    category: config
+    dps:
+      - id: 51
+        type: string
+        name: option
+        mapping:
+          - dps_val: self_powered
+            value: Self Powered
+          - dps_val: time_of_use
+            value: Time of Use
+          - dps_val: manual
+            value: Manual
+          - dps_val: plug
+            value: Plug
+          - dps_val: diy
+            value: Do It Yourself
+  - entity: number
+    name: Output Power Limit
+    mode: box
+    category: config
+    dps:
+      - id: 53
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 0
+          max: 100000
+        mapping:
+          - step: 1
+  - entity: switch
+    name: Feedin Power Limit Enable
+    category: config
+    dps:
+      - id: 54
+        type: boolean
+        name: switch
+  - entity: number
+    name: Feedin Power Limit
+    mode: box
+    category: config
+    dps:
+      - id: 55
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 0
+          max: 100000
+        mapping:
+          - step: 1
+  - entity: sensor
+    name: Country Code
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 56
+        type: integer
+        name: sensor
+  - entity: select
+    name: Indicator Light Mode
+    category: config
+    dps:
+      - id: 57
+        type: string
+        name: option
+        mapping:
+          - dps_val: "eco"
+            value: Eco
+          - dps_val: "on"
+            value: "Always On"
+          - dps_val: "off"
+            value: "Manual"
+  - entity: sensor
+    name: Smart Meter Type
+    class: enum
+    dps:
+      - id: 58
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: none
+            value: None
+          - dps_val: ty_lan
+            value: Lan
+          - dps_val: ty_rs485
+            value: RS485
+  - entity: switch
+    name: Recalibrate Battery
+    category: config
+    dps:
+      - id: 59
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Offgrid Port Enable
+    category: config
+    dps:
+      - id: 60
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Peak Shaving Enable
+    category: config
+    dps:
+      - id: 63
+        type: boolean
+        name: switch
+  - entity: number
+    name: Peak Shaving Threshold
+    mode: box
+    category: config
+    dps:
+      - id: 64
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 0
+          max: 30000
+        mapping:
+          - step: 1
+  - entity: select
+    name: Vibe Light Mode
+    category: config
+    dps:
+      - id: 65
+        type: string
+        name: option
+        mapping:
+          - dps_val: scene
+            value: Scene
+          - dps_val: "off"
+            value: "Off"
+  - entity: select
+    name: Offgrid Mode
+    category: config
+    dps:
+      - id: 68
+        type: string
+        name: option
+        mapping:
+          - dps_val: backup
+            value: Backup
+          - dps_val: plugin
+            value: Plugin
+  - entity: number
+    name: Inverter Input Power Limit
+    mode: box
+    category: config
+    dps:
+      - id: 69
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 0
+          max: 2500
+        mapping:
+          - step: 1
+  - entity: switch
+    name: Reserve Priority
+    category: config
+    dps:
+      - id: 70
+        type: boolean
+        name: switch
+  - entity: select
+    name: LED Items
+    category: config
+    dps:
+      - id: 73
+        type: string
+        name: option
+        mapping:
+          - dps_val: led_all
+            value: Cycle All
+          - dps_val: led_pv
+            value: PV
+          - dps_val: led_bypass
+            value: Bypass
+  - entity: select
+    name: Baseline Strategy
+    category: config
+    dps:
+      - id: 78
+        type: string
+        name: option
+        mapping:
+          - dps_val: self_powered
+            value: Self Powered
+          - dps_val: pv_only
+            value: PV Only
+  - entity: sensor
+    name: Regulation Grid Export Power Limit
+    category: diagnostic
+    dps:
+      - id: 84
+        type: integer
+        name: sensor
+        unit: W
+  - entity: switch
+    name: LP Sleep
+    category: config
+    hidden: true
+    dps:
+      - id: 85
+        type: boolean
+        name: switch
+  - entity: number
+    name: Base Load
+    mode: box
+    category: config
+    dps:
+      - id: 91
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 0
+          max: 99999
+        mapping:
+          - step: 1

--- a/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000_pro_battery.yaml
@@ -20,7 +20,6 @@ entities:
     class: problem
     dps:
       - id: 11
-        optional: true
         type: bitfield
         name: sensor
         mapping:
@@ -31,11 +30,9 @@ entities:
         type: string
         name: error_code
       - id: 11
-        optional: true
         type: bitfield
         name: fault_code
       - id: 11
-        optional: true
         type: bitfield
         name: description
         mapping:
@@ -110,6 +107,7 @@ entities:
     hidden: true
     dps:
       - id: 13
+        optional: true
         type: integer
         name: sensor
         unit: dBm
@@ -119,6 +117,7 @@ entities:
     hidden: true
     dps:
       - id: 14
+        optional: true
         type: string
         name: sensor
   - entity: sensor
@@ -127,6 +126,7 @@ entities:
     hidden: true
     dps:
       - id: 15
+        optional: true
         type: string
         name: sensor
   - entity: binary_sensor
@@ -148,7 +148,6 @@ entities:
     class: occupancy
     dps:
       - id: 18
-        optional: true
         type: boolean
         name: sensor
   - entity: sensor
@@ -370,6 +369,7 @@ entities:
     class: energy
     dps:
       - id: 44
+        optional: true
         type: integer
         name: sensor
         unit: kWh
@@ -403,7 +403,6 @@ entities:
     class: energy
     dps:
       - id: 47
-        optional: true
         type: integer
         name: sensor
         unit: kWh
@@ -490,6 +489,7 @@ entities:
     class: enum
     dps:
       - id: 58
+        optional: true
         type: string
         name: sensor
         mapping:
@@ -537,7 +537,6 @@ entities:
     category: config
     dps:
       - id: 65
-        optional: true
         type: string
         name: option
         mapping:
@@ -563,7 +562,6 @@ entities:
     category: config
     dps:
       - id: 69
-        optional: true
         type: integer
         name: value
         unit: W
@@ -575,7 +573,6 @@ entities:
     category: config
     dps:
       - id: 70
-        optional: true
         type: boolean
         name: switch
   - entity: select
@@ -583,7 +580,6 @@ entities:
     category: config
     dps:
       - id: 73
-        optional: true
         type: string
         name: option
         mapping:
@@ -598,7 +594,6 @@ entities:
     category: config
     dps:
       - id: 78
-        optional: true
         type: string
         name: option
         mapping:
@@ -611,7 +606,6 @@ entities:
     category: diagnostic
     dps:
       - id: 84
-        optional: true
         type: integer
         name: sensor
         unit: W
@@ -633,7 +627,6 @@ entities:
     category: config
     dps:
       - id: 91
-        optional: true
         type: integer
         name: value
         unit: W

--- a/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
@@ -15,6 +15,17 @@ entities:
         unit: kWh
         mapping:
           - scale: 1000
+      - id: 14
+        optional: true
+        type: string
+        name: hardware_version
+      - id: 15
+        optional: true
+        type: string
+        name: software_version
+      - id: 1
+        type: string
+        name: serial_number
   - entity: binary_sensor
     category: diagnostic
     class: problem
@@ -82,9 +93,6 @@ entities:
             value: meter_comm_failure
           - dps_val: 2097152
             value: system_temp_diff_protection
-      - id: 1
-        type: string
-        name: serial_number
   - entity: sensor
     name: Connection state
     category: diagnostic
@@ -111,24 +119,6 @@ entities:
         type: integer
         name: sensor
         unit: dBm
-  - entity: sensor
-    name: Hardware version
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 14
-        optional: true
-        type: string
-        name: sensor
-  - entity: sensor
-    name: System version
-    category: diagnostic
-    hidden: true
-    dps:
-      - id: 15
-        optional: true
-        type: string
-        name: sensor
   - entity: binary_sensor
     name: Cell heating
     category: diagnostic
@@ -241,7 +231,7 @@ entities:
           min: -20000
           max: 20000
   - entity: sensor
-    name: Battery charging power pv
+    name: PV charging power
     class: power
     dps:
       - id: 28
@@ -250,7 +240,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: Battery charging power grid
+    name: Grid charging power
     class: power
     dps:
       - id: 29
@@ -268,7 +258,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion pack 1 soc
+    name: Expansion pack 1 SoC
     class: battery
     hidden: true
     dps:
@@ -277,7 +267,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion pack 2 soc
+    name: Expansion pack 2 SoC
     class: battery
     hidden: true
     dps:
@@ -286,7 +276,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion pack 3 soc
+    name: Expansion pack 3 SoC
     class: battery
     hidden: true
     dps:
@@ -295,7 +285,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion pack 4 soc
+    name: Expansion pack 4 SoC
     class: battery
     hidden: true
     dps:
@@ -304,7 +294,7 @@ entities:
         name: sensor
         unit: "%"
   - entity: sensor
-    name: Expansion pack 5 soc
+    name: Expansion pack 5 SoC
     class: battery
     hidden: true
     dps:
@@ -321,7 +311,7 @@ entities:
         name: sensor
         unit: W
   - entity: sensor
-    name: Cumulative energy generated pv
+    name: Cumulative PV energy generated
     class: energy
     dps:
       - id: 40
@@ -332,7 +322,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative energy output inverter
+    name: Cumulative inverter energy output
     class: energy
     dps:
       - id: 41
@@ -365,7 +355,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative energy charged pv
+    name: Cumulative PV energy charged
     class: energy
     dps:
       - id: 44
@@ -377,7 +367,7 @@ entities:
         mapping:
           - scale: 1000
   - entity: sensor
-    name: Cumulative energy charged grid
+    name: Cumulative grid energy charged
     class: energy
     dps:
       - id: 45
@@ -438,7 +428,7 @@ entities:
           - dps_val: plug
             value: Plug
           - dps_val: diy
-            value: Do It Yourself
+            value: Custom
   - entity: number
     name: Output power limit
     mode: box


### PR DESCRIPTION
# Summary
* Add [CONOW CBE2000 Pro](https://www.conow.com/products/cbe-2000-pro-solar-storage) Solar Battery to Tuya Local.

# Why
* The standard Tuya integration of Home Assistant is very limited for the CBE2000 Pro, many datapoints missing and you can't even set the base load

# Testing
* Tested with the CBE2000 Pro I have and Tuya Local Version 2026.7.1
  * All inputs/selects tested ✓
  * Loading the battery from grid via automation ✓
  * Feeding the grid by automation ✓

# Screenshots

<img width="424" height="887" alt="image" src="https://github.com/user-attachments/assets/50ebae57-213a-4b21-af7d-f675ce52f991" />

<img width="428" height="405" alt="image" src="https://github.com/user-attachments/assets/cd752241-0d2c-47b6-b471-e5454bb97229" />

<img width="415" height="858" alt="image" src="https://github.com/user-attachments/assets/2542b005-d4d6-4e79-885d-af918c6b898a" />

<img width="410" height="340" alt="image" src="https://github.com/user-attachments/assets/c0edd1b1-aee7-4a91-927b-63f473763ea2" />

<img width="431" height="520" alt="image" src="https://github.com/user-attachments/assets/ab1682f3-c34a-412b-84eb-418b1284dde5" />
