### PR TITLE
fix: add QTFV3-3 humidity value scaling

### DIFF
--- a/custom_components/tuya_local/devices/qtfv3_3_airquality.yaml
+++ b/custom_components/tuya_local/devices/qtfv3_3_airquality.yaml
@@ -42,6 +42,8 @@ entities:
         name: sensor
         unit: "%"
         class: measurement
+        mapping:
+          - scale: 10
   - entity: sensor
     class: carbon_dioxide
     dps:


### PR DESCRIPTION
Without the scale mapping, the humidity value in QTFV3-3 air quality monitor is 10 times higher (556% instead of 55.6%).
The temperature sensor already has this scaling, the humidity does not.