### PR TITLE
Add Zemismart SPM01-D2TW-ZM (Metering_1PN_WiFi) energy meter

### DIFF
--- a/custom_components/tuya_local/devices/zemismart_spm01_d2tw_energymeter.yaml
+++ b/custom_components/tuya_local/devices/zemismart_spm01_d2tw_energymeter.yaml
@@ -1,0 +1,144 @@
+name: Energy meter
+# products:
+#   - id: TBC - no Tuya cloud product_id available (no cloud link)
+#     manufacturer: Zemismart
+#     model: SPM01-D2TW-ZM
+#     model_id: Metering_1PN_WiFi
+# Note: this firmware batch of the SPM01-D2TW-ZM uses a different dp layout to
+# the one merged into earu_smart_wifi_circuit_breaker_with_energy_monitor.yaml
+# (upstream issue #2219), which expects dp101/dp16/dp6 that this unit never
+# sends. Confirmed live via direct DPS query: dps 1, 9, 19, 23, 32, 50, 102,
+# 103, 104. See also upstream issue #4081, which reports the same dp23
+# reverse-energy shift on the sibling 3-phase SPM02-D2TW.
+entities:
+  - entity: sensor
+    translation_key: energy_consumed
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+      - id: 19
+        type: string
+        name: meter_id
+        optional: true
+  - entity: sensor
+    translation_key: energy_produced
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    class: power
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: W
+        class: measurement
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: V
+        class: measurement
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 103
+        type: integer
+        name: sensor
+        unit: A
+        class: measurement
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: frequency
+    category: diagnostic
+    dps:
+      - id: 32
+        type: integer
+        name: sensor
+        unit: Hz
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: sensor
+    class: power_factor
+    category: diagnostic
+    dps:
+      - id: 50
+        type: integer
+        name: sensor
+        unit: "%"
+        class: measurement
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 9
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 9
+        type: bitfield
+        name: fault_code
+      - id: 9
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: short_circuit
+          - dps_val: 2
+            value: surge
+          - dps_val: 4
+            value: overload
+          - dps_val: 8
+            value: earth_leak
+          - dps_val: 16
+            value: temperature_difference
+          - dps_val: 32
+            value: fire
+          - dps_val: 64
+            value: high_power
+          - dps_val: 128
+            value: self_test
+          - dps_val: 256
+            value: over_current
+          - dps_val: 512
+            value: unbalanced
+          - dps_val: 1024
+            value: over_voltage
+          - dps_val: 2048
+            value: under_voltage
+          - dps_val: 4096
+            value: miss_phase
+          - dps_val: 8192
+            value: outage
+          - dps_val: 16384
+            value: magnetism
+          - dps_val: 32768
+            value: credit_low
+          - dps_val: 65536
+            value: credit_expired


### PR DESCRIPTION
## Summary

Adds a device config for a firmware batch of the Zemismart SPM01-D2TW-ZM
(generic Tuya product name `Metering_1PN_WiFi`) that uses a different dp
layout to the one merged for #2219
(`earu_smart_wifi_circuit_breaker_with_energy_monitor.yaml`).

That config expects `dp101`/`dp16`/`dp6` (packed base64 V/A/kW), none of
which this unit sends. Confirmed live via direct DPS query against the
device: `dps 1, 9, 19, 23, 32, 50, 102, 103, 104`.

Voltage/current/power were cross-checked against the reported power factor
for consistency: `240.2V x 0.623A x 0.41pf = 61.9W`, matching `dp104 = 62W`.

`dp23` for reverse/produced energy matches the same shift reported on the
sibling 3-phase SPM02-D2TW in #4081, so this looks like a batch-wide
renumbering by the OEM rather than a one-off.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff check --select -I .`
- [x] `uv run ruff format --check .`
- [x] `uv run yamllint custom_components/tuya_local/devices`
- [x] `uv run pytest tests/test_device_config.py` (32 passed)
- [x] `uv run pytest tests/test_translations.py` (1 passed)
- [x] Deployed to my own live HA instance and confirmed all entities report
      correct, physically-consistent values (voltage/current/power/energy/
      frequency/power factor/fault state)

Related: #2219, #4081