### PR TITLE
rgb48_lightstring: map colour work_mode to effect to avoid unsupporte…

### DIFF
--- a/custom_components/tuya_local/devices/rgb48_lightstring.yaml
+++ b/custom_components/tuya_local/devices/rgb48_lightstring.yaml
@@ -39,7 +39,7 @@ entities:
           - dps_val: "white"
             value: "color_temp"
           - dps_val: "colour"
-            value: "hs"
+            value: "Draw"
             hidden: true  # there is no RGB dp, so prevent selection of this
           - dps_val: "scene"
             value: "scene"


### PR DESCRIPTION
Firmware for product 2znvfkx64d4fkzxp self-transitions work_mode (DP 21) to colour when DP 59 draw_tool frames are applied. This profile declares no colour-data DP (the device has no functional one — per-bulb paint via DP 59 is the only colour path), so mapping colour → "hs" reports a color mode outside supported_color_modes. HA Core now raises HomeAssistantError on that mismatch, which blocks entity add and fails every state write while a painted pattern is active. Mapping colour to a non-ColorMode value routes it through the effect path instead: entity stays valid in color_temp mode and reports the painted state as effect “Draw”.