### PR TITLE
fix(dewall_evcharger): keep refresh available

### DIFF
--- a/custom_components/tuya_local/devices/dewall_evcharger.yaml
+++ b/custom_components/tuya_local/devices/dewall_evcharger.yaml
@@ -214,5 +214,5 @@ entities:
         name: available
         mapping:
           - dps_val: null
-            value: false
+            value: true
           - value: true


### PR DESCRIPTION
## Summary

- treat a missing/null DP188 availability value as available for the hidden Refresh button
- fixes newer dewall_evcharger firmware where DP188 is listed in the cloud specification but omitted from the initial local DPS snapshot
- allows the existing Refresh button to request updated DP102 electrical metrics

## Compatibility note

This is intentionally a draft. Reports #3120 and #3152 use the same product ID but do not list DP188, while #4314 and the tested firmware do. Because product ID alone cannot distinguish these variants, maintainer guidance is requested on whether always exposing the hidden optional Refresh button is acceptable or whether a stronger discriminator is needed.

Tested device: product witok7vhhjohtr02, firmware 9.7.5. Before this change the enabled Refresh entity was unavailable; after it, button.press completes without an availability error.

## Validation

- uv run pytest tests/test_device_config.py — 32 passed
- uv run ruff check .
- uv run ruff check --select I .
- uv run ruff format --check .
- uv run yamllint custom_components/tuya_local/devices/dewall_evcharger.yaml