### PR TITLE
Add Positivo PLW91 product id

### DIFF
--- a/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
@@ -58,6 +58,9 @@ products:
   - id: keytg5kq8gvkv9dh
     manufacturer: LSC Smart Connect
     model: GU10 White and Color Ambiance
+  - id: keypymhxrj35tnqj
+    manufacturer: Positivo
+    model: PLW91
 entities:
   - entity: light
     dps:


### PR DESCRIPTION
Add the product ID keypymhxrj35tnqj for the Positivo PLW91 light to the existing rgbcw_lightbulb configuration.