### PR TITLE
Add Baxi Smart Link thermostat

### DIFF
--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -473,9 +473,19 @@ entities:
         type: integer
         name: sensor
 
-  - entity: water_heater
+  - entity: climate
     name: Domestic hot water
+    category: config
+    icon: "mdi:water-boiler"
     dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
       - id: 121
         type: integer
         name: temperature

--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -71,7 +71,6 @@ entities:
 
   - entity: select
     name: Heating season
-    category: config
     icon: "mdi:sun-snowflake-variant"
     dps:
       - id: 28
@@ -91,28 +90,32 @@ entities:
         type: boolean
         name: switch
 
+  - entity: text
+    translation_key: schedule
+    category: config
+    hidden: true
+    dps:
+      - id: 37
+        type: base64
+        name: value
+
+  - entity: button
+    translation_key: factory_reset
+    category: config
+    hidden: true
+    dps:
+      - id: 39
+        type: boolean
+        name: button
+
   - entity: binary_sensor
     class: window
-    category: diagnostic
     dps:
       - id: 3
         type: string
         name: sensor
         mapping:
           - dps_val: window_opened
-            value: true
-          - value: false
-
-  - entity: binary_sensor
-    name: Central heating
-    class: running
-    icon: "mdi:radiator"
-    dps:
-      - id: 3
-        type: string
-        name: sensor
-        mapping:
-          - dps_val: heating
             value: true
           - value: false
 
@@ -209,7 +212,7 @@ entities:
             step: 5
 
   - entity: sensor
-    name: Inlet water temperature
+    name: Return water temperature
     class: temperature
     category: diagnostic
     dps:
@@ -222,7 +225,7 @@ entities:
           - scale: 100
 
   - entity: sensor
-    name: Outlet water temperature
+    name: Boiler water temperature
     class: temperature
     icon: "mdi:coolant-temperature"
     dps:
@@ -235,7 +238,7 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: Boiler water pressure
+    name: Central heating pressure
     class: pressure
     category: diagnostic
     dps:
@@ -248,16 +251,16 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: Fire power
+    name: Flame level
     category: diagnostic
+    hidden: true
     dps:
       - id: 104
         type: integer
         name: sensor
-        class: measurement
 
   - entity: sensor
-    name: OEM fault code
+    name: Boiler fault code
     category: diagnostic
     icon: "mdi:alert-circle-outline"
     dps:
@@ -292,7 +295,7 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: Modulation level
+    name: Relative modulation level
     category: diagnostic
     dps:
       - id: 108
@@ -317,9 +320,8 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: Boiler external temperature
+    name: Outside temperature
     class: temperature
-    category: diagnostic
     dps:
       - id: 112
         type: integer
@@ -449,9 +451,10 @@ entities:
         name: switch
 
   - entity: number
-    name: OpenTherm read item
+    name: OpenTherm diagnostic query
     category: config
     mode: box
+    hidden: true
     dps:
       - id: 119
         type: integer
@@ -461,8 +464,9 @@ entities:
           max: 127
 
   - entity: sensor
-    name: OpenTherm return value
+    name: OpenTherm diagnostic value
     category: diagnostic
+    hidden: true
     dps:
       - id: 120
         type: integer
@@ -513,6 +517,7 @@ entities:
           - value: true
 
   - entity: binary_sensor
+    name: Control panel problem
     category: diagnostic
     class: problem
     dps:
@@ -528,7 +533,7 @@ entities:
         name: fault_code
 
   - entity: sensor
-    name: Fault bitmap
+    name: Control panel fault bitmap
     category: diagnostic
     icon: "mdi:alert-circle-outline"
     dps:

