### PR TITLE
Vevor EV charger: add missing class for Phase A power

### DIFF
--- a/custom_components/tuya_local/devices/vevor_3_7kw_evcharger.yaml
+++ b/custom_components/tuya_local/devices/vevor_3_7kw_evcharger.yaml
@@ -83,6 +83,7 @@ entities:
         name: sensor
         optional: true
         unit: kW
+        class: measurement
         mask: "0000000000FFFFFF"
         mapping:
           - scale: 1000

--- a/custom_components/tuya_local/devices/vevor_ev_charger.yaml
+++ b/custom_components/tuya_local/devices/vevor_ev_charger.yaml
@@ -86,6 +86,7 @@ entities:
         name: sensor
         optional: true
         unit: kW
+        class: measurement
         mask: "0000000000FFFFFF"
         mapping:
           - scale: 1000


### PR DESCRIPTION
The measurement class is needed to be able to add the current power to the energy dashboard.
