### PR TITLE
Add NovaDigital T20A product id

### DIFF
--- a/custom_components/tuya_local/devices/smartplugv2_energyv3.yaml
+++ b/custom_components/tuya_local/devices/smartplugv2_energyv3.yaml
@@ -19,6 +19,9 @@ products:
   - id: 74xo1nolwa6xkjeu
     manufacturer: Arlec
     model: PC191HA Series 4
+  - id: keykmm3rjyqy5r8p
+    manufacturer: NovaDigital
+    model: T20A
 entities:
   - entity: switch
     class: outlet


### PR DESCRIPTION
Add the product ID keykmm3rjyqy5r8p for the NovaDigital T20A smart plug to the existing smartplugv2_energyv3 configuration.
