### PR TITLE
Add Vidapool VTX016 16,000 BTU pool heat pump device configuration

### DIFF
--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -1,0 +1,152 @@
+name: Vidapool VTX016 Pool Heat Pump
+products:
+  - id: tujtt0l6dup0is9d
+    manufacturer: Vidapool
+    model: 16000 BTU Pool Heat Pump
+entities:
+  - entity: climate
+    translation_key: pool_heatpump
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: HEAT
+                value: heat
+              - dps_val: COOL
+                value: cool
+      - id: 2
+        name: mode
+        type: string
+        hidden: true
+      - id: 34
+        name: temperature
+        type: integer
+        range:
+          min: 46
+          max: 104
+      - id: 6
+        name: temperature_unit
+        type: string
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 35
+        name: current_temperature
+        type: integer
+        unit: F
+      - id: 27
+        name: hvac_action
+        type: boolean
+        mapping:
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: HEAT
+                value: heating
+              - dps_val: COOL
+                value: cooling
+          - dps_val: false
+            value: idle
+  - entity: select
+    name: HVAC Mode
+    category: config
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: HEAT
+            value: heat
+          - dps_val: COOL
+            value: cool
+  - entity: select
+    name: Fan Mode
+    category: diagnostic
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: High
+            value: high
+          - dps_val: Mid
+            value: mid
+          - dps_val: Low
+            value: low
+  - entity: sensor
+    name: Inlet Temperature
+    device_class: temperature
+    state_class: measurement
+    unit: F
+    dps:
+      - id: 35
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Ambient Temperature
+    device_class: temperature
+    state_class: measurement
+    unit: F
+    dps:
+      - id: 38
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Coiler Temperature
+    device_class: temperature
+    state_class: measurement
+    unit: F
+    dps:
+      - id: 21
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Defrost Timer
+    category: diagnostic
+    unit: min
+    dps:
+      - id: 41
+        type: integer
+        name: sensor
+  - entity: binary_sensor
+    name: Compressor State
+    icon: "mdi:engine"
+    category: diagnostic
+    dps:
+      - id: 27
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Four-way Valve
+    icon: "mdi:valve"
+    category: diagnostic
+    dps:
+      - id: 28
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: Water Flow Switch
+    device_class: opening
+    icon: "mdi:water-pump"
+    category: diagnostic
+    dps:
+      - id: 110
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    name: High Pressure Switch
+    device_class: opening
+    icon: "mdi:gauge"
+    category: diagnostic
+    dps:
+      - id: 107
+        type: boolean
+        name: sensor

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -84,37 +84,37 @@ entities:
   - entity: sensor
     name: Inlet Temperature
     class: temperature
-    unit: F
     dps:
       - id: 35
         type: integer
         name: sensor
+        unit: F
         class: measurement
   - entity: sensor
     name: Ambient Temperature
     class: temperature
-    unit: F
     dps:
       - id: 38
         type: integer
         name: sensor
+        unit: F
         class: measurement
   - entity: sensor
     name: Coiler Temperature
     class: temperature
-    unit: F
     dps:
       - id: 21
         type: integer
         name: sensor
+        unit: F
         class: measurement
   - entity: sensor
     name: Defrost Timer
     category: diagnostic
-    unit: min
     dps:
       - id: 41
         type: integer
+        unit: min
         name: sensor
   - entity: binary_sensor
     name: Compressor State

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -83,31 +83,31 @@ entities:
             value: low
   - entity: sensor
     name: Inlet Temperature
-    device_class: temperature
-    state_class: measurement
+    class: temperature
     unit: F
     dps:
       - id: 35
         type: integer
         name: sensor
+        class: measurement
   - entity: sensor
     name: Ambient Temperature
-    device_class: temperature
-    state_class: measurement
+    class: temperature
     unit: F
     dps:
       - id: 38
         type: integer
         name: sensor
+        class: measurement
   - entity: sensor
     name: Coiler Temperature
-    device_class: temperature
-    state_class: measurement
+    class: temperature
     unit: F
     dps:
       - id: 21
         type: integer
         name: sensor
+        class: measurement
   - entity: sensor
     name: Defrost Timer
     category: diagnostic
@@ -134,7 +134,7 @@ entities:
         name: sensor
   - entity: binary_sensor
     name: Water Flow Switch
-    device_class: opening
+    class: opening
     icon: "mdi:water-pump"
     category: diagnostic
     dps:
@@ -143,7 +143,7 @@ entities:
         name: sensor
   - entity: binary_sensor
     name: High Pressure Switch
