### PR TITLE
Fix Parkside mower STANDBY state mapping

### DIFF
--- a/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
@@ -18,7 +18,7 @@ entities:
         type: string
         mapping:
           - dps_val: STANDBY
-            value: paused
+            value: docked
           - dps_val: MOWING
             value: mowing
           - dps_val: CHARGING


### PR DESCRIPTION
Restore `STANDBY` mapping to `docked`.

This regression was introduced by commit [44172eb](https://github.com/make-all/tuya-local/commit/44172eb33ab4dd326058c1afed385e509c78416b) when moving the Parkside mower configuration from `moebot_s_mower.yaml` to `parkside_bluetooth_mower.yaml`.

On my Parkside mower, `STANDBY` means the mower is in the dock. The paused state is reported separately as `PAUSED`, matching Home Assistant's lawn mower state definitions.