### PR TITLE
Adding Friedrich Chill Premier - CCW08B10C + Fix bug with existing Friedrich AC's

### DIFF
--- a/custom_components/tuya_local/devices/friedrich_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/friedrich_airconditioner.yaml
@@ -3,6 +3,10 @@ products:
   - id: vfdma8hzkgpdkwlm
     manufacturer: Friedrich
     model: UCT14A30/UCT12A30
+  - id: vfdma8hzkgpdkwlm
+    manufacturer: Friedrich
+    model: Chill Premier
+    model_id: CCW08B10C
 entities:
   - entity: climate
     dps:
@@ -28,7 +32,7 @@ entities:
         name: temperature
         unit: F
         range:
-          min: 69
+          min: 61
           max: 89
       - id: 3
         type: integer

--- a/custom_components/tuya_local/devices/friedrich_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/friedrich_airconditioner.yaml
@@ -2,11 +2,8 @@ name: Air conditioner
 products:
   - id: vfdma8hzkgpdkwlm
     manufacturer: Friedrich
-    model: UCT14A30/UCT12A30
-  - id: vfdma8hzkgpdkwlm
-    manufacturer: Friedrich
     model: Chill Premier
-    model_id: CCW08B10C
+    model_id: UCT14A30/UCT12A30/CCW08B10C
 entities:
   - entity: climate
     dps:


### PR DESCRIPTION
Hey team - adding support for another Friedrich AC model - the Chill Premier with model ID  CCW08B10C. 

This PR sets a new model + ID to the supported list for this AC and fix the temperature ranges listed for these devices. 

Checking the device diagnostic logs, it listed its min and max at 0 and 100 degrees which is wrong.  The currently configured 69-89 range was also incorrect though as this model supports 61 degrees to 89 degrees.  

I checked the manual for the existing uni-fit friedrich models UCT14A30/UCT12A30 that were also defined in this config and they also have a min of 61 and a max of 89.  I believe this was a bug since this config was created

https://www.friedrich.com/hubfs/2023%20Literature%20PDFs/Installation%20Manuals/2023%20Uni-fit%20R-32%20IOM.pdf?hsLang=en
(page 18 lists the temp range supported for the existing models)

Let me know if anything needs updating here