### PR TITLE
Rework Sensio Titan Kinetic Driver config to properly separate channel enable, driver power, and kinetic-switch-equivalent controls

### DIFF
--- a/custom_components/tuya_local/devices/sensio_titankinetic_lightsdriver.yaml
+++ b/custom_components/tuya_local/devices/sensio_titankinetic_lightsdriver.yaml
@@ -1,71 +1,11 @@
-name: Five channel dimmer
+name: Titan Smart Kinetic Driver Single Colour
 products:
   - id: whg6uhsccujw03km
     manufacturer: Sensio
     model: Titan Smart Kinetic Driver
 entities:
   - entity: light
-    name: Channel 1
-    dps:
-      - id: 106
-        type: boolean
-        name: switch
-      - id: 101
-        type: integer
-        name: brightness
-        range:
-          min: 10
-          max: 1000
-  - entity: light
-    name: Channel 2
-    dps:
-      - id: 107
-        type: boolean
-        name: switch
-      - id: 102
-        type: integer
-        name: brightness
-        range:
-          min: 10
-          max: 1000
-  - entity: light
-    name: Channel 3
-    dps:
-      - id: 108
-        type: boolean
-        name: switch
-      - id: 103
-        type: integer
-        name: brightness
-        range:
-          min: 10
-          max: 1000
-  - entity: light
-    name: Channel 4
-    dps:
-      - id: 109
-        type: boolean
-        name: switch
-      - id: 104
-        type: integer
-        name: brightness
-        range:
-          min: 10
-          max: 1000
-  - entity: light
-    name: Channel 5
-    dps:
-      - id: 110
-        type: boolean
-        name: switch
-      - id: 105
-        type: integer
-        name: brightness
-        range:
-          min: 10
-          max: 1000
-  - entity: light
-    name: All channels
+    name: Driver Power
     dps:
       - id: 20
         type: boolean
@@ -78,6 +18,96 @@ entities:
             value: "off"
           - dps_val: scene
             value: Scene
+  - entity: light
+    name: Channel 1 Enable
+    dps:
+      - id: 106
+        type: boolean
+        name: switch
+  - entity: light
+    name: Channel 2 Enable
+    dps:
+      - id: 107
+        type: boolean
+        name: switch
+  - entity: light
+    name: Channel 3 Enable
+    dps:
+      - id: 108
+        type: boolean
+        name: switch
+  - entity: light
+    name: Channel 4 Enable
+    dps:
+      - id: 109
+        type: boolean
+        name: switch
+  - entity: light
+    name: Channel 5 Enable
+    dps:
+      - id: 110
+        type: boolean
+        name: switch
+  - entity: light
+    name: Channel 1
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 101
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: light
+    name: Channel 2
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 102
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: light
+    name: Channel 3
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 103
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: light
+    name: Channel 4
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 104
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
+  - entity: light
+    name: Channel 5
+    dps:
+      - id: 20
+        type: boolean
+        name: switch
+      - id: 105
+        type: integer
+        name: brightness
+        range:
+          min: 10
+          max: 1000
   - entity: select
     translation_key: scene
     category: config

--- a/custom_components/tuya_local/devices/sensio_titankinetic_lightsdriver.yaml
+++ b/custom_components/tuya_local/devices/sensio_titankinetic_lightsdriver.yaml
@@ -5,7 +5,7 @@ products:
     model: Titan Smart Kinetic Driver
 entities:
   - entity: light
-    name: Driver Power
+    name: All Channels Control
     dps:
       - id: 20
         type: boolean
@@ -18,32 +18,37 @@ entities:
             value: "off"
           - dps_val: scene
             value: Scene
-  - entity: light
+  - entity: switch
     name: Channel 1 Enable
+    category: config
     dps:
       - id: 106
         type: boolean
         name: switch
-  - entity: light
+  - entity: switch
     name: Channel 2 Enable
+    category: config
     dps:
       - id: 107
         type: boolean
         name: switch