-    device_class: opening
+    class: opening
     icon: "mdi:gauge"
     category: diagnostic
     dps:

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -1,4 +1,4 @@
-name: Vidapool VTX016 Pool Heat Pump
+name: Pool heat pump
 products:
   - id: tujtt0l6dup0is9d
     manufacturer: Vidapool
@@ -28,20 +28,28 @@ entities:
         name: temperature
         type: integer
         range:
-          min: 46
-          max: 104
+          min: 18
+          max: 40
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 32
+                  max: 104
       - id: 6
         name: temperature_unit
         type: string
         mapping:
-          - dps_val: c
+          - dps_val: f
+            value: F
             value: C
           - dps_val: f
             value: F
       - id: 35
         name: current_temperature
         type: integer
-        unit: F
       - id: 27
         name: hvac_action
         type: boolean
@@ -55,34 +63,6 @@ entities:
                 value: cooling
           - dps_val: false
             value: idle
-  - entity: select
-    name: HVAC Mode
-    category: config
-    dps:
-      - id: 2
-        type: string
-        name: option
-        mapping:
-          - dps_val: HEAT
-            value: heat
-          - dps_val: COOL
-            value: cool
-  - entity: select
-    name: Fan Mode
-    category: diagnostic
-    dps:
-      - id: 19
-        type: string
-        name: option
-        mapping:
-          - dps_val: High
-            value: high
-          - dps_val: Mid
-            value: mid
-          - dps_val: Low
-            value: low
-  - entity: sensor
-    name: Inlet Temperature
     class: temperature
     dps:
       - id: 35
@@ -118,12 +98,6 @@ entities:
         name: sensor
   - entity: binary_sensor
     name: Compressor State
-    icon: "mdi:engine"
-    category: diagnostic
-    dps:
-      - id: 27
-        type: boolean
-        name: sensor
   - entity: binary_sensor
     name: Four-way Valve
     icon: "mdi:valve"

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -93,6 +93,7 @@ entities:
   - entity: sensor
     name: Ambient Temperature
     class: temperature
+    translation_key: ambient_temperature
     dps:
       - id: 38
         type: integer

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -30,14 +30,6 @@ entities:
         range:
           min: 18
           max: 40
-        mapping:
-          - constraint: temperature_unit
-            conditions:
-              - dps_val: f
-                value_redirect: temp_set_f
-                range:
-                  min: 32
-                  max: 104
       - id: 6
         name: temperature_unit
         type: string

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -44,7 +44,7 @@ entities:
         mapping:
           - dps_val: f
             value: F
-          -  value: C
+          - value: C
       - id: 35
         name: current_temperature
         type: integer

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -44,7 +44,7 @@ entities:
         mapping:
           - dps_val: f
             value: F
-            value: C
+          -  value: C
       - id: 35
         name: current_temperature
         type: integer

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -45,8 +45,6 @@ entities:
           - dps_val: f
             value: F
             value: C
-          - dps_val: f
-            value: F
       - id: 35
         name: current_temperature
         type: integer
@@ -64,12 +62,6 @@ entities:
           - dps_val: false
             value: idle
     class: temperature
-    dps:
-      - id: 35
-        type: integer
-        name: sensor
-        unit: F
-        class: measurement
   - entity: sensor
     class: temperature
     translation_key: ambient_temperature

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -91,7 +91,6 @@ entities:
         unit: F
         class: measurement
   - entity: sensor
-    name: Ambient Temperature
     class: temperature
     translation_key: ambient_temperature
     dps:

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -74,6 +74,7 @@ entities:
         class: measurement
   - entity: sensor
     name: Defrost Timer
+    class: duration
     category: diagnostic
     dps:
       - id: 41

--- a/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
+++ b/custom_components/tuya_local/devices/vidapool_vtx016_poolheater.yaml
@@ -89,8 +89,6 @@ entities:
         unit: min
         name: sensor
   - entity: binary_sensor
-    name: Compressor State
-  - entity: binary_sensor
     name: Four-way Valve
     icon: "mdi:valve"
     category: diagnostic


### PR DESCRIPTION
Add device configuration for Vidapool VTX016 heat pump: [https://www.amazon.com/dp/B0H628BYXQ?ref=ppx_yo2ov_dt_b_fed_asin_title&th=1](url)

Entities included in configuration:
- Climate control - temperature setpoint, heat/cool modes
- Sensors for ambient/coiler/inlet temperatures
- Diagnostic sensors for compressor state, defrost timer, fan mdoe, four-way valve, high pressure switch, water flow switch

Configuration generated with the help of AI, though all functionality confirmed before submitting.

---

- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Please describe in simple terms what you are submitting. Do not paste a multi-page AI generated rambling story here, as the maintainers do not have time to read that.
