### PR TITLE
Add Hantech 9000 BTU portable air conditioner

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -138,6 +138,7 @@
 - Fujicool Yuzu heat pump
 - Goldair GCPAC350W portable air conditioner
 - Haier Airmart wall air conditioner
+- Hantech 9000 BTU portable air conditioner
 - Hokkaido HKEDM 263 ZL air conditioner
 - HTW IX75B air conditioner
 - Idea Heating Belt (with CS1 USB dongle)

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -138,7 +138,6 @@
 - Fujicool Yuzu heat pump
 - Goldair GCPAC350W portable air conditioner
 - Haier Airmart wall air conditioner
-- Hantech 9000 BTU portable air conditioner
 - Hokkaido HKEDM 263 ZL air conditioner
 - HTW IX75B air conditioner
 - Idea Heating Belt (with CS1 USB dongle)

--- a/custom_components/tuya_local/devices/costway_portable_ac.yaml
+++ b/custom_components/tuya_local/devices/costway_portable_ac.yaml
@@ -2,6 +2,9 @@ name: Portable air conditioner
 products:
   - id: 86sjxqebxymrjt3z
     manufacturer: Costway
+  - id: av6ejal3j9epuw3e
+    manufacturer: Hantech
+    model: 9000 BTU
 entities:
   - entity: climate
     dps:
@@ -42,15 +45,31 @@ entities:
             value: low
           - dps_val: high
             value: high
-      - id: 20
-        type: integer
-        name: unknown_20
-      - id: 103
-        type: boolean
-        name: unknown_103
       - id: 107
         type: integer
-        name: unknown_106
+        name: temp_set_f
+        hidden: true
       - id: 109
         type: integer
-        name: unknown_107
+        name: unknown_109
+  - entity: switch
+    translation_key: sleep
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 20
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 20
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
Adds a device profile for the Hantech 9000 BTU mobile air conditioner (Tuya category `ydkt`, product id `av6ejal3j9epuw3e`).

The official Tuya integration cannot map this device: the cloud returns an empty function/status schema (DP Instruction mode) and category `ydkt` is not covered. It shares the OEM base of the Cecotec ForceClima Soundless, but without heat mode and without the swing DP (110).

All DP behaviour was verified locally over the LAN with tinytuya (protocol 3.5) and confirmed working in Home Assistant via tuya-local:

- Power (1), target temperature (2, 16-30 C), current temperature (3)
- Mode (4): `cold`->cool, `wet`->dry, `wind`->fan_only (no heat/auto)
- Fan (5): low / high only
- Sleep switch (103), fault (20, bitfield), temperature F mirror (107, hidden)
- dp109 is read-only (always 0)

The `problem` and `tank_full` fault mappings on dp20 are inherited from the ForceClima OEM base; dp20 read 0 throughout testing, so the other fault codes were not individually exercised.