### PR TITLE
Add ProfiCook PC-WKS 1167 G kettle operation mode

### DIFF
--- a/custom_components/tuya_local/devices/koenic_ktm_kettle.yaml
+++ b/custom_components/tuya_local/devices/koenic_ktm_kettle.yaml
@@ -3,10 +3,36 @@ products:
   - id: d9wi3si7ytqma30a
     manufacturer: Koenic
     model: KTM 221723 M
+  - id: h6MjwrnldNTu4kX3
+    manufacturer: ProfiCook
+    model: PC-WKS 1167 G
 entities:
   - entity: water_heater
     translation_key: kettle
     dps:
+      - id: 101
+        type: string
+        name: operation_mode
+        mapping:
+          - dps_val: "0"
+            value: electric
+            hidden: true
+          - dps_val: "1"
+            value: electric
+            hidden: true
+          - dps_val: "2"
+            value: electric
+            hidden: true
+          - dps_val: "3"
+            value: electric
+            hidden: true
+          - dps_val: "4"
+            value: electric
+          - dps_val: "5"
+            value: electric
+            hidden: true
+          - dps_val: "6"
+            value: "off"
       - id: 102
         type: integer
         name: temperature

--- a/custom_components/tuya_local/devices/koenic_ktm_kettle.yaml
+++ b/custom_components/tuya_local/devices/koenic_ktm_kettle.yaml
@@ -14,25 +14,12 @@ entities:
         type: string
         name: operation_mode
         mapping:
-          - dps_val: "0"
-            value: electric
-            hidden: true
-          - dps_val: "1"
-            value: electric
-            hidden: true
-          - dps_val: "2"
-            value: electric
-            hidden: true
-          - dps_val: "3"
-            value: electric
-            hidden: true
           - dps_val: "4"
             value: electric
-          - dps_val: "5"
-            value: electric
-            hidden: true
           - dps_val: "6"
             value: "off"
+          - value: electric
+            hidden: true
       - id: 102
         type: integer
         name: temperature


### PR DESCRIPTION
## What changed

- Add the ProfiCook PC-WKS 1167 G product ID to the existing Koenic KTM kettle profile.
- Expose DP 101 as the water heater `operation_mode` while keeping the existing detailed mode select.
- Map standby to `off` and active programs to `electric`; writing `electric` selects DP 101 mode `4` (boil).

## Why

The profile currently exposes target and current temperatures but no water-heater operation state. Home Assistant therefore reports the entity state as `unknown`, with no `operation_list`. Consumers such as Yandex Smart Home can expose an `on_off` capability for the water heater but cannot translate it into a supported Home Assistant action.

The ProfiCook product and DP semantics are documented in the matching Blakadder template:
https://github.com/blakadder/templates/blob/master/_templates/proficook_PC-WKS_1167

## Validation

- `uv run pytest tests/test_device_config.py` — 32 passed
- `uv run pytest` — 403 passed
- `uv run ruff check .`
- `uv run ruff check --select I .`
- `uv run ruff format --check .`
- `uv run yamllint custom_components/tuya_local/devices`

Live validation on Home Assistant 2026.7.3 with tuya-local 2026.7.2:

- DP 101 mode `6` reports `state: off` and `operation_list: [electric, off]`.
- `water_heater.set_operation_mode: electric` selects DP 101 mode `4`; the existing select reports `boil` and the status sensor reports `heating`.
- `water_heater.set_operation_mode: off` selects DP 101 mode `6`; the select reports `off` and the status sensor reports `idle`.
- Yandex Smart Home on/off commands successfully start and stop the kettle without the previous `NOT_SUPPORTED_IN_CURRENT_MODE` error.
