### PR TITLE
Add Clean Air Optima CA-707

### DIFF
--- a/custom_components/tuya_local/devices/cleanair_ca707_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/cleanair_ca707_dehumidifier.yaml
@@ -1,0 +1,225 @@
+name: Clean Air Optima CA-707
+
+products:
+  - id: gynthidZEhTUCoMN
+    manufacturer: Clean Air Optima
+    model: CA-707 Smart
+
+entities:
+  #
+  # Main
+  #
+  - entity: humidifier
+    class: dehumidifier
+    translation_only_key: extended
+    dps:
+      - id: 1
+        name: switch
+        type: boolean
+
+      - id: 2
+        name: mode
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: normal
+          - dps_val: "1"
+            value: continuous
+          - dps_val: "2"
+            value: laundry
+          - dps_val: "3"
+            value: purify
+
+      - id: 4
+        name: humidity
+        type: integer
+        range:
+          min: 30
+          max: 80
+        mapping:
+          - step: 5
+
+      - id: 104
+        name: current_humidity
+        type: integer
+
+      - id: 102
+        name: sleep_mode
+        type: boolean
+
+  #
+  # Fan speed
+  #
+  - entity: select
+    translation_key: fan_with_presets
+    dps:
+      - id: 6
+        name: option
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: low
+          - dps_val: "3"
+            value: high
+
+  #
+  # Ionizer
+  #
+  - entity: switch
+    translation_key: ionizer
+    dps:
+      - id: 5
+        name: switch
+        type: boolean
+
+  #
+  # Sleep mode
+  #
+  - entity: switch
+    translation_key: sleep
+    dps:
+      - id: 102
+        name: switch
+        type: boolean
+
+  #
+  # Temperature
+  #
+  - entity: sensor
+    class: temperature
+    dps:
+      - id: 103
+        name: sensor
+        type: integer
+        unit: "°C"
+        class: measurement
+
+  #
+  # Current humidity
+  #
+  - entity: sensor
+    class: humidity
+    dps:
+      - id: 104
+        name: sensor
+        type: integer
+        unit: "%"
+        class: measurement
+
+  #
+  # Timer
+  #
+  # Note: according to the official Tuya DP spec, this value should
+  # reflect the actual remaining timer duration when read, and
+  # (re)start the timer when written. In practice, this device's
+  # firmware only ever reports back the last commanded value; it does
+  # not count down and no "cancel" event is sent when the timer
+  # expires. Timers set via the physical control panel are not
+  # reported back on this DP at all. Treat this entity as "last
+  # commanded value", not as a reliable live status.
+  - entity: select
+    translation_key: timer
+    dps:
+      - id: 12
+        name: option
+        type: string
+        mapping:
+          - dps_val: "0"
+            value: cancel
+          - dps_val: "1"
+            value: "1h"
+          - dps_val: "2"
+            value: "2h"
+          - dps_val: "3"
+            value: "3h"
+          - dps_val: "4"
+            value: "4h"
+          - dps_val: "5"
+            value: "5h"
+          - dps_val: "6"
+            value: "6h"
+          - dps_val: "7"
+            value: "7h"
+          - dps_val: "8"
+            value: "8h"
+          - dps_val: "9"
+            value: "9h"
+          - dps_val: "10"
+            value: "10h"
+          - dps_val: "11"
+            value: "11h"
+          - dps_val: "12"
+            value: "12h"
+          - dps_val: "13"
+            value: "13h"
+          - dps_val: "14"
+            value: "14h"
+          - dps_val: "15"
+            value: "15h"
+          - dps_val: "16"
+            value: "16h"
+          - dps_val: "17"
+            value: "17h"
+          - dps_val: "18"
+            value: "18h"
+          - dps_val: "19"
+            value: "19h"
+          - dps_val: "20"
+            value: "20h"
+          - dps_val: "21"
+            value: "21h"
+          - dps_val: "22"
+            value: "22h"
+          - dps_val: "23"
+            value: "23h"
+          - dps_val: "24"
+            value: "24h"
+
+  #
+  # Tank full
+  #
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 11
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 8
+            value: true
+          - value: false
+
+  #
+  # General problem
+  #
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 11
+        name: sensor
+        type: bitfield
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 8
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+
+      - id: 11
+        name: fault_code
+        type: bitfield
+
+  #
+  # Defrost
+  #
+  - entity: binary_sensor
+    translation_key: defrost
+    category: diagnostic
+    dps:
+      - id: 105
+        name: sensor
+        type: boolean

--- a/custom_components/tuya_local/devices/cleanair_ca707_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/cleanair_ca707_dehumidifier.yaml
@@ -1,4 +1,4 @@
-name: Clean Air Optima CA-707
+name: Dehumidifier
 
 products:
   - id: gynthidZEhTUCoMN
@@ -43,24 +43,24 @@ entities:
         name: current_humidity
         type: integer
 
-      - id: 102
-        name: sleep_mode
-        type: boolean
-
   #
   # Fan speed
   #
-  - entity: select
-    name: "Fan speed"
+  - entity: fan
+    name: Fan
     dps:
+      - id: 1
+        name: switch
+        type: boolean
+
       - id: 6
-        name: option
+        name: speed
         type: string
         mapping:
           - dps_val: "1"
-            value: low
+            value: 33
           - dps_val: "3"
-            value: high
+            value: 100
 
   #
   # Ionizer
@@ -92,18 +92,6 @@ entities:
         name: sensor
         type: integer
         unit: "°C"
-        class: measurement
-
-  #
-  # Current humidity
-  #
-  - entity: sensor
-    class: humidity
-    dps:
-      - id: 104
-        name: sensor
-        type: integer
-        unit: "%"
         class: measurement
 
   #

--- a/custom_components/tuya_local/devices/cleanair_ca707_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/cleanair_ca707_dehumidifier.yaml
@@ -51,7 +51,7 @@ entities:
   # Fan speed
   #
   - entity: select
-    translation_key: fan_with_presets
+    name: "Fan speed"
     dps:
       - id: 6
         name: option


### PR DESCRIPTION
Add support for the Clean Air Optima CA-707 Smart dehumidifier.

Tested functions:

Power
Operating modes
Target humidity
Fan speed
Ionizer
Sleep mode
Temperature
Current humidity
Tank full
Defrost
The timer (DP12) is included with a note because the device firmware only reports the last commanded value instead of the actual remaining time.

- Please submit each new device as a separate PR on its own branch.
- Please submit additional translations separately from device submissions, after review of whether any existing translations can be used instead.
- Please do not update DEVICES.md or ACKNOWLEDGEMENTS.md as part of your submission, as these files have high risk of conflicts.
- Once submitted, do not force push your branch unless it is necessary for conflict resolution.
- If submitting a code change, please submit a bug report first making it clear what the issue is that you are fixing, and link the report to your PR.
- If using AI to code your changes, you must understand what the AI has done. Vibe coded contributions without understanding by the submitter take up a lot of review time and will be deprioritized.
- PRs with all CI errors and warnings fixed will be prioritized, so please fix what you can (unless the error is outside the scope of your change).

Please describe in simple terms what you are submitting. Do not paste a multi-page AI generated rambling story here, as the maintainers do not have time to read that.