--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -1,0 +1,518 @@
+name: OpenTherm thermostat
+products:
+  - id: eewzuhyvcsrqi2zn
+    manufacturer: Baxi
+    model: Smart Link
+entities:
+  - entity: climate
+    translation_key: thermostat
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: manual
+            value: manual
+          - dps_val: eco
+            value: eco
+          - dps_val: auto
+            value: auto
+      - id: 3
+        type: string
+        name: hvac_action
+        mapping:
+          - dps_val: heating
+            value: heating
+          - value: idle
+      - id: 24
+        type: integer
+        name: current_temperature
+        range:
+          min: 0
+          max: 500
+        mapping:
+          - scale: 10
+      - id: 16
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 50
+          max: 350
+        mapping:
+          - scale: 10
+            step: 5
+      - id: 26
+        type: integer
+        name: min_temperature
+        range:
+          min: 50
+          max: 350
+        mapping:
+          - scale: 10
+            step: 5
+      - id: 19
+        type: integer
+        name: max_temperature
+        range:
+          min: 50
+          max: 350
+        mapping:
+          - scale: 10
+            step: 5
+      - id: 101
+        type: integer
+        optional: true
+        name: dead_zone
+
+  - entity: select
+    name: Heating season
+    category: config
+    icon: "mdi:sun-snowflake-variant"
+    dps:
+      - id: 28
+        type: string
+        name: option
+        mapping:
+          - dps_val: winter
+            value: Winter
+          - dps_val: summer
+            value: Summer
+
+  - entity: switch
+    translation_key: anti_frost
+    category: config
+    dps:
+      - id: 10
+        type: boolean
+        name: switch
+
+  - entity: binary_sensor
+    class: window
+    category: diagnostic
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: window_opened
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    name: Central heating
+    class: running
+    icon: "mdi:radiator"
+    dps:
+      - id: 3
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: heating
+            value: true
+          - value: false
+
+  - entity: binary_sensor
+    name: Burner
+    class: running
+    icon: "mdi:fire"
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+
+  - entity: binary_sensor
+    name: Domestic hot water
+    class: running
+    icon: "mdi:water-boiler"
+    dps:
+      - id: 3
+        type: string
+        name: central_heating
+        hidden: true
+      - id: 108
+        type: integer
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+            constraint: central_heating
+            conditions:
+              - dps_val: heating
+                value: false
+
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 40
+        type: boolean
+        name: lock
+
+  - entity: number
+    translation_key: minimum_temperature
+    category: config
+    class: temperature
+    mode: slider
+    dps:
+      - id: 26
+        name: value
+        type: integer
+        unit: C
+        range:
+          min: 50
+          max: 350
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: number
+    translation_key: maximum_temperature
+    category: config
+    class: temperature
+    mode: slider
+    dps:
+      - id: 19
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 50
+          max: 350
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: number
+    translation_key: temperature_calibration
+    class: temperature_delta
+    category: config
+    dps:
+      - id: 27
+        name: value
+        type: integer
+        unit: C
+        range:
+          min: -80
+          max: 80
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: sensor
+    name: Central heating water temperature
+    class: temperature
+    icon: "mdi:coolant-temperature"
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Boiler outlet water temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Boiler water pressure
+    class: pressure
+    category: diagnostic
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: bar
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Fire power
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Domestic hot water flow rate
+    class: volume_flow_rate
+    category: diagnostic
+    dps:
+      - id: 106
+        type: integer
+        name: sensor
+        unit: L/min
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Modulation level
+    category: diagnostic
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Underfloor water temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Boiler external temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: number
+    name: Central heating water upper limit
+    class: temperature
+    category: config
+    mode: box
+    dps:
+      - id: 110
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 200
+          max: 900
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: number
+    name: Central heating water lower limit
+    class: temperature
+    category: config
+    mode: box
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 100
+          max: 800
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: number
+    name: Internal compensation coefficient
+    category: config
+    mode: box
+    dps:
+      - id: 113
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 200
+        mapping:
+          - scale: 10
+            step: 1
+
+  - entity: number
+    name: External compensation coefficient
+    category: config
+    mode: box
+    dps:
+      - id: 114
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 200
+        mapping:
+          - scale: 10
+            step: 1
+
+  - entity: number
+    name: Compensation offset
+    category: config
+    mode: box
+    dps:
+      - id: 115
+        type: integer
+        name: value
+        range:
+          min: -200
+          max: 200
+        mapping:
+          - scale: 10
+            step: 1
+
+  - entity: number
+    name: Proportional coefficient
+    category: config
+    mode: box
+    dps:
+      - id: 116
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 10
+        mapping:
+          - scale: 10
+            step: 1
+
+  - entity: number
+    name: Overridden outside temperature
+    class: temperature
+    category: config
+    mode: box
+    dps:
+      - id: 117
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: -200
+          max: 200
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: switch
+    name: OEM fault forwarding
+    category: config
+    dps:
+      - id: 118
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: OpenTherm debug status
+    category: diagnostic
+    dps:
+      - id: 119
+        type: integer
+        name: sensor
+
+  - entity: sensor
+    name: OpenTherm debug return value
+    category: diagnostic
+    dps:
+      - id: 120
+        type: integer
+        name: sensor
+
+  - entity: number
+    name: Domestic hot water target temperature
+    class: temperature
+    category: config
+    mode: slider
+    dps:
+      - id: 121
+        type: integer
+        name: value
+        unit: C
+        range:
+          min: 200
+          max: 700
+        mapping:
+          - scale: 10
+            step: 5
+
+  - entity: sensor
+    name: Domestic hot water temperature
+    class: temperature
+    icon: "mdi:thermometer-water"
+    dps:
+      - id: 122
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: binary_sensor
+    name: Boiler connection
+    class: connectivity
+    category: diagnostic
+    icon: "mdi:link-variant"
+    dps:
+      - id: 45
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 16
+            value: false
+          - value: true
+
+  - entity: binary_sensor
+    category: diagnostic
+    class: problem
+    dps:
+      - id: 45
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 45
+        type: bitfield
+        name: fault_code
+
+  - entity: sensor
+    name: Fault code
+    category: diagnostic
+    icon: "mdi:alert-circle-outline"
+    dps:
+      - id: 45
+        type: bitfield
+        name: sensor

