### PR TITLE
Add dedicated config for Parkside PMRDA 20-Li A1 mower with integer DP 121 type

### DIFF
--- a/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_bluetooth_mower.yaml
@@ -7,9 +7,6 @@ products:
   - id: 7yr5iwga
     manufacturer: Parkside
     model: PMRC 250 Ai Bluetooth
-  - id: icw5sal7xfcevsve
-    manufacturer: Parkside
-    model: PMRDA 20-Li A1
 entities:
   - entity: lawn_mower
     dps:

--- a/custom_components/tuya_local/devices/parkside_pmrda_mower.yaml
+++ b/custom_components/tuya_local/devices/parkside_pmrda_mower.yaml
@@ -1,0 +1,399 @@
+name: Lawnmower
+products:
+  - id: icw5sal7xfcevsve
+    manufacturer: Parkside
+    model: PMRDA 20-Li A1
+entities:
+  - entity: lawn_mower
+    dps:
+      - id: 101
+        name: activity
+        type: string
+        mapping:
+          - dps_val: STANDBY
+            value: docked
+          - dps_val: MOWING
+            value: mowing
+          - dps_val: CHARGING
+            value: docked
+          - dps_val: EMERGENCY
+            value: error
+          - dps_val: LOCKED
+            value: docked
+          - dps_val: PAUSED
+            value: paused
+          - dps_val: PARK
+            value: returning
+          - dps_val: CHARGING_WITH_TASK_SUSPEND
+            value: docked
+          - dps_val: FIXED_MOWING
+            value: mowing
+          - dps_val: ERROR
+            value: error
+          - dps_val: UPDATA
+            value: docked
+          - dps_val: SELF_TEST
+            value: docked
+          - dps_val: EDGE
+            value: mowing
+      - id: 115
+        name: command
+        type: string
+        optional: true
+        mapping:
+          - dps_val: StartMowing
+            value: start_mowing
+          - dps_val: StartFixedMowing
+            value: start_mowing
+            hidden: true
+          - dps_val: PauseWork
+            value: pause
+          - dps_val: CancelWork
+            value: pause
+            hidden: true
+          - dps_val: ContinueWork
+            value: start_mowing
+            hidden: true
+          - dps_val: StartReturnStation
+            value: dock
+          - dps_val: EDGE
+            value: start_mowing
+            hidden: true
+      - id: 101
+        name: raw_activity
+        type: string
+      - id: 106
+        type: integer
+        name: password
+        sensitive: true
+      - id: 110
+        type: string
+        name: schedule
+        optional: true
+      - id: 112
+        type: string
+        name: work_log
+        optional: true
+      - id: 113
+        type: string
+        name: zones
+        optional: true
+      - id: 134
+        type: string
+        name: firmware_version
+        optional: true
+  - entity: button
+    name: Start fixed mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: StartFixedMowing
+            value: true
+  - entity: button
+    name: Cancel work
+    icon: "mdi:mower"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: CancelWork
+            value: true
+  - entity: button
+    name: Continue mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: ContinueWork
+            value: true
+  - entity: button
+    name: Edge mowing
+    icon: "mdi:mower-on"
+    dps:
+      - id: 115
+        type: string
+        name: button
+        optional: true
+        mapping:
+          - dps_val: EDGE
+            value: true
+  - entity: sensor
+    class: battery
+    dps:
+      - id: 6
+        type: integer
+        optional: true
+        name: sensor
+        unit: "%"
+        class: measurement
+        mapping:
+          - dps_val: null
+            value_redirect: alt
+      - id: 13
+        type: integer
+        optional: true
+        name: alt
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 102
+        type: bitfield
+        name: sensor
+        optional: true
+        persist: false
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 102
+        type: bitfield
+        optional: true
+        name: fault_code
+      - id: 111
+        type: string
+        name: error_log
+        optional: true
+  - entity: sensor
+    name: Problem
+    icon: "mdi:robot-mower-outline"
+    icon_priority: 2
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 103
+        name: sensor
+        type: string
+        optional: true
+        persist: false
+        mapping:
+          - dps_val: null
+            value: OK
+          - dps_val: MOWER_LEAN
+            value: Tilted
+            icon: "mdi:angle-acute"
+            icon_priority: 1
+          - dps_val: MOWER_STEEP
+            value: Steep
+            icon: "mdi:slope-uphill"
+            icon_priority: 1
+          - dps_val: RAIN_PARK
+            value: Raining
+            icon: "mdi:weather-pouring"
+            icon_priority: 1
+          - dps_val: BATTERY_NOT_ENOUGH
+            value: Low battery
+            icon: "mdi:battery-low"
+            icon_priority: 1
+          - dps_val: NO_LOOP_SIGNAL
+            value: Weak signal
+            icon: "mdi:signal-cellular-1"
+            icon_priority: 1
+          - dps_val: CLOSE_TOPCOVER
+            value: Close top cover
+            icon: "mdi:door-open"
+            icon_priority: 1
+          - dps_val: MOWER_IN_STATION
+            value: Docked
+            icon: "mdi:mower"
+            icon_priority: 1
+          - dps_val: MOWER_OUT_STATION
+            value: Undocked
+            icon: "mdi:mower-on"
+            icon_priority: 1
+          - dps_val: PLACE_INSIDE_STATION
+            value: Manually dock
+            icon: "mdi:home-alert"
+            icon_priority: 1
+          - dps_val: PLACE_INSIDE
+            value: Manually dock
+            icon: "mdi:home-alert"
+            icon_priority: 1
+          - dps_val: FIXED_END
+            value: Finished fixed mowing
+            icon: "mdi:mower"
+            icon_priority: 1
+          - dps_val: CHARGING_DISCONNECT
+            value: Disconnected
+            icon: "mdi:power-plug-battery"
+            icon_priority: 1
+          - dps_val: CHARGING_PAUSE
+            value: Paused charging
+            icon: "mdi:battery-clock"
+            icon_priority: 1
+          - dps_val: WORK_INTERRUPT
+            value: Interrupted
+            icon: "mdi:alert-octogon"
+            icon_priority: 1
+          - dps_val: FIXED_MOWING_INTERRUPT
+            value: Interrupted fixed mowing
+            icon: "mdi:alert-octogon"
+            icon_priority: 1
+          - dps_val: FIXED_MOWING_INTERUPT
+            value: Interrupted fixed mowing
+            icon: "mdi:alert-octogon"
+            icon_priority: 1
+          - dps_val: TURN_ON_BUTTON
+            value: Turn on button
+            icon: "mdi:button-pointer"
+            icon_priority: 1
+          - dps_val: PRESS_START_KEY
+            value: Press start
+            icon: "mdi:play"
+            icon_priority: 1
+          - dps_val: TIMESET_30MIN
+            value: Set 30 minute timer
+            icon: "mdi:fast-forward-30"
+            icon_priority: 1
+          - dps_val: TIMESET_UNLEGAL
+            value: Invalid timer
+            icon: "mdi:timer-alert"
+            icon_priority: 1
+          - dps_val: CHARGR_CURRENT_LOW
+            value: Charging current low
+            icon: "mdi:flash-alert"
+            icon_priority: 1
+          - dps_val: RAIN_OUT_STATION
+            value: Caught in rain
+            icon: "mdi:weather-pouring"
+            icon_priority: 1
+          - dps_val: UPDATA_FAIL
+            value: Data upload failure
+            icon: "mdi:cloud-alert"
+            icon_priority: 1
+          - dps_val: CONTINUE_TOOLTIP
+            value: Continue
+            icon: "mdi:step-forward"
+            icon_priority: 1
+          - dps_val: MOWER_EMERGENCY
+            value: Stopped
+            icon: "mdi:octagon"
+            icon_priority: 1
+          - dps_val: MOWER_UI_LOCKED
+            value: UI locked
+            icon: "mdi:hand-back-right-off"
+            icon_priority: 1
+          - dps_val: DISCHARGE_ERROR
+            value: Discharge error
+            icon: "mdi:battery-alert"
+            icon_priority: 1
+          - dps_val: CHARGE_TEMP_ERROR
+            value: Charging temperature error
+            icon: "mdi:thermometer-alert"
+            icon_priority: 1
+          - dps_val: HEDGEHOG
+            value: Hedgehog detected
+            icon: "mdi:paw"
+            icon_priority: 1
+          - dps_val: NTC
+            value: Temperature sensor error
+            icon: "mdi:thermometer-alert"
+            icon_priority: 1
+  - entity: switch
+    name: Rain mode
+    icon: "mdi:weather-pouring"
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+  - entity: number
+    name: Running time
+    category: config
+    icon: "mdi:clock"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 1
+          max: 24
+  - entity: button
+    name: Clear schedule
+    icon: "mdi:calendar-remove"
+    category: config
+    dps:
+      - id: 107
+        type: boolean
+        name: button
+        optional: true
+  - entity: button
+    name: Refresh schedule
+    icon: "mdi:calendar-refresh"
+    category: config
+    dps:
+      - id: 108
+        type: boolean
+        name: button
+        optional: true
+  - entity: button
+    name: Refresh zones
+    icon: "mdi:map-search"
+    category: config
+    dps:
+      - id: 109
+        type: boolean
+        name: button
+        optional: true
+
+  - entity: button
+    name: Clear zones
+    icon: "mdi:map-marker-remove"
+    category: config
+    dps:
+      - id: 114
+        type: boolean
+        name: button
+        optional: true
+  - entity: binary_sensor
+    name: Cover
+    category: diagnostic
+    dps:
+      - id: 116
+        type: boolean
+        name: sensor
+        optional: true
+  - entity: switch
+    name: Hedgehog protection
+    icon: "mdi:account-group"
+    category: config
+    dps:
+      - id: 118
+        type: boolean
+        name: switch
+        optional: true
+  - entity: switch
+    name: Backward blade stop
+    icon: "mdi:saw-blade"
+    category: config
+    hidden: unavailable
+    dps:
+      - id: 121
+        type: integer
+        name: switch
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 1
+            value: true
+      - id: 121
+        type: integer
+        optional: true
+        name: available
+        mapping:
+          - dps_val: null
+            value: false
+          - value: true


