### PR TITLE
Add Lyfco 9kW Pool Heatpump device config

### DIFF
--- a/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
+++ b/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
@@ -129,7 +129,8 @@ entities:
           - dps_val: 1048576
             value: "E21 Evaporator Temperature (T2) Low Protection"
           - dps_val: 2097152
-            value: "E22 Communication Error between Wireless Control and Mainboard"
+            value: "E22 Communication Error between Wireless Control and\
+            Mainboard"
           - dps_val: 4194304
             value: "E23 Phase Missing Protection"
           - dps_val: 8388608
@@ -141,9 +142,11 @@ entities:
           - dps_val: 67108864
             value: "E27 Low Water Flow Protection"
           - dps_val: 134217728
-            value: "E28 Outlet Temperature Exceed High Protection in Heating Mode"
+            value: "E28 Outlet Temperature Exceed High Protection in\
+            Heating Mode"
           - dps_val: 268435456
-            value: "E29 Outlet Temperature Exceed Low Protectiond in Cooling Mode"
+            value: "E29 Outlet Temperature Exceed Low Protection\
+            in Cooling Mode"
           - dps_val: 536870912
             value: "E30 Evaporator Temperature Sensor (T2) Error"
           - dps_val: 1073741824

--- a/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
+++ b/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
@@ -1,0 +1,153 @@
+name: Lyfco 9kW Pool Heatpump
+products:
+  - id: zwmuxensvaoxc8n5
+    name: Lyfco 9kW Pool Heatpump
+entities:
+  - entity: climate
+    translation_key: pool_heatpump
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: preset_mode
+            conditions:
+              - dps_val: "Cooling"
+                value: cool
+              - dps_val: "Heating"
+                value: heat
+              - dps_val: "Auto"
+                value: auto
+
+      - id: 2
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: "Cooling"
+            value: cool
+          - dps_val: "Heating"
+            value: heat
+          - dps_val: "Auto"
+            value: auto
+      - id: 4
+        name: temperature
+        type: integer
+        range:
+          min: 150
+          max: 400
+        mapping:
+          - scale: 10
+            step: 10
+      - id: 16
+        name: current_temperature
+        type: integer
+        mapping:
+          - scale: 10
+      - id: 5
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: "Smart"
+            value: auto
+          - dps_val: "Silence"
+            value: quiet
+          - dps_val: "Boost"
+            value: boost
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 15
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 15
+        name: fault_code
+        type: bitfield
+      - id: 15
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: "OK"
+          - dps_val: 1
+            value: "E01 IPM (Driver Module) Protection"
+          - dps_val: 2
+            value: "E02 AC Voltage Over/Under Protection"
+          - dps_val: 4
+            value: "E03 AC Current Overload Protection"
+          - dps_val: 8
+            value: "E04 Gas Exhaust Temperature High Protection"
+          - dps_val: 16
+            value: "E05 External Coil Temperature High Protection"
+          - dps_val: 32
+            value: "E06 Compressor Drive Protection"
+          - dps_val: 64
+            value: "E07 Air Temperature Sensor Error"
+          - dps_val: 128
+            value: "E08 External Coil Temperature Sensor Error"
+          - dps_val: 256
+            value: "E09 Gas Exhaust Temperature Sensor Error"
+          - dps_val: 512
+            value: "E10 Buss Spänning Över/Underspänningsskydd"
+          - dps_val: 1024
+            value: "E11 Current Sensor Error"
+          - dps_val: 2048
+            value: "E12 Compressor Driver Communication Error"
+          - dps_val: 4096
+            value: "E13 DC Fan Motor Error"
+          - dps_val: 8192
+            value: "E14 Gas Suction Temperature Sensor Error"
+          - dps_val: 16384
+            value: "E15 Driver EE Error"
+          - dps_val: 32768
+            value: "E16 Mainboard EE Error"
+          - dps_val: 65536
+            value: "E17 Low Pressure Protection"
+          - dps_val: 131072
+            value: "E18 High Pressure Protection"
+          - dps_val: 262144
+            value: "E19 IPM Temperature Above High Protection"
+          - dps_val: 524288
+            value: "E20 Sudden Loss of Mains"
+          - dps_val: 1048576
+            value: "E21 Evaporator Temperature (T2) Low Protection"
+          - dps_val: 2097152
+            value: "E22 Communication Error between Wireless Control and Mainboard"
+          - dps_val: 4194304
+            value: "E23 Phase Missing Protection"
+          - dps_val: 8388608
+            value: "E24 Inlet Temperature Sensor Error"
+          - dps_val: 16777216
+            value: "E25 Outlet Temperature Sensor Error"
+          - dps_val: 33554432
+            value: "E26 Water Flow Protection Error"
+          - dps_val: 67108864
+            value: "E27 Low Water Flow Protection"
+          - dps_val: 134217728
+            value: "E28 Outlet Temperature Exceed High Protection in Heating Mode"
+          - dps_val: 268435456
+            value: "E29 Outlet Temperature Exceed Low Protectiond in Cooling Mode"
+          - dps_val: 536870912
+            value: "E30 Evaporator Temperature Sensor (T2) Error"
+          - dps_val: 1073741824
+            value: "E31 Unknown"
+          - dps_val: 2147483648
+            value: "E32 Unknown"
+          - dps_val: 4294967296
+            value: "E33 PFC Hardware F0 Error"
+          - dps_val: 8589934592
+            value: "E34 PFC Software - Over Current Protection"
+          - dps_val: 17179869184
+            value: "E35 Compressor Step Loss"
+          - dps_val: 34359738368
+            value: "E36 Unknown"
+          - dps_val: 68719476736
+            value: "E37 Compressor Start Error"

