### PR TITLE
Add support for flymoon humidifier with all controls

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -600,6 +600,7 @@
 - Eanons QT-JS2014 purifying humidifier
 - Eberg HUMI H03G1 humidifier
 - Eta Noble humidifier
+- Flymoon Top Fill 5L Cool Mist Humidifier
 - Homvana H111S humidifier
 - Inkbird IHC-200 humidity controller
 - Klarta Humea and Humea Grande humidifiers

--- a/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
+++ b/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
@@ -100,7 +100,7 @@ entities:
   # Water shortage alarm
   - entity: binary_sensor
     name: Water Shortage
-    device_class: problem
+    class: problem
     dps:
       - id: 22
         type: bitfield

--- a/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
+++ b/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
@@ -1,6 +1,6 @@
 name: Humidifier
 products:
-  - id: e1n23s20
+  - id: w1na5rczyvflglvn
     manufacturer: FLYMOON
     model: Top Fill 5L Cool Mist Humidifier
 

--- a/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
+++ b/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
@@ -23,22 +23,17 @@ entities:
       - id: 14
         type: integer
         name: current_humidity
-
-  # Mist level control
-  - entity: select
-    name: Mist Level
-    icon: mdi:water
-    dps:
+      # Mist level
       - id: 3
         type: string
-        name: option
+        name: mode
         mapping:
           - dps_val: small
-            value: Small
+            value: eco
           - dps_val: middle
-            value: Medium
+            value: normal
           - dps_val: large
-            value: Large
+            value: boost
 
   # Sleep mode
   - entity: switch
@@ -60,31 +55,31 @@ entities:
         name: option
         mapping:
           - dps_val: cancel
-            value: "Off"
+            value: "cancel"
           - dps_val: 1h
-            value: "1 hour"
+            value: "1h"
           - dps_val: 2h
-            value: "2 hours"
+            value: "2h"
           - dps_val: 3h
-            value: "3 hours"
+            value: "3h"
           - dps_val: 4h
-            value: "4 hours"
+            value: "4h"
           - dps_val: 5h
-            value: "5 hours"
+            value: "5h"
           - dps_val: 6h
-            value: "6 hours"
+            value: "6h"
           - dps_val: 7h
-            value: "7 hours"
+            value: "7h"
           - dps_val: 8h
-            value: "8 hours"
+            value: "8h"
           - dps_val: 9h
-            value: "9 hours"
+            value: "9h"
           - dps_val: 10h
-            value: "10 hours"
+            value: "10h"
           - dps_val: 11h
-            value: "11 hours"
+            value: "11h"
           - dps_val: 12h
-            value: "12 hours"
+            value: "12h"
 
   # Remaining countdown time
   - entity: sensor
@@ -99,8 +94,7 @@ entities:
 
   # Water shortage alarm
   - entity: binary_sensor
-    name: Water Shortage
-    class: problem
+    translation_key: tank_empty
     dps:
       - id: 22
         type: bitfield
@@ -108,5 +102,3 @@ entities:
         mapping:
           - dps_val: 1
             value: true
-          - dps_val: 0
-            value: false

--- a/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
+++ b/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
@@ -1,0 +1,112 @@
+name: Humidifier
+products:
+  - id: e1n23s20
+    manufacturer: FLYMOON
+    model: Top Fill 5L Cool Mist Humidifier
+
+entities:
+  # Main humidifier (power + target humidity)
+  - entity: humidifier
+    class: humidifier
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 13
+        type: integer
+        name: humidity
+        range:
+          min: 30
+          max: 90
+        mapping:
+          - step: 5
+      - id: 14
+        type: integer
+        name: current_humidity
+
+  # Mist level control
+  - entity: select
+    name: Mist Level
+    icon: mdi:water
+    dps:
+      - id: 3
+        type: string
+        name: option
+        mapping:
+          - dps_val: small
+            value: Small
+          - dps_val: middle
+            value: Medium
+          - dps_val: large
+            value: Large
+
+  # Sleep mode
+  - entity: switch
+    translation_key: sleep
+    category: config
+    icon: mdi:bed
+    dps:
+      - id: 16
+        type: boolean
+        name: switch
+
+  # Timer
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: "Off"
+          - dps_val: 1h
+            value: "1 hour"
+          - dps_val: 2h
+            value: "2 hours"
+          - dps_val: 3h
+            value: "3 hours"
+          - dps_val: 4h
+            value: "4 hours"
+          - dps_val: 5h
+            value: "5 hours"
+          - dps_val: 6h
+            value: "6 hours"
+          - dps_val: 7h
+            value: "7 hours"
+          - dps_val: 8h
+            value: "8 hours"
+          - dps_val: 9h
+            value: "9 hours"
+          - dps_val: 10h
+            value: "10 hours"
+          - dps_val: 11h
+            value: "11 hours"
+          - dps_val: 12h
+            value: "12 hours"
+
+  # Remaining countdown time
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: min
+
+  # Water shortage alarm
+  - entity: binary_sensor
+    name: Water Shortage
+    device_class: problem
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 1
+            value: true
+          - dps_val: 0
+            value: false

--- a/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
+++ b/custom_components/tuya_local/devices/flymoon_5l_humidifier.yaml
@@ -1,8 +1,8 @@
 name: Humidifier
 products:
   - id: w1na5rczyvflglvn
-    manufacturer: FLYMOON
-    model: Top Fill 5L Cool Mist Humidifier
+    manufacturer: Flymoon
+    model: Top Fill 5L Cool Mist
 
 entities:
   # Main humidifier (power + target humidity)
@@ -39,7 +39,6 @@ entities:
   - entity: switch
     translation_key: sleep
     category: config
-    icon: mdi:bed
     dps:
       - id: 16
         type: boolean
@@ -102,3 +101,4 @@ entities:
         mapping:
           - dps_val: 1
             value: true
+          - value: false


### PR DESCRIPTION
Added support for a humidifier that didn't have full support with existing devices.

It's this one: https://www.amazon.com/dp/B0FXFWSZMV

Mist level and sleep (turn the display off) support were missing from the current best matching device (venta_ah510_humidifier). It's all added now and is default selecting it correctly when adding this specific humidifier.

Got all the DPs from the tuya cloud iot console, so they are all accurate.
I have this humidifier and tested it with the latest Home Assistant & tuya-local versions.
I understand the added yaml file.
It's pretty simple.

Also note for anyone using this device in the future who finds this PR, this humidifier uses protocol 3.5 which tuya-local supports already. That's the one you select when adding the device.