### PR DESCRIPTION
## 🔍 Problem
The Parkside PMRDA 20-Li A1 mower was previously included in the shared `parkside_bluetooth_mower.yaml` config file, but newer Parkside mower models (e.g., PAMRC 250) send DP 121 as a JSON boolean (`true`/`false`), while the PMRDA 20-Li A1 sends it as an integer (`0`/`1`).

This type mismatch caused:
- ❌ The PMRDA 20-Li A1 device not appearing in the GUI device selection
- ❌ Incompatibility with the boolean-based configs of newer models

## ✅ Solution
- **Created dedicated config file**: `parkside_pmrda_mower.yaml` for the PMRDA 20-Li A1
- **Removed the device from shared config**: Removed PMRDA 20-Li A1 (icw5sal7xfcevsve) from `parkside_bluetooth_mower.yaml`
- **Preserved integer type for DP 121**: The new config correctly defines DP 121 as `type: integer` with proper mappings (0 → false, 1 → true)
- **Backward compatible**: No breaking changes for other Parkside mower models

## 📋 Changes
- **New file**: `parkside_pmrda_mower.yaml` (399 lines) – complete config for PMRDA 20-Li A1
- **Modified**: `parkside_bluetooth_mower.yaml` – removed PMRDA 20-Li A1 device entry

## 🎯 Impact
- ✓ PMRDA 20-Li A1 is now selectable in the GUI
- ✓ Newer Parkside models with boolean DP 121 continue to work correctly
- ✓ No regressions for other devices