### PR TITLE
Add support for Tesla Smart Pet Sofa PS300

### DIFF
--- a/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
+++ b/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
@@ -1,0 +1,95 @@
+name: Tesla Smart Pet Sofa PS300
+
+products:
+  - id: 13oghytketwcoz1z
+    manufacturer: Tesla
+    model: Smart Pet Sofa PS300
+
+entities:
+  - entity: climate
+    icon: mdi:sofa
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: true
+            value: "heat_cool"
+          - dps_val: false
+            value: "off"
+
+      - id: 8
+        name: temperature
+        type: integer
+        unit: C
+        range:
+          min: 0
+          max: 45
+          step: 1
+
+      - id: 16
+        name: current_temperature
+        type: integer
+
+      - id: 101
+        name: hvac_action
+        type: integer
+        mapping:
+          - dps_val: 1
+            value: idle
+          - dps_val: 2
+            value: heating
+          - dps_val: 3
+            value: cooling
+
+      - id: 7
+        name: preset_mode
+        type: string
+        mapping:
+          - dps_val: auto
+            value: Auto
+          - dps_val: manual
+            value: Manual
+          - dps_val: smart
+            value: Smart
+
+  - entity: sensor
+    name: Ambient temperature
+    class: temperature
+    dps:
+      - id: 102
+        type: integer
+        name: sensor
+        unit: C
+
+  - entity: sensor
+    name: Fault
+    category: diagnostic
+    dps:
+      - id: 22
+        type: integer
+        name: sensor
+
+  - entity: text
+    name: LED schedule
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: text
+
+  - entity: text
+    name: Schedule
+    category: config
+    dps:
+      - id: 104
+        type: string
+        name: text
+
+  - entity: sensor
+    name: Push state
+    category: diagnostic
+    dps:
+      - id: 105
+        type: integer
+        name: sensor

--- a/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
+++ b/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
@@ -8,7 +8,7 @@ products:
 entities:
   - entity: climate
     icon: mdi:sofa
-    translation_key: pet_sofa
+    name: Pet sofa
     dps:
       - id: 1
         name: hvac_mode

--- a/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
+++ b/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
@@ -8,6 +8,7 @@ products:
 entities:
   - entity: climate
     icon: mdi:sofa
+    translation_key: pet_sofa
     dps:
       - id: 1
         name: hvac_mode
@@ -53,13 +54,13 @@ entities:
             value: Smart
 
   - entity: sensor
-    name: Ambient temperature
+    translation_key: ambient_temperature
     class: temperature
     dps:
       - id: 102
         type: integer
         name: sensor
-        unit: C
+        unit: "C"
 
   - entity: sensor
     name: Fault

--- a/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
+++ b/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
@@ -25,7 +25,7 @@ entities:
         range:
           min: 0
           max: 45
-          step: 1
+        step: 1
 
       - id: 16
         name: current_temperature

--- a/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
+++ b/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
@@ -70,22 +70,6 @@ entities:
         type: integer
         name: sensor
 
-  - entity: text
-    name: LED schedule
-    category: config
-    dps:
-      - id: 103
-        type: string
-        name: text
-
-  - entity: text
-    name: Schedule
-    category: config
-    dps:
-      - id: 104
-        type: string
-        name: text
-
   - entity: sensor
     name: Push state
     category: diagnostic

--- a/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
+++ b/custom_components/tuya_local/devices/tesla_smart_sofa.yaml
@@ -21,11 +21,10 @@ entities:
       - id: 8
         name: temperature
         type: integer
-        unit: C
+        unit: "C"
         range:
-          min: 0
-          max: 45
-        step: 1
+          min: 20
+          max: 38
 
       - id: 16
         name: current_temperature

--- a/custom_components/tuya_local/devices/teslasmart_ps300_petsofa.yaml
+++ b/custom_components/tuya_local/devices/teslasmart_ps300_petsofa.yaml
@@ -1,5 +1,4 @@
-name: Tesla Smart Pet Sofa PS300
-
+name: Pet sofa
 products:
   - id: 13oghytketwcoz1z
     manufacturer: Tesla
@@ -7,7 +6,7 @@ products:
 
 entities:
   - entity: climate
-    icon: mdi:sofa
+    icon: "mdi:sofa"
     name: Pet sofa
     dps:
       - id: 1
@@ -18,15 +17,13 @@ entities:
             value: "heat_cool"
           - dps_val: false
             value: "off"
-
       - id: 8
         name: temperature
         type: integer
-        unit: "C"
+        unit: C
         range:
           min: 20
           max: 38
-
       - id: 16
         name: current_temperature
         type: integer
@@ -41,17 +38,16 @@ entities:
             value: heating
           - dps_val: 3
             value: cooling
-
       - id: 7
         name: preset_mode
         type: string
         mapping:
           - dps_val: auto
-            value: Auto
+            value: auto
           - dps_val: manual
-            value: Manual
+            value: manual
           - dps_val: smart
-            value: Smart
+            value: smart
 
   - entity: sensor
     translation_key: ambient_temperature
@@ -62,18 +58,20 @@ entities:
         name: sensor
         unit: "C"
 
-  - entity: sensor
-    name: Fault
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
     dps:
       - id: 22
-        type: integer
+        type: bitfield
         name: sensor
-
-  - entity: sensor
-    name: Push state
-    category: diagnostic
-    dps:
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
       - id: 105
         type: integer
-        name: sensor
+        name: push_state


### PR DESCRIPTION
Add support for the Tesla Smart Pet Sofa PS300 (product ID `13oghytketwcoz1z`).
Entities
* Climate
  * HVAC mode (Off / Heat_Cool)
  * Target temperature
  * Current temperature
  * Preset mode (Auto, Manual, Smart)
  * HVAC action (Idle, Heating, Cooling)
  
* Ambient temperature sensor
* Fault sensor
* Schedule (text)
* Push state (diagnostic)

Testing
Tested against a physical Tesla Smart Pet Sofa PS300 using protocol 3.3.