### PR TITLE
Add generic "PRO V2 W/Wi-Fi & Bluetooth LE" electric fireplace (v4r5dzjgkhnagnqc)

### DIFF
--- a/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
+++ b/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
@@ -3,6 +3,8 @@ name: Fireplace
 # "PRO V2 W/Wi-Fi & Bluetooth LE"
 products:
   - id: v4r5dzjgkhnagnqc
+    manufacturer: Modern Flames
+    model: Landscape Pro Slim
 entities:
   - entity: climate
     icon: "mdi:fireplace"
@@ -23,6 +25,7 @@ entities:
                 value: heat
               - dps_val: "3"
                 value: heat
+                hidden: true
       - id: 2
         name: temperature
         type: integer
@@ -60,8 +63,7 @@ entities:
         name: temperature_unit
         type: string
         mapping:
-          - dps_val: c
-            value: C
+          - value: C
           - dps_val: f
             value: F
       - id: 20
@@ -126,7 +128,7 @@ entities:
         name: sensor
         unit: min
   - entity: select
-    name: Light effect
+    name: Light preset
     icon: "mdi:palette"
     category: config
     dps:
@@ -167,11 +169,11 @@ entities:
         name: rgbhsv
         type: hex
         format:
-          - name: spare_r
+          - name: r
             bytes: 1
-          - name: spare_g
+          - name: g
             bytes: 1
-          - name: spare_b
+          - name: b
             bytes: 1
           - name: h
             bytes: 2
@@ -199,11 +201,11 @@ entities:
         name: rgbhsv
         type: hex
         format:
-          - name: spare_r
+          - name: r
             bytes: 1
-          - name: spare_g
+          - name: g
             bytes: 1
-          - name: spare_b
+          - name: b
             bytes: 1
           - name: h
             bytes: 2
@@ -232,11 +234,11 @@ entities:
         name: rgbhsv
         type: hex
         format:
-          - name: spare_r
+          - name: r
             bytes: 1
-          - name: spare_g
+          - name: g
             bytes: 1
-          - name: spare_b
+          - name: b
             bytes: 1
           - name: h
             bytes: 2
@@ -319,7 +321,7 @@ entities:
         name: value
         optional: true
   - entity: text
-    name: Weekly schedule
+    translation_key: schedule
     icon: "mdi:calendar-clock"
     category: config
     hidden: true

--- a/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
+++ b/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
@@ -1,0 +1,321 @@
+name: Fireplace
+# manufacturer/model unknown - sold under multiple brands as
+# "PRO V2 W/Wi-Fi & Bluetooth LE"
+products:
+  - id: v4r5dzjgkhnagnqc
+entities:
+  - entity: climate
+    icon: "mdi:fireplace"
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: heat
+      - id: 2
+        name: temperature
+        type: integer
+        range:
+          min: 10
+          max: 30
+        optional: true
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_set_f
+                range:
+                  min: 50
+                  max: 85
+      - id: 3
+        name: current_temperature
+        type: integer
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                value_redirect: temp_current_f
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: "1"
+            value: "off"
+          - dps_val: "2"
+            value: low
+          - dps_val: "3"
+            value: high
+      - id: 19
+        name: temperature_unit
+        type: string
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 20
+        name: temp_set_f
+        type: integer
+        hidden: true
+        optional: true
+        range:
+          min: 50
+          max: 85
+      - id: 21
+        name: temp_current_f
+        type: integer
+        hidden: true
+  - entity: select
+    translation_key: temperature_unit
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: c
+            value: celsius
+          - dps_val: f
+            value: fahrenheit
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 11
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: cancel
+          - dps_val: "0_5"
+            value: "30m"
+          - dps_val: "1"
+            value: "1h"
+          - dps_val: "2"
+            value: "2h"
+          - dps_val: "3"
+            value: "3h"
+          - dps_val: "4"
+            value: "4h"
+          - dps_val: "5"
+            value: "5h"
+          - dps_val: "6"
+            value: "6h"
+          - dps_val: "7"
+            value: "7h"
+          - dps_val: "8"
+            value: "8h"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 12
+        type: integer
+        name: sensor
+        unit: min
+  - entity: select
+    name: Light effect
+    icon: "mdi:palette"
+    category: config
+    dps:
+      - id: 4
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: Default
+          - dps_val: "1"
+            value: Rainbow fade
+          - dps_val: "2"
+            value: 3-color fade
+          - dps_val: "3"
+            value: Red fade
+          - dps_val: "4"
+            value: Green fade
+          - dps_val: "5"
+            value: Blue fade
+          - dps_val: "6"
+            value: Rainbow jump
+          - dps_val: "7"
+            value: 3-color jump
+          - dps_val: "8"
+            value: Custom 1
+          - dps_val: "9"
+            value: Custom 2
+          - dps_val: "10"
+            value: Custom 3
+  - entity: light
+    translation_key: flame
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 101
+        name: rgbhsv
+        type: hex
+        format:
+          - name: spare_r
+            bytes: 1
+          - name: spare_g
+            bytes: 1
+          - name: spare_b
+            bytes: 1
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 1
+            range:
+              min: 0
+              max: 100
+          - name: v
+            bytes: 1
+            range:
+              min: 0
+              max: 100
+  - entity: light
+    translation_key: embers
+    category: config
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 102
+        name: rgbhsv
+        type: hex
+        format:
+          - name: spare_r
+            bytes: 1
+          - name: spare_g
+            bytes: 1
+          - name: spare_b
+            bytes: 1
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 1
+            range:
+              min: 0
+              max: 100
+          - name: v
+            bytes: 1
+            range:
+              min: 0
+              max: 100
+  - entity: light
+    name: Downlight
+    icon: "mdi:spotlight-beam"
+    category: config
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 103
+        name: rgbhsv
+        type: hex
+        format:
+          - name: spare_r
+            bytes: 1
+          - name: spare_g
+            bytes: 1
+          - name: spare_b
+            bytes: 1
+          - name: h
+            bytes: 2
+            range:
+              min: 0
+              max: 360
+          - name: s
+            bytes: 1
+            range:
+              min: 0
+              max: 100
+          - name: v
+            bytes: 1
+            range:
+              min: 0
+              max: 100
+  - entity: switch
+    name: Sync lights
+    icon: "mdi:sync"
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+  - entity: select
+    name: Flame motor speed
+    icon: "mdi:fan"
+    category: config
+    dps:
+      - id: 110
+        type: string
+        name: option
+        mapping:
+          - dps_val: "1"
+            value: "1"
+          - dps_val: "2"
+            value: "2"
+          - dps_val: "3"
+            value: "3"
+          - dps_val: "4"
+            value: "4"
+  - entity: text
+    name: Custom scene 1
+    icon: "mdi:playlist-edit"
+    category: config
+    hidden: true
+    dps:
+      - id: 105
+        type: string
+        name: value
+        optional: true
+  - entity: text
+    name: Custom scene 2
+    icon: "mdi:playlist-edit"
+    category: config
+    hidden: true
+    dps:
+      - id: 106
+        type: string
+        name: value
+        optional: true
+  - entity: text
+    name: Custom scene 3
+    icon: "mdi:playlist-edit"
+    category: config
+    hidden: true
+    dps:
+      - id: 107
+        type: string
+        name: value
+        optional: true
+  - entity: text
+    name: Custom scene preview
+    icon: "mdi:eye"
+    category: diagnostic
+    hidden: true
+    dps:
+      - id: 108
+        type: string
+        name: value
+        optional: true
+  - entity: text
+    name: Weekly schedule
+    icon: "mdi:calendar-clock"
+    category: config
+    hidden: true
+    dps:
+      - id: 109
+        type: base64
+        name: value
+        optional: true

