### PR TITLE
Add Cecotec Ready Warm 6750 Crystal Connection heater

### DIFF
--- a/custom_components/tuya_local/devices/cecotec_readywarm_6750_heater.yaml
+++ b/custom_components/tuya_local/devices/cecotec_readywarm_6750_heater.yaml
@@ -1,0 +1,52 @@
+name: Glass panel heater
+products:
+  - id: n72zzd550zyw8qte
+    manufacturer: Cecotec
+    model: Ready Warm 6750 Crystal Connection
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: "heat"
+      - id: 3
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 5
+          max: 35
+      - id: 4
+        type: integer
+        name: current_temperature
+      - id: 7
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: "Low"
+            value: eco
+          - dps_val: "High"
+            value: boost
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 2
+        type: boolean
+        name: lock
+  - entity: time
+    translation_key: timer
+    category: config
+    dps:
+      - id: 5
+        type: integer
+        name: minute
+        range:
+          min: 0
+          max: 1440


### PR DESCRIPTION
New device: Cecotec Ready Warm 6750 Crystal Connection glass panel heater (product id `n72zzd550zyw8qte`, protocol 3.5).

DPs were mapped from live LAN status of two physical units — the Tuya cloud returns no data model for this product ("not support this device", code 2009), which is also why the official cloud integration shows empty entities for it:

`{"1": false, "2": false, "3": 25, "4": 23, "5": 0, "7": "Low"}`

- DP1 power → climate hvac_mode (off/heat)
- DP3 target temperature (range 5-35 assumed from panel limits)
- DP4 current temperature (verified against room readings)
- DP7 "Low"/"High" heat mode → presets eco/boost
- DP2 child lock, DP5 timer (minutes assumed; reads 0 when off)

Config validated against `device_config_schema.json` and running on both units (climate, lock and timer entities working, temperature readings feeding automations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvgtRfkkdxqJjY8ps47iBe
