### PR TITLE
[Kibernetik 12K Airconditioner] added heating mode, constrained temperature range to fit the air conditioner

### DIFF
--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
@@ -18,26 +18,18 @@ entities:
             conditions:
               - dps_val: COOL
                 value: cool
+              - dps_val: HEAT
+                value: heat
               - dps_val: FAN
                 value: fan_only
-              # dp4 also lists HEAT, but this is a cool-only model (see dp110).
-              # Left out until a heat-capable model can confirm it.
               - dps_val: DRY
                 value: dry
       - id: 2
         name: temperature
         type: integer
-        mapping:
-          - constraint: temperature_unit
-            conditions:
-              - dps_val: C
-                range:
-                  min: 16
-                  max: 32
-              - dps_val: F
-                range:
-                  min: 60
-                  max: 90
+        range:
+          min: 16
+          max: 30
       - id: 3
         name: current_temperature
         type: integer

--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
@@ -27,9 +27,17 @@ entities:
       - id: 2
         name: temperature
         type: integer
-        range:
-          min: 16
-          max: 30
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: c
+                range:
+                  min: 16
+                  max: 30
+              - dps_val: f
+                range:
+                  min: 60
+                  max: 90
       - id: 3
         name: current_temperature
         type: integer
@@ -84,9 +92,9 @@ entities:
         type: string
         name: option
         mapping:
-          - dps_val: C
+          - dps_val: c
             value: celsius
-          - dps_val: F
+          - dps_val: f
             value: fahrenheit
   - entity: switch
     translation_key: auto_dry

--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner.yaml
@@ -2,7 +2,7 @@ name: Air conditioner
 products:
   - id: deedvplnx2yvge08
     manufacturer: Kibernetik
-    model: 12K portable split
+    model: 12K portable split cool only
 entities:
   - entity: climate
     translation_only_key: aircon_extra
@@ -18,10 +18,10 @@ entities:
             conditions:
               - dps_val: COOL
                 value: cool
-              - dps_val: HEAT
-                value: heat
               - dps_val: FAN
                 value: fan_only
+              # dp4 also lists HEAT, but this is a cool-only model (see dp110).
+              # Left out until a heat-capable model can confirm it.
               - dps_val: DRY
                 value: dry
       - id: 2
@@ -33,7 +33,7 @@ entities:
               - dps_val: c
                 range:
                   min: 16
-                  max: 30
+                  max: 32
               - dps_val: f
                 range:
                   min: 60
@@ -92,9 +92,9 @@ entities:
         type: string
         name: option
         mapping:
-          - dps_val: c
+          - dps_val: C
             value: celsius
-          - dps_val: f
+          - dps_val: F
             value: fahrenheit
   - entity: switch
     translation_key: auto_dry

--- a/custom_components/tuya_local/devices/kibernetik_12k_airconditioner_heat_and_cool.yaml
+++ b/custom_components/tuya_local/devices/kibernetik_12k_airconditioner_heat_and_cool.yaml
@@ -1,0 +1,144 @@
+name: Air conditioner
+products:
+  - id: deedvplnx2yvge08
+    manufacturer: Kibernetik
+    model: 12K portable split heat & cool
+entities:
+  - entity: climate
+    translation_only_key: aircon_extra
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: COOL
+                value: cool
+              - dps_val: HEAT
+                value: heat
+              - dps_val: FAN
+                value: fan_only
+              - dps_val: DRY
+                value: dry
+      - id: 2
+        name: temperature
+        type: integer
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: c
+                range:
+                  min: 16
+                  max: 30
+              - dps_val: f
+                range:
+                  min: 60
+                  max: 90
+      - id: 3
+        name: current_temperature
+        type: integer
+      - id: 4
+        name: mode
+        type: string
+        hidden: true
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: quiet
+          - dps_val: "2"
+            value: low
+          - dps_val: "3"
+            value: medium
+          - dps_val: "4"
+            value: high
+          - dps_val: "5"
+            value: strong
+      - id: 19
+        name: temperature_unit
+        type: string
+      - id: 101
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: sleep
+          - dps_val: false
+            value: comfort
+      - id: 104
+        name: swing_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            value: "vertical"
+          - dps_val: false
+            value: "off"
+      - id: 110
+        # "model" per Tuya data model; meaning of values unconfirmed.
+        # This cool-only 5-speed unit reports "0" - a heat-capable or
+        # 3-speed model may report differently (may gate heat/fan speeds).
+        name: model
+        type: string
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+  - entity: switch
+    translation_key: auto_dry
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+  - entity: number
+    translation_key: timer
+    category: config
+    class: duration
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 24
+  - entity: sensor
+    translation_key: time_remaining
+    category: diagnostic
+    class: duration
+    dps:
+      - id: 105
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 102
+        type: boolean
+        name: sensor
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 106
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true


### PR DESCRIPTION
Added support for heating mode for this device (supports it, can confirm) and fixed the homeassistant climate entity not being limited to the devices capabilities, causing usability problems (device supports 16°C to 30°C, not the standard 7°C to 35°C).

Updated temperature range for the air conditioner and added HEAT mode.
