### PR TITLE
Conow CBE2000 Pro: Fix SoC / Battery power state_class

### DIFF
--- a/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
@@ -258,6 +258,7 @@ entities:
         type: integer
         name: sensor
         unit: "%"
+        class: measurement
   - entity: sensor
     name: Expansion pack 1 SoC
     class: battery

--- a/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
@@ -188,6 +188,7 @@ entities:
         type: integer
         name: sensor
         unit: "%"
+        class: measurement
   - entity: sensor
     name: Load state
     translation_key: status

--- a/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
+++ b/custom_components/tuya_local/devices/conow_cbe2000pro_battery.yaml
@@ -212,6 +212,7 @@ entities:
         type: integer
         name: sensor
         unit: W
+        class: measurement
   - entity: sensor
     name: Grid power
     class: power


### PR DESCRIPTION
Set `Unit SoC`, `Battery array SoC` and `Battery power` to state_class `measurement`, otherwise the SoC and the power of the battery can not be selected in the battery configuration dialog of the energy dashboard of Home Assistant.

## Details

I could not set the Unit SoC nor the Battery power in the Energy Dashboard when configuring the CBE2000 Pro as battery. The FAQ states that this depends on the device_class or the state_class (in my understanding). Since I don't want to change the device_class of the sensors I changed the state_class which was successful to solve this problem. After the change I now can select the Unit SoC and the Battery power in the battery configuration dialog of the energy dashboard.

[Energy Dashboard: Missing Entitys FAQ](https://www.home-assistant.io/docs/energy/faq/#troubleshooting-missing-entities):

```
* device_class must be energy or power for electricity grid, solar, or battery categories. It must be gas for gas, or water for water.
* state_class must be measurement for power sensors and total or total_increasing for all others.
```

Screenshot with now working entities:

<img width="742" height="468" alt="image" src="https://github.com/user-attachments/assets/28dff5ca-a139-4bde-a860-612ec27d7009" />