--- a/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
+++ b/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
@@ -21,7 +21,6 @@ entities:
                 value: heat
               - dps_val: "Auto"
                 value: auto
-
       - id: 2
         name: preset_mode
         type: string
@@ -56,6 +55,16 @@ entities:
             value: quiet
           - dps_val: "Boost"
             value: boost
+      - id: 2
+        name: hvac_action
+        type: string
+        mapping:
+          - dps_val: "Heating"
+            value: heat
+          - dps_val: "Cooling"
+            value: cool
+          - dps_val: "Auto"
+            value: auto
 
   - entity: binary_sensor
     class: problem

--- a/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
+++ b/custom_components/tuya_local/devices/lyfco_9kw_heatpump.yaml
@@ -1,70 +1,77 @@
-name: Lyfco 9kW Pool Heatpump
+name: Lyfco 9kW Pool Heat Pump
+
 products:
   - id: zwmuxensvaoxc8n5
-    name: Lyfco 9kW Pool Heatpump
+    manufacturer: Lyfco
+    model: 9kW
+    name: Lyfco 9kW Pool Heat Pump
+
 entities:
   - entity: climate
-    translation_key: pool_heatpump
+    translation_only_key: pool_heatpump
     dps:
       - id: 1
-        name: hvac_mode
         type: boolean
+        name: hvac_mode
         mapping:
           - dps_val: false
             value: "off"
           - dps_val: true
-            constraint: preset_mode
+            constraint: mode
             conditions:
-              - dps_val: "Cooling"
+              - dps_val: Cooling
                 value: cool
-              - dps_val: "Heating"
+              - dps_val: Heating
                 value: heat
-              - dps_val: "Auto"
+              - dps_val: Auto
                 value: auto
       - id: 2
-        name: preset_mode
         type: string
-        mapping:
-          - dps_val: "Cooling"
-            value: cool
-          - dps_val: "Heating"
-            value: heat
-          - dps_val: "Auto"
-            value: auto
+        name: mode
+        hidden: true
       - id: 4
-        name: temperature
         type: integer
+        name: temperature
         range:
-          min: 150
+          min: 70
           max: 400
         mapping:
           - scale: 10
             step: 10
       - id: 16
-        name: current_temperature
         type: integer
+        name: current_temperature
         mapping:
           - scale: 10