--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -71,6 +71,7 @@ entities:
 
   - entity: select
     name: Heating season
+    category: config
     icon: "mdi:sun-snowflake-variant"
     dps:
       - id: 28
@@ -472,15 +473,12 @@ entities:
         type: integer
         name: sensor
 
-  - entity: number
-    name: Domestic hot water target temperature
-    class: temperature
-    category: config
-    mode: slider
+  - entity: water_heater
+    name: Domestic hot water
     dps:
       - id: 121
         type: integer
-        name: value
+        name: temperature
         unit: C
         range:
           min: 0
@@ -489,16 +487,10 @@ entities:
           - scale: 10
             step: 5
 
-  - entity: sensor
-    name: Domestic hot water temperature
-    class: temperature
-    icon: "mdi:thermometer-water"
-    dps:
       - id: 122
         type: integer
-        name: sensor
+        name: current_temperature
         unit: C
-        class: measurement
         mapping:
           - scale: 10
 

--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -37,7 +37,7 @@ entities:
         name: current_temperature
         range:
           min: 0
-          max: 500
+          max: 1000
         mapping:
           - scale: 10
       - id: 16
@@ -54,8 +54,8 @@ entities:
         type: integer
         name: min_temperature
         range:
-          min: 50
-          max: 350
+          min: 0
+          max: 200
         mapping:
           - scale: 10
             step: 5
@@ -63,15 +63,11 @@ entities:
         type: integer
         name: max_temperature
         range:
-          min: 50
-          max: 350
+          min: 200
+          max: 800
         mapping:
           - scale: 10
             step: 5
-      - id: 101
-        type: integer
-        optional: true
-        name: dead_zone
 
   - entity: select
     name: Heating season
@@ -173,8 +169,8 @@ entities:
         type: integer
         unit: C
         range:
-          min: 50
-          max: 350
+          min: 0
+          max: 200
         mapping:
           - scale: 10
             step: 5
@@ -190,8 +186,8 @@ entities:
         name: value
         unit: C
         range:
-          min: 50
-          max: 350
+          min: 200
+          max: 800
         mapping:
           - scale: 10
             step: 5
@@ -213,7 +209,20 @@ entities:
             step: 5
 
   - entity: sensor
-    name: Central heating water temperature
+    name: Inlet water temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: C
+        class: measurement
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: Outlet water temperature
     class: temperature
     icon: "mdi:coolant-temperature"
     dps:
@@ -226,24 +235,11 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: Boiler outlet water temperature
-    class: temperature
-    category: diagnostic
-    dps:
-      - id: 103
-        type: integer
-        name: sensor
-        unit: C
-        class: measurement
-        mapping:
-          - scale: 10
-
-  - entity: sensor
     name: Boiler water pressure
     class: pressure
     category: diagnostic
     dps:
-      - id: 104
+      - id: 103
         type: integer
         name: sensor
         unit: bar
@@ -255,13 +251,19 @@ entities:
     name: Fire power
     category: diagnostic
     dps:
+      - id: 104
+        type: integer
+        name: sensor
+        class: measurement
+
+  - entity: sensor
+    name: OEM fault code
+    category: diagnostic
+    icon: "mdi:alert-circle-outline"
+    dps:
       - id: 105
         type: integer
         name: sensor
-        unit: "%"
-        class: measurement
-        mapping:
-          - scale: 10
 
   - entity: sensor
     name: Domestic hot water flow rate
@@ -272,6 +274,19 @@ entities:
         type: integer
         name: sensor
         unit: L/min
