### PR TITLE
Add Cat Elite Sync pet feeder as a variant of advwin_6l_petfeeder

### DIFF
--- a/custom_components/tuya_local/devices/advwin_6l_petfeeder.yaml
+++ b/custom_components/tuya_local/devices/advwin_6l_petfeeder.yaml
@@ -6,6 +6,9 @@ products:
   - id: vd6bt2zlpmjmm02o
     manufacturer: Papifeed
     model: 7L camera 202301
+  - id: lcvb9ivikrml5f1v
+    manufacturer: Cat Elite
+    model: Sync
 entities:
   - entity: switch
     translation_key: motion_detection


### PR DESCRIPTION
## Summary
- Adds the Cat Elite Sync pet feeder (product id `lcvb9ivikrml5f1v`) as a product entry on the existing `advwin_6l_petfeeder.yaml` config.
- The device shares the same dp set as the existing Advwin/Papifeed 6L camera pet feeder (`uv run duplicates` reports a 100% match), so no new config file is needed — it is added as a product variant instead.

## Test plan
- [x] `uv run yamllint custom_components/tuya_local/devices/advwin_6l_petfeeder.yaml`
- [x] `uv run pytest tests/test_device_config.py` (32 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)