-      - id: 5
-        name: preset_mode
+      - id: 17
         type: string
-        mapping:
-          - dps_val: "Smart"
-            value: auto
-          - dps_val: "Silence"
-            value: quiet
-          - dps_val: "Boost"
-            value: boost
-      - id: 2
         name: hvac_action
-        type: string
         mapping:
-          - dps_val: "Heating"
-            value: heat
-          - dps_val: "Cooling"
-            value: cool
-          - dps_val: "Auto"
-            value: auto
+          - dps_val: standby
+            value: idle
+          - dps_val: heating
+            value: heating
+          - dps_val: warm
+            value: idle
+      - id: 5
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: Boost
+            value: quick
+          - dps_val: Silence
+            value: quiet
+          - dps_val: Smart
+            value: smart
+
+  - entity: sensor
+    name: Outlet temperature
+    class: temperature
+    category: diagnostic
+    dps:
+      - id: 25
+        type: integer
+        name: sensor
 
   - entity: binary_sensor
     class: problem
@@ -78,8 +85,8 @@ entities:
             value: false
           - value: true
       - id: 15
-        name: fault_code
         type: bitfield
+        name: fault_code
       - id: 15
         type: bitfield
         name: description
@@ -105,7 +112,7 @@ entities:
           - dps_val: 256
             value: "E09 Gas Exhaust Temperature Sensor Error"
           - dps_val: 512
-            value: "E10 Buss Spänning Över/Underspänningsskydd"
+            value: "E10 Bus Voltage Over/Under voltage protection"
           - dps_val: 1024
             value: "E11 Current Sensor Error"
           - dps_val: 2048
@@ -129,7 +136,7 @@ entities:
           - dps_val: 1048576
             value: "E21 Evaporator Temperature (T2) Low Protection"
           - dps_val: 2097152
-            value: "E22 Communication Error between Wireless Control and\
+            value: "E22 Communication Error between Wireless Control and \
             Mainboard"
           - dps_val: 4194304
             value: "E23 Phase Missing Protection"
@@ -142,24 +149,10 @@ entities:
           - dps_val: 67108864
             value: "E27 Low Water Flow Protection"
           - dps_val: 134217728
-            value: "E28 Outlet Temperature Exceed High Protection in\
+            value: "E28 Outlet Temperature Exceed High Protection in \
             Heating Mode"
           - dps_val: 268435456
-            value: "E29 Outlet Temperature Exceed Low Protection\
+            value: "E29 Outlet Temperature Exceed Low Protection \
             in Cooling Mode"
           - dps_val: 536870912
             value: "E30 Evaporator Temperature Sensor (T2) Error"
-          - dps_val: 1073741824
-            value: "E31 Unknown"
-          - dps_val: 2147483648
-            value: "E32 Unknown"
-          - dps_val: 4294967296
-            value: "E33 PFC Hardware F0 Error"
-          - dps_val: 8589934592
-            value: "E34 PFC Software - Over Current Protection"
-          - dps_val: 17179869184
-            value: "E35 Compressor Step Loss"
-          - dps_val: 34359738368
-            value: "E36 Unknown"
-          - dps_val: 68719476736
-            value: "E37 Compressor Start Error"


### PR DESCRIPTION
Adds device config support for the Lyfco 9kW Pool Heatpump (product ID zwmuxensvaoxc8n5).
- Now PR with the correct file, running and verified in my system

Entities:
climate:
- heat/cool/auto modes via dps 1 (on/off) + dps 2 (mode)
- target temperature via dps 4 (10–40°C, step 1°C)
- current temperature via dps 16
- Smart/Silence/Boost modes via dps 5

binary_sensor (diagnostic, problem class):
- fault detection via dps 15, a 37-bit bitfield covering all documented error codes (E01–E37, e.g. IPM protection, voltage/current faults, sensor errors, water flow protection, etc.)

Testing:
Configured and tested locally against a physical unit running HAOS under Proxmox. Mode switching, temperature set/read, and fault sensor reporting all behave as expected.