### PR TITLE
fix(petoneer_fresco_ezgo_petfountain): map status code 32

### DIFF
--- a/custom_components/tuya_local/devices/petoneer_fresco_ezgo_petfountain.yaml
+++ b/custom_components/tuya_local/devices/petoneer_fresco_ezgo_petfountain.yaml
@@ -118,6 +118,8 @@ entities:
             value: "Pump clogged"
           - dps_val: 16
             value: "Pump not detected"
+          - dps_val: 32
+            value: "Water level low"
   - entity: binary_sensor
     name: Geyser mode status
     category: diagnostic

--- a/custom_components/tuya_local/devices/petoneer_fresco_ezgo_petfountain.yaml
+++ b/custom_components/tuya_local/devices/petoneer_fresco_ezgo_petfountain.yaml
@@ -98,6 +98,8 @@ entities:
         mapping:
           - dps_val: 0
             value: false
+          - dps_val: 32
+            value: false
           - value: true
       - id: 23
         type: bitfield
@@ -120,6 +122,16 @@ entities:
             value: "Pump not detected"
           - dps_val: 32
             value: "Water level low"
+  - entity: binary_sensor
+    translation_key: tank_empty
+    dps:
+      - id: 23
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 32
+            value: true
+          - value: false
   - entity: binary_sensor
     name: Geyser mode status
     category: diagnostic


### PR DESCRIPTION
This is not documented on the API, but it is reported when water level is low.