### PR TITLE
Oscal PowerMax2400Pro (EU) fixes and additions

### DIFF
--- a/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
+++ b/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
@@ -64,10 +64,10 @@ entities:
         type: string
         name: unit
         mapping:
-          - dps_val: f
-            value: F
           - dps_val: c
             value: C
+          - dps_val: f
+            value: F
   - entity: switch
     translation_key: keytone
     category: config
@@ -94,23 +94,27 @@ entities:
           - dps_val: f
             value: fahrenheit
   - entity: switch
-    name: Buzzer (Beep)
+    translation_key: sound
     category: config
-    icon: "mdi:volume-high"
     dps:
       - id: 25
         type: boolean
         name: switch
   - entity: sensor
-    name: Time Remaining (Hours)
-    icon: "mdi:timer-sand"
+    translation_key: time_remaining
     category: diagnostic
+    class: duration
     dps:
+      - id: 108
+        type: integer
+        name: day
       - id: 37
         type: integer
         name: sensor
         unit: h
-        class: measurement
+      - id: 127
+        type: integer
+        name: minute
   - entity: switch
     name: Notifications
     category: config
@@ -172,15 +176,6 @@ entities:
         range:
           min: 0
           max: 30
-  - entity: sensor
-    name: Time Remaining (Days)
-    icon: "mdi:calendar-clock"
-    category: diagnostic
-    dps:
-      - id: 108
-        type: integer
-        name: sensor
-        unit: d
   - entity: select
     name: Display timeout
     icon: "mdi:television-ambient-light"
@@ -202,8 +197,8 @@ entities:
           - dps_val: "never_close"
             value: "cancel"
   - entity: sensor
-    name: Device Status
     class: enum
+    translation_key: status
     category: diagnostic
     dps:
       - id: 110
@@ -371,19 +366,11 @@ entities:
         name: sensor
         unit: W
         class: measurement
-  - entity: sensor
-    name: Time Remaining (Minutes)
-    icon: "mdi:timer-sand"
-    category: diagnostic
-    dps:
-      - id: 127
-        type: integer
-        name: sensor
-        unit: min
   - entity: number
     name: AC charging limit
     icon: "mdi:battery-charging-90"
     category: config
+    class: power
     dps:
       - id: 128
         type: integer
@@ -557,47 +544,37 @@ entities:
             value: "12h"
           - dps_val: "24hour"
             value: "24h"
-  - entity: number
-    name: Primary feed-in start hour
+  - entity: time
+    name: Primary feed-in time period start
     category: config
     icon: "mdi:clock-start"
     dps:
       - id: 143
         type: integer
-        name: value
+        name: hour
         range:
           min: 0
           max: 23
-  - entity: number
-    name: Primary feed-in start minute
-    category: config
-    icon: "mdi:clock-start"
-    dps:
       - id: 144
         type: integer
-        name: value
+        name: minute
         range:
           min: 0
           max: 59
-  - entity: number
-    name: Primary feed-in end hour
+  - entity: time
+    name: Primary feed-in time period end
     category: config
     icon: "mdi:clock-end"
     dps:
       - id: 145
         type: integer
-        name: value
+        name: hour
         range:
           min: 0
           max: 23
-  - entity: number
-    name: Primary feed-in end minute
-    category: config
-    icon: "mdi:clock-end"
-    dps:
       - id: 146
         type: integer
-        name: value
+        name: minute
         range:
           min: 0
           max: 59
@@ -614,47 +591,37 @@ entities:
           max: 800
         mapping:
           - step: 50
-  - entity: number
-    name: Secondary feed-in start hour
+  - entity: time
+    name: Secondary feed-in time period start
     category: config
     icon: "mdi:clock-start"
     dps:
       - id: 148
         type: integer
-        name: value
+        name: hour
         range:
           min: 0
           max: 23
-  - entity: number
-    name: Secondary feed-in start minute
-    category: config
-    icon: "mdi:clock-start"
-    dps:
       - id: 149
         type: integer
-        name: value
+        name: minute
         range:
           min: 0
           max: 59
-  - entity: number
-    name: Secondary feed-in end hour
+  - entity: time
+    name: Secondary feed-in time period end
     category: config
     icon: "mdi:clock-end"
     dps:
       - id: 150
         type: integer
-        name: value
+        name: hour
         range:
           min: 0
           max: 23
-  - entity: number
-    name: Secondary feed-in end minute
-    category: config
-    icon: "mdi:clock-end"
-    dps:
       - id: 151
         type: integer
-        name: value
+        name: minute
         range:
           min: 0
           max: 59