--- a/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
+++ b/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
@@ -14,7 +14,15 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            value: heat
+            value: fan_only
+            constraint: fan_mode
+            conditions:
+              - dps_val: "1"
+                value: fan_only
+              - dps_val: "2"
+                value: heat
+              - dps_val: "3"
+                value: heat
       - id: 2
         name: temperature
         type: integer
@@ -150,6 +158,7 @@ entities:
             value: Custom 3
   - entity: light
     translation_key: flame
+    category: config
     dps:
       - id: 1
         type: boolean

--- a/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
+++ b/custom_components/tuya_local/devices/fireplace_pro_v2.yaml
@@ -128,7 +128,7 @@ entities:
         name: sensor
         unit: min
   - entity: select
-    name: Light preset
+    translation_key: scene
     icon: "mdi:palette"
     category: config
     dps:


### PR DESCRIPTION
New device config for an electric fireplace, product ID `v4r5dzjgkhnagnqc`. No branding found on the unit or in the Tuya app beyond the generic name "PRO V2 W/Wi-Fi & Bluetooth LE" - seems to be a whitelabeled OEM product.

DP info came from the Tuya Cloud `/v2.0/cloud/thing/{id}/model` endpoint, cross-checked against a local `status()` poll of the real device. That data model gave descriptions (in Chinese) for all 20 DPs, including the ones outside the standard "specification" schema (the RGB/mode/custom-scene ones).

What's mapped:
- `climate`: power, target/current temp (C and F), heater level (off/low/high)
- `select`: temp unit, timer, shared light effect mode, flame motor speed
- `sensor`: timer remaining
- `light` x3 (flame/ember/downlight): each has its own DP encoding RGB+HSV as a 7-byte hex string (R,G,B,H(2b),S,V) - only H/S/V are used, R/G/B are redundant duplicates per the device's own docs, so they're pulled in as unused spare fields to keep the byte offsets right
- `switch`: sync-lights toggle
- 3 custom-scene DPs + weekly-schedule DP are exposed as hidden/opaque text fields - their packed formats are variable-length free-form byte sequences (documented in the cloud data model) that don't fit the fixed-format decoding the format: option supports, so I didn't try to force them into real controls

`pytest tests/test_device_config.py`, `untranslated_entities`, and `yamllint` all pass locally. I haven't yet confirmed entity behavior against the live device through the HA UI (pending a restart on my end) - will follow up in this PR if anything needs adjusting once I've done that.