### PR TITLE
feat(devices): add Lumary D1 6" retrofit downlight (independent RGB ring + CCT)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -960,6 +960,7 @@ of device.
 - LSC Smart Connect Neon LED strip
 - LSC Smart Connect Party string lights
 - LSC smart connect RGB CCT lightbulb (similar to older generic bulbs, so may work for others)
+- Lumary D1 6 inch retrofit downlight (independent RGB ring and CCT centre)
 - Lytmi Fantasy/Neo 3 HDMI sync backlight
 - Malmbergs QS-WIFI-D02-TRIAC single dimmer module
 - Malmbergs QS-WIFI-D02-TRIAC-2C dual dimmer module

--- a/custom_components/tuya_local/devices/lumary_d1_downlight.yaml
+++ b/custom_components/tuya_local/devices/lumary_d1_downlight.yaml
@@ -62,10 +62,3 @@ entities:
             range:
               min: 0
               max: 1000
-      - id: 24
-        type: hex
-        name: brightness
-        range:
-          min: 0
-          max: 1000
-        mask: "00000000FFFF"

--- a/custom_components/tuya_local/devices/lumary_d1_downlight.yaml
+++ b/custom_components/tuya_local/devices/lumary_d1_downlight.yaml
@@ -1,0 +1,71 @@
+name: Recessed downlight
+products:
+  - id: nko0qtqcv4dsddvh
+    manufacturer: Lumary
+    model: D1
+    model_id: L-DL6D1
+  - id: key5q5hf8heh9xag
+    manufacturer: Lumary
+    model: D1
+    model_id: L-DL6D1
+entities:
+  # White CCT centre (independent switch, brightness and colour temperature)
+  - entity: light
+    name: Centre
+    icon: "mdi:circle-slice-8"
+    dps:
+      - id: 63
+        type: boolean
+        name: switch
+      - id: 22
+        name: brightness
+        type: integer
+        range:
+          min: 10
+          max: 1000
+      - id: 23
+        name: color_temp
+        type: integer
+        optional: true
+        range:
+          min: 0
+          max: 1000
+        mapping:
+          - target_range:
+              min: 2700
+              max: 6500
+  # RGB ring (independent switch, HSV colour, brightness on value channel)
+  - entity: light
+    name: Ring
+    icon: "mdi:circle-outline"
+    dps:
+      - id: 54
+        type: boolean
+        name: switch
+      - id: 24
+        name: rgbhsv
+        type: hex
+        optional: true
+        format:
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+          - name: v
+            bytes: 2
+            range:
+              min: 0
+              max: 1000
+      - id: 24
+        type: hex
+        name: brightness
+        range:
+          min: 0
+          max: 1000
+        mask: "00000000FFFF"


### PR DESCRIPTION
## Device

**Lumary 6 Inch Smart LED Recessed Lighting Retrofit, Dual Controlled — RGBAI Ring & CCT Main** (model **D1** / `L-DL6D1`).

- Cloud `product_id`: `nko0qtqcv4dsddvh`
- Local discovery `productKey`: `key5q5hf8heh9xag`

(Both are listed in the config, per the devices README recommendation when they differ.)

This fixture has two **independently controllable** light channels — a white CCT centre and an RGBAI colour ring — so it is exposed as two `light` entities (`Centre` and `Ring`).

## Why a dedicated config (not generic RGBCW)

The Tuya **cloud data model only documents the standard single-channel RGBCW DPs** (20–28, 34). With those alone the device behaves as one light whose `work_mode` (DP 21) multiplexes between white and colour, so the ring and centre cannot be lit at the same time.

By polling the device locally I found **three additional DPs that are absent from the cloud data model** — **54, 55, 63** — which drive the two channels independently. Using them, both channels can be controlled fully independently. That is what this config does.

## DPS map (sanitised)

| DP | Code (cloud) | Type | Range / values | Mapped to |
|----|--------------|------|----------------|-----------|
| 63 | *(not in cloud model)* | bool | on/off | **Centre** switch |
| 22 | `bright_value` | int | 10–1000 | Centre brightness |
| 23 | `temp_value` | int | 0–1000 → 2700–6500 K | Centre colour temp |
| 54 | *(not in cloud model)* | bool | on/off | **Ring** switch |
| 24 | `colour_data` | hex HSV (12 chars) | h 0–360, s 0–1000, v 0–1000 | Ring colour + brightness (v) |
| 20 | `switch_led` | bool | on/off | aggregate master — device-managed, left unmapped |
| 21 | `work_mode` | enum | white/colour/scene/music | unmapped |
| 25 | `scene_data` | string | — | unmapped |
| 26 | `countdown` | int | 0–86400 s | unmapped |
| 27 | `music_data` | string | — | unmapped |
| 28 | `control_data` | string | — | unmapped |
| 34 | `do_not_disturb` | bool | — | unmapped |
| 55 | *(not in cloud model)* | enum | ring work_mode | unmapped |

Note: although the cloud model types `colour_data` (DP 24) as JSON, the **local protocol transmits it as a 12-character hex HSV string** (e.g. `0115019c03c9` = H 0x0115, S 0x019c, V 0x03c9), so it is configured as `rgbhsv` hex with 2-byte h/s/v, and ring brightness is taken from the value bytes.

## Verified on real hardware

Tested on **6 units** (all identical DPS layout and product IDs):

- Both channels driven **independently and simultaneously** (ring on with centre off, centre on with ring off, and both on).
- **Ring:** HSV colour set and read back exact (red / amber / green / blue / magenta / cyan), brightness round-trips.
- **Centre:** colour temperature (3000–4000 K within the 2700–6500 K range) and brightness set and read back.
- All values round-trip through the local connection; entities restore correctly.

## Related

- Community demand for local control of these dual-channel Lumary retrofit lights (with the same DP 63/22/23 centre + ring layout): see HA community threads for "Lumary … Local Tuya".
- #3725 requested a *different* Lumary recessed model (the single-channel "Pro / G1 Ultra-thin", product `o0xasegbwgayuzaf`, DPs 20–24 only) and is not addressed here.

## Checklist

- [x] `uv run yamllint custom_components/tuya_local/devices/lumary_d1_downlight.yaml` — clean
- [x] `uv run pytest tests/test_device_config.py` — passes
- [x] Added to `DEVICES.md`
- [x] Reuses existing conventions; no new translation keys added
