### PR TITLE
Add Sukflow NBQ1000-EU dual-MPPT microinverter

### DIFF
--- a/custom_components/tuya_local/devices/sukflow_nbq1000_eu_microinverter.yaml
+++ b/custom_components/tuya_local/devices/sukflow_nbq1000_eu_microinverter.yaml
@@ -1,0 +1,112 @@
+name: Solar microinverter (dual MPPT)
+products:
+  - id: dlwqvcfv08b4iosh
+    manufacturer: Sukflow
+    model: NBQ1000-EU
+entities:
+  - entity: switch
+    dps:
+      - id: 6
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    class: voltage
+    name: PV1 Voltage
+    dps:
+      - id: 114
+        type: integer
+        name: sensor
+        unit: V
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    class: current
+    name: PV1 Current
+    dps:
+      - id: 115
+        type: integer
+        name: sensor
+        unit: A
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    class: voltage
+    name: PV2 Voltage
+    dps:
+      - id: 117
+        type: integer
+        name: sensor
+        unit: V
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    class: current
+    name: PV2 Current
+    dps:
+      - id: 118
+        type: integer
+        name: sensor
+        unit: A
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    class: voltage
+    name: AC Voltage
+    dps:
+      - id: 104
+        type: integer
+        name: sensor
+        unit: V
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    class: current
+    name: AC Current
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: A
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 107
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    class: frequency
+    dps:
+      - id: 116
+        type: integer
+        name: sensor
+        unit: Hz
+
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        unit: Wh
+        class: total_increasing
+        mapping:
+          - scale: 100
+
+  - entity: sensor
+    name: Serial Number
+    category: diagnostic
+    dps:
+      - id: 111
+        type: string
+        name: sensor


### PR DESCRIPTION
Add Sukflow NBQ1000-EU dual-MPPT microinverter

Adds support for the Sukflow NBQ1000-EU 1000W dual-MPPT microinverter.

**Device info:**
- Sukflow NBQ1000-EU 1000W
- Protocol: Tuya v3.5
- Category: MPPT solar microinverter

**Verified DPs (from official Tuya Cloud schema + cross-checked with Smart Life app):**
- DP 6: switch (on/off)
- DP 7: fault bitmap
- DP 104: AC voltage 
- DP 105: AC current 
- DP 107: temperature (°C)
- DP 108: session energy 
- DP 111: device serial number
- DP 114: PV1 voltage 
- DP 115: PV1 current 
- DP 116: grid frequency (Hz)
- DP 117: PV2 voltage
- DP 118: PV2 current 