--- a/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
+++ b/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
@@ -657,3 +657,4 @@ entities:
         name: value
         range:
           min: 0
+          max: 59

--- a/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
+++ b/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
@@ -47,6 +47,8 @@ entities:
             value: Bright
           - dps_val: sos
             value: Emergency
+          - dps_val: breath
+            value: Pulse
           - dps_val: flash
             value: Flash
   - entity: sensor
@@ -64,7 +66,8 @@ entities:
         mapping:
           - dps_val: f
             value: F
-          - value: C
+          - dps_val: c
+            value: C
   - entity: switch
     translation_key: keytone
     category: config
@@ -91,15 +94,16 @@ entities:
           - dps_val: f
             value: fahrenheit
   - entity: switch
-    translation_key: sound
+    name: Buzzer (Beep)
     category: config
+    icon: "mdi:volume-high"
     dps:
       - id: 25
         type: boolean
         name: switch
   - entity: sensor
-    class: duration
-    name: Generation time
+    name: Time Remaining (Hours)
+    icon: "mdi:timer-sand"
     category: diagnostic
     dps:
       - id: 37
@@ -169,8 +173,8 @@ entities:
           min: 0
           max: 30
   - entity: sensor
-    name: Estimated battery life
-    class: duration
+    name: Time Remaining (Days)
+    icon: "mdi:calendar-clock"
     category: diagnostic
     dps:
       - id: 108
@@ -198,20 +202,20 @@ entities:
           - dps_val: "never_close"
             value: "cancel"
   - entity: sensor
+    name: Device Status
     class: enum
-    translation_key: status
     category: diagnostic
     dps:
       - id: 110
         type: string
         name: sensor
         mapping:
-          - dps_val: "1"
-            value: charging
-          - dps_val: "2"
-            value: discharging
           - dps_val: "0"
+            value: discharging
+          - dps_val: "1"
             value: standby
+          - dps_val: "2"
+            value: charging
   - entity: sensor
     name: AC input
     class: power
@@ -233,11 +237,18 @@ entities:
         unit: W
         class: measurement
   - entity: switch
-    name: Slow charge
+    name: Bluetooth speaker
     category: config
-    icon: "mdi:battery-charging"
+    icon: "mdi:speaker-bluetooth"
     dps:
       - id: 114
+        type: boolean
+        name: switch
+  - entity: switch
+    name: Grid feed-in
+    category: config
+    dps:
+      - id: 115
         type: boolean
         name: switch
   - entity: sensor
@@ -273,6 +284,19 @@ entities:
         range:
           min: 0
           max: 255
+  - entity: number
+    name: Primary feed-in limit
+    category: config
+    dps:
+      - id: 119
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 50
+          max: 800
+        mapping:
+          - step: 50
   - entity: sensor
     name: Pack 1
     class: battery
@@ -283,10 +307,6 @@ entities:
         name: sensor
         unit: "%"
         class: measurement
-      - id: 119
-        type: integer
-        optional: true
-        name: pack_id
   - entity: sensor
     name: Pack 1 temperature
     class: temperature
@@ -352,28 +372,26 @@ entities:
         unit: W
         class: measurement
   - entity: sensor
-    translation_key: time_remaining
-    class: duration
+    name: Time Remaining (Minutes)
+    icon: "mdi:timer-sand"
     category: diagnostic
     dps:
       - id: 127
         type: integer
         name: sensor
         unit: min
-        class: measurement
   - entity: number
-    name: Slow charge
+    name: AC charging limit
+    icon: "mdi:battery-charging-90"
     category: config
-    class: power
     dps:
       - id: 128
         type: integer
-        optional: true
         name: value
         unit: W
         range:
           min: 100
-          max: 1200
+          max: 1400
         mapping:
           - step: 100
   - entity: sensor
@@ -488,9 +506,10 @@ entities:
         unit: W
         class: measurement
   - entity: select
-    name: AC timer
+    name: AC Standby Time
     class: timer
     category: config
+    icon: "mdi:timer-outline"
     dps:
       - id: 139
         type: string
@@ -513,8 +532,10 @@ entities:
           - dps_val: "24hour"
             value: "24h"
   - entity: select
+    name: DC Standby Time
     class: timer
     category: config
+    icon: "mdi:timer-outline"
     dps:
       - id: 140
         type: string
@@ -536,3 +557,103 @@ entities:
             value: "12h"
           - dps_val: "24hour"
             value: "24h"
