### PR TITLE
feat: add Bolero Ceiling Fan device from Klarstein

### DIFF
--- a/custom_components/tuya_local/devices/klarstein_bolero_ceilingfan.yaml
+++ b/custom_components/tuya_local/devices/klarstein_bolero_ceilingfan.yaml
@@ -1,0 +1,30 @@
+name: "Klarstein - Bolero Ceiling Fan with Light"
+products:
+  - id: 89y2fdsm8alx6cjx
+    manufacturer: Klarstein
+    model: "Bolero (CL23001)"
+    name: "Bolero Ceiling Fan with Light"
+entities:
+  - entity: light
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+  - entity: fan
+    dps:
+      - id: 60
+        type: boolean
+        name: switch
+      - id: 62
+        type: integer
+        name: speed
+        range:
+          min: 1
+          max: 6
+      - id: 63
+        type: string
+        name: direction
+      - id: 64
+        type: integer
+        name: fan_countdown_left
+        optional: true

--- a/custom_components/tuya_local/devices/klarstein_bolero_ceilingfan.yaml
+++ b/custom_components/tuya_local/devices/klarstein_bolero_ceilingfan.yaml
@@ -1,9 +1,9 @@
-name: "Klarstein - Bolero Ceiling Fan with Light"
+name: Ceiling fan with light
 products:
   - id: 89y2fdsm8alx6cjx
     manufacturer: Klarstein
-    model: "Bolero (CL23001)"
-    name: "Bolero Ceiling Fan with Light"
+    model: Bolero
+    model_id: CL23001
 entities:
   - entity: light
     dps:


### PR DESCRIPTION
Created a new device descriptor for Klarstein - Bolero Ceiling Fan

Descriptor has been generated assisted by Claude (Sonnet 5), based on Tuya api payloads and response.
Device tested on my own setup. Seems good.