+        class: measurement
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: Exhaust temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        unit: C
         class: measurement
         mapping:
           - scale: 10
@@ -325,8 +340,8 @@ entities:
         name: value
         unit: C
         range:
-          min: 200
-          max: 900
+          min: 0
+          max: 1000
         mapping:
           - scale: 10
             step: 5
@@ -342,8 +357,8 @@ entities:
         name: value
         unit: C
         range:
-          min: 100
-          max: 800
+          min: 0
+          max: 1000
         mapping:
           - scale: 10
             step: 5
@@ -433,16 +448,20 @@ entities:
         type: boolean
         name: switch
 
-  - entity: sensor
-    name: OpenTherm debug status
-    category: diagnostic
+  - entity: number
+    name: OpenTherm read item
+    category: config
+    mode: box
     dps:
       - id: 119
         type: integer
-        name: sensor
+        name: value
+        range:
+          min: 0
+          max: 127
 
   - entity: sensor
-    name: OpenTherm debug return value
+    name: OpenTherm return value
     category: diagnostic
     dps:
       - id: 120
@@ -460,8 +479,8 @@ entities:
         name: value
         unit: C
         range:
-          min: 200
-          max: 700
+          min: 0
+          max: 800
         mapping:
           - scale: 10
             step: 5
@@ -509,7 +528,7 @@ entities:
         name: fault_code
 
   - entity: sensor
-    name: Fault code
+    name: Fault bitmap
     category: diagnostic
     icon: "mdi:alert-circle-outline"
     dps:

--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -304,7 +304,7 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: Underfloor water temperature
+    name: Central heating water setpoint
     class: temperature
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
+++ b/custom_components/tuya_local/devices/baxi_smart_link_thermostat.yaml
@@ -35,9 +35,6 @@ entities:
       - id: 24
         type: integer
         name: current_temperature
-        range:
-          min: 0
-          max: 1000
         mapping:
           - scale: 10
       - id: 16
@@ -53,21 +50,13 @@ entities:
       - id: 26
         type: integer
         name: min_temperature
-        range:
-          min: 0
-          max: 200
         mapping:
           - scale: 10
-            step: 5
       - id: 19
         type: integer
         name: max_temperature
-        range:
-          min: 200
-          max: 800
         mapping:
           - scale: 10
-            step: 5
 
   - entity: select
     name: Heating season
@@ -473,19 +462,17 @@ entities:
         type: integer
         name: sensor
 
-  - entity: climate
-    name: Domestic hot water
+  - entity: water_heater
     category: config
-    icon: "mdi:water-boiler"
     dps:
       - id: 1
         type: boolean
-        name: hvac_mode
+        name: operation_mode
         mapping:
           - dps_val: false
             value: "off"
           - dps_val: true
-            value: heat
+            value: electric
       - id: 121
         type: integer
         name: temperature
@@ -496,7 +483,6 @@ entities:
         mapping:
           - scale: 10
             step: 5
-
       - id: 122
         type: integer
         name: current_temperature


### PR DESCRIPTION
## Summary

- add a Tuya Local device profile for the Baxi Smart Link OpenTherm thermostat
- expose thermostat control, heating and domestic hot water state, boiler diagnostics, and supported configuration datapoints
- map Tuya bitmap faults and OpenTherm connectivity
- apply datapoint ranges and scaling from the Tuya device data model

## Why

The standard Tuya integration exposes only a limited subset of this thermostat's capabilities. This profile provides local access to heating, domestic hot water, modulation, temperature, and diagnostic datapoints.

The mappings were checked against the Tuya data model and live captures in idle, central heating, and domestic hot water operation. DP3 distinguishes central heating from domestic hot water, while DP108 reports burner modulation.

## Validation

- `ruff check .`
- `ruff check --select I .`
- `ruff format --check .`
- `yamllint custom_components/tuya_local/devices`
- `pytest tests/test_device_config.py` — 32 passed
<img width="1220" height="673" alt="image" src="https://github.com/user-attachments/assets/2aaf2a34-8e7f-4aa7-b0c1-9a46358919e0" />
<img width="392" height="732" alt="image" src="https://github.com/user-attachments/assets/91da341c-0c94-41b3-b2b6-1ba8ef4c8830" />
<img width="392" height="732" alt="image" src="https://github.com/user-attachments/assets/fce2b53e-33dd-4cea-9ae1-0b8de8b03ba8" />
<img width="392" height="732" alt="image" src="https://github.com/user-attachments/assets/52c3dd21-2630-48da-83c8-829cf3a5d42b" />
