### PR TITLE
Add support for Kogan heater fan

### DIFF
--- a/custom_components/tuya_local/devices/kogan_heater_fan.yaml
+++ b/custom_components/tuya_local/devices/kogan_heater_fan.yaml
@@ -1,0 +1,153 @@
+name: Heater fan
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: heater
+            conditions:
+              - dps_val: true
+                value: heat
+              - dps_val: false
+                value: fan_only
+      - id: 101
+        type: boolean
+        name: heater
+        hidden: true
+      - id: 20
+        type: integer
+        name: temperature
+        range:
+          min: 15
+          max: 35
+        unit: C
+      - id: 21
+        type: integer
+        name: current_temperature
+      - id: 3
+        type: integer
+        name: fan_mode
+        mapping:
+          - dps_val: 1
+            value: "1"
+          - dps_val: 2
+            value: "2"
+          - dps_val: 3
+            value: "3"
+          - dps_val: 4
+            value: "4"
+          - dps_val: 5
+            value: "5"
+          - dps_val: 6
+            value: "6"
+          - dps_val: 7
+            value: "7"
+          - dps_val: 8
+            value: "8"
+          - dps_val: 9
+            value: "9"
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: normal
+            value: none
+          - dps_val: strong
+            value: boost
+      - id: 5
+        type: boolean
+        name: swing_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: "on"
+  - entity: fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 3
+        type: integer
+        name: speed
+        range:
+          min: 1
+          max: 9
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: normal
+            value: none
+          - dps_val: strong
+            value: boost
+      - id: 5
+        type: boolean
+        name: oscillate
+  - entity: number
+    name: Heat level
+    category: config
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 2
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 13
+        type: boolean
+        name: switch
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: 1h
+            value: 1h
+          - dps_val: 2h
+            value: 2h
+          - dps_val: 3h
+            value: 3h
+          - dps_val: 4h
+            value: 4h
+          - dps_val: 5h
+            value: 5h
+          - dps_val: 6h
+            value: 6h
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 24
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 24
+        type: bitfield
+        name: fault_code

--- a/custom_components/tuya_local/devices/kogan_heater_fan.yaml
+++ b/custom_components/tuya_local/devices/kogan_heater_fan.yaml
@@ -1,0 +1,131 @@
+name: Heater fan
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: heater
+            conditions:
+              - dps_val: true
+                value: heat
+              - dps_val: false
+                value: fan_only
+      - id: 101
+        type: boolean
+        name: heater
+        hidden: true
+      - id: 20
+        type: integer
+        name: temperature
+        range:
+          min: 15
+          max: 35
+        unit: C
+      - id: 21
+        type: integer
+        name: current_temperature
+      - id: 2
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: strong
+            value: high
+          - constraint: speed
+            conditions:
+              - dps_val: 1
+                value: low
+              - dps_val: 2
+                value: low
+              - dps_val: 3
+                value: low
+              - dps_val: 4
+                value: medium
+              - dps_val: 5
+                value: medium
+              - dps_val: 6
+                value: medium
+              - dps_val: 7
+                value: medium
+              - dps_val: 8
+                value: medium
+              - dps_val: 9
+                value: medium
+      - id: 3
+        type: integer
+        name: speed
+        hidden: true
+      - id: 5
+        type: boolean
+        name: swing_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: "on"
+  - entity: number
+    name: Heat level
+    category: config
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 2
+  - entity: switch
+    translation_key: sound
+    category: config
+    dps:
+      - id: 13
+        type: boolean
+        name: switch
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 22
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: 1h
+            value: 1h
+          - dps_val: 2h
+            value: 2h
+          - dps_val: 3h
+            value: 3h
+          - dps_val: 4h
+            value: 4h
+          - dps_val: 5h
+            value: 5h
+          - dps_val: 6h
+            value: 6h
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 23
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 24
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 24
+        type: bitfield
+        name: fault_code

--- a/custom_components/tuya_local/devices/kogan_heater_fan.yaml
+++ b/custom_components/tuya_local/devices/kogan_heater_fan.yaml
@@ -1,72 +1,5 @@
 name: Heater fan
 entities:
-  - entity: climate
-    dps:
-      - id: 1
-        type: boolean
-        name: hvac_mode
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            constraint: heater
-            conditions:
-              - dps_val: true
-                value: heat
-              - dps_val: false
-                value: fan_only
-      - id: 101
-        type: boolean
-        name: heater
-        hidden: true
-      - id: 20
-        type: integer
-        name: temperature
-        range:
-          min: 15
-          max: 35
-        unit: C
-      - id: 21
-        type: integer
-        name: current_temperature
-      - id: 3
-        type: integer
-        name: fan_mode
-        mapping:
-          - dps_val: 1
-            value: "1"
-          - dps_val: 2
-            value: "2"
-          - dps_val: 3
-            value: "3"
-          - dps_val: 4
-            value: "4"
-          - dps_val: 5
-            value: "5"
-          - dps_val: 6
-            value: "6"
-          - dps_val: 7
-            value: "7"
-          - dps_val: 8
-            value: "8"
-          - dps_val: 9
-            value: "9"
-      - id: 2
-        type: string
-        name: preset_mode
-        mapping:
-          - dps_val: normal
-            value: none
-          - dps_val: strong
-            value: boost
-      - id: 5
-        type: boolean
-        name: swing_mode
-        mapping:
-          - dps_val: false
-            value: "off"
-          - dps_val: true
-            value: "on"
   - entity: fan
     dps:
       - id: 1
@@ -89,16 +22,40 @@ entities:
       - id: 5
         type: boolean
         name: oscillate
-  - entity: number
-    name: Heat level
-    category: config
+  - entity: climate
+    translation_key: heater
     dps:
+      - id: 1
+        type: boolean
+        name: available
+      - id: 101
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+      - id: 20
+        type: integer
+        name: temperature
+        range:
+          min: 15
+          max: 35
+        unit: C
+      - id: 21
+        type: integer
+        name: current_temperature
       - id: 102
         type: integer
-        name: value
-        range:
-          min: 0
-          max: 2
+        name: preset_mode
+        mapping:
+          - dps_val: 0
+            value: low
+          - dps_val: 1
+            value: medium
+          - dps_val: 2
+            value: high
   - entity: switch
     translation_key: sound
     category: config


### PR DESCRIPTION
Adds support for the Kogan heater fan.

It is a fan heater with `heat` and `fan_only` modes, oscillation, a countdown
timer, sound toggle and a 0-2 heat level. dp 1 is the main power switch and
dp 101 selects between heating and fan-only, so `hvac_mode` is mapped from
dp 1 with a condition on dp 101.

Tested against a physical device on protocol 3.4. All 12 dps the device
reports are covered by the config, and it matches at 100% quality.

I have not included a `products:` block as I do not have a reliable product id
for this device; it matches on dps.
