### PR TITLE
Add Anderic UC7235T4 ceiling fan receiver

### DIFF
--- a/custom_components/tuya_local/devices/anderic_uc7235t4_ceilingfanreceiver.yaml
+++ b/custom_components/tuya_local/devices/anderic_uc7235t4_ceilingfanreceiver.yaml
@@ -1,0 +1,32 @@
+name: Ceiling fan
+products:
+  - id: kzmjklvux6c5cu1u
+    manufacturer: Anderic
+    model: UC7235T4
+entities:
+  - entity: fan
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+      - id: 104
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "1"
+            value: 33
+          - dps_val: "2"
+            value: 66
+          - dps_val: "3"
+            value: 100
+  - entity: light
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+      - id: 102
+        type: integer
+        name: brightness
+        range:
+          min: 25
+          max: 255


### PR DESCRIPTION
Adds support for the Anderic UC7235T4 universal ceiling fan receiver, identified by Tuya as AtmoSync AC.

Product ID: `kzmjklvux6c5cu1u`

Data points

- 101: Fan switch
- 102: Light brightness, range 25–255
- 103: Light switch
- 104: Fan speed, values 1–3

Tested with a Home Assistant VM and a physical Anderic UC7235T4:

- Fan on/off works
- All three fan speeds work
- Light on/off works
- Brightness control works

`duplicates` reported no overlapping configurations.