+  - entity: number
+    name: Primary feed-in start hour
+    category: config
+    icon: "mdi:clock-start"
+    dps:
+      - id: 143
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 23
+  - entity: number
+    name: Primary feed-in start minute
+    category: config
+    icon: "mdi:clock-start"
+    dps:
+      - id: 144
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 59
+  - entity: number
+    name: Primary feed-in end hour
+    category: config
+    icon: "mdi:clock-end"
+    dps:
+      - id: 145
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 23
+  - entity: number
+    name: Primary feed-in end minute
+    category: config
+    icon: "mdi:clock-end"
+    dps:
+      - id: 146
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 59
+  - entity: number
+    name: Secondary feed-in limit
+    category: config
+    dps:
+      - id: 147
+        type: integer
+        name: value
+        unit: W
+        range:
+          min: 50
+          max: 800
+        mapping:
+          - step: 50
+  - entity: number
+    name: Secondary feed-in start hour
+    category: config
+    icon: "mdi:clock-start"
+    dps:
+      - id: 148
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 23
+  - entity: number
+    name: Secondary feed-in start minute
+    category: config
+    icon: "mdi:clock-start"
+    dps:
+      - id: 149
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 59
+  - entity: number
+    name: Secondary feed-in end hour
+    category: config
+    icon: "mdi:clock-end"
+    dps:
+      - id: 150
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 23
+  - entity: number
+    name: Secondary feed-in end minute
+    category: config
+    icon: "mdi:clock-end"
+    dps:
+      - id: 151
+        type: integer
+        name: value
+        range:
+          min: 0

--- a/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
+++ b/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
@@ -64,10 +64,9 @@ entities:
         type: string
         name: unit
         mapping:
-          - dps_val: c
-            value: C
           - dps_val: f
             value: F
+          - value: C
   - entity: switch
     translation_key: keytone
     category: config
@@ -493,7 +492,7 @@ entities:
         unit: W
         class: measurement
   - entity: select
-    name: AC Standby Time
+    name: AC standby sime
     class: timer
     category: config
     icon: "mdi:timer-outline"
@@ -519,7 +518,7 @@ entities:
           - dps_val: "24hour"
             value: "24h"
   - entity: select
-    name: DC Standby Time
+    name: DC standby time
     class: timer
     category: config
     icon: "mdi:timer-outline"
@@ -545,7 +544,7 @@ entities:
           - dps_val: "24hour"
             value: "24h"
   - entity: time
-    name: Primary feed-in time period start
+    name: Primary feed-in start
     category: config
     icon: "mdi:clock-start"
     dps:
@@ -562,7 +561,7 @@ entities:
           min: 0
           max: 59
   - entity: time
-    name: Primary feed-in time period end
+    name: Primary feed-in end
     category: config
     icon: "mdi:clock-end"
     dps:
@@ -592,7 +591,7 @@ entities:
         mapping:
           - step: 50
   - entity: time
-    name: Secondary feed-in time period start
+    name: Secondary feed-in start
     category: config
     icon: "mdi:clock-start"
     dps:
@@ -609,7 +608,7 @@ entities:
           min: 0
           max: 59
   - entity: time
-    name: Secondary feed-in time period end
+    name: Secondary feed-in end
     category: config
     icon: "mdi:clock-end"
     dps:

--- a/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
+++ b/custom_components/tuya_local/devices/oscal_powermax2400pro_portablepower.yaml
@@ -107,11 +107,11 @@ entities:
     dps:
       - id: 108
         type: integer
-        name: day
+        name: sensor
+        unit: d
       - id: 37
         type: integer
-        name: sensor
-        unit: h
+        name: hour
       - id: 127
         type: integer
         name: minute


### PR DESCRIPTION
Corresponding issue: https://github.com/make-all/tuya-local/issues/5657

- dp 9: Added "breath" option, which is a slow pulse of the light
- dp 24: missing dps_val for centigrade
- dp 25: that's not just "sound", it's a toggle that makes the box beep until toggled off, renamed it
- dps 108,37,127: That's days/hours/minutes of the remaining time (charging/discharging)
- dp 110: status assignments were incorrect
- dp 114: That's a toggle for the bluetooth speaker, not "Slow charge"
- dp 115: Toggle for the Grid feed-in function
- dp 119: This isn't the pack id, it's the power limit for the primary feed-in period
- dp 128: This is the AC charging limit and it goes up to 1400, not 1200. Also renamed it to "AC charging limit"
- dp 139: renamed from AC timer to "AC Standby Time"
- dp 140: added name "DC Standby Time"
- dps 143-146: Primary feed-in period starting and ending times
- dp 147: Secondary feed-in period power limit
- dps 148-151: Secondary feed-in period starting and ending times