-  - entity: light
+  - entity: switch
     name: Channel 3 Enable
+    category: config
     dps:
       - id: 108
         type: boolean
         name: switch
-  - entity: light
+  - entity: switch
     name: Channel 4 Enable
+    category: config
     dps:
       - id: 109
         type: boolean
         name: switch
-  - entity: light
+  - entity: switch
     name: Channel 5 Enable
+    category: config
     dps:
       - id: 110
         type: boolean


### PR DESCRIPTION
Background

The Sensio Titan Smart Kinetic Driver is an LED strip driver with 5 independent dimmable output channels. It's designed to be paired with a separate accessory, the Titan Kinetic Switch — a battery-free, wireless wall switch that talks directly to the driver (not through Tuya's cloud or app). A single tap of this physical switch turns the whole driver on/off; holding it down dims the lights.

This PR doesn't change anything about that physical switch — it can't be reconfigured, and isn't part of Home Assistant at all. The goal here is to make the Home Assistant entities behave the same way the physical switch does, and to stop them from silently doing something the physical switch never does (permanently disabling a channel).

Problem

The current config exposes entities that don't match how the hardware and physical switch actually behave, which makes it easy to break the physical control by accident from Home Assistant.

Specifically:

Each channel's dp for switch_1–switch_5 (dps 106–110) is currently paired with that channel's brightness dp inside a single light entity, which reads as a normal per-channel on/off — the same way you'd expect any dimmable light to have an on/off.
It isn't that. These dps are a hardware enable/disable flag for the channel, closer to physically disconnecting that output than switching off a light. Turning one "off" from Home Assistant disables the channel at the driver, and afterwards the physical Kinetic Switch can no longer control that channel at all — confirmed by testing, and by a raw dp dump showing that a channel's brightness value stays unchanged even while "off," which a normal light dp wouldn't do.
The physical Kinetic Switch never touches these dps. All it does is: tap → toggle switch_led (dp 20, a driver-wide "all channels" power flag), hold → adjust brightness on all five channels at once, each incrementing/decrementing independently from wherever its brightness currently sits (bright_value_1–bright_value_5, dps 101–105). It has no concept of enabling or disabling individual channels.

Net effect of the current config: anyone turning off what looks like a normal per-channel light from Home Assistant is actually disabling that channel at the hardware level, in a way the physical switch has no way to undo. This is surprising and easy to trigger by accident (e.g. via a "turn off all lights" automation).

Changes
All Channels Control (light, dps 20 + 21): mirrors what a tap of the physical switch does — whole-driver power, plus the driver's white/scene effect mode.
Channel 1–Channel 5 (light, shared dp 20 + that channel's own brightness dp 101–105): each one mirrors what holding the switch does to that specific channel — same driver-wide power dp, individual brightness. Note the physical switch always adjusts all five channels together when held; to fully reproduce that combined gesture from Home Assistant, all five of these entities would need to be driven together (e.g. via a light group or template light). These entities give the correct per-channel building block for that.
Channel 1 Enable–Channel 5 Enable (switch, category: config, dps 106–110 only): renamed and moved from light to switch to reflect what they actually do — an enable/disable flag, not a light. Placed in the config category since this is a set-once setting most users will rarely touch, not a daily control, and to keep it well out of the way of the actual light entities so it's harder to hit by mistake.

Scene select and hidden scene text entities are unchanged from the original config.

Why this matters

This separates three genuinely different things that the old config conflated into one ambiguous "Channel N" entity per channel:

Whole-driver power — what a tap of the physical switch does
Per-channel dimming — what holding the physical switch does to that channel (with all five needing to be driven together to reproduce the exact combined gesture)
Per-channel hardware enable/disable — something the physical switch has no way to do at all, and which most users will set once (or never) rather than use day to day

The result is that entities behaving like normal lights in Home Assistant no longer share dps with the hardware enable/disable flags, so a normal "turn the lights off" action can no longer accidentally strand a channel.