### PR TITLE
Add Eberg Qubo Q40NE AC

### DIFF
--- a/custom_components/tuya_local/devices/eberg_qubo_q40ne_airconditioner.yaml
+++ b/custom_components/tuya_local/devices/eberg_qubo_q40ne_airconditioner.yaml
@@ -1,4 +1,4 @@
-name: Portable heat pump
+name: Portable air conditioner
 # products: Eberg Qubo Q40NE
 entities:
   - entity: climate

--- a/custom_components/tuya_local/devices/eberg_qubo_q40ne_heatpump.yaml
+++ b/custom_components/tuya_local/devices/eberg_qubo_q40ne_heatpump.yaml
@@ -1,0 +1,98 @@
+name: Portable heat pump
+# products: Eberg Qubo Q40NE
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        name: hvac_mode
+        type: boolean
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: cold
+                value: cool
+              - dps_val: hot
+                value: heat
+              - dps_val: dehumidify
+                value: dry
+      - id: 2
+        name: temperature
+        type: integer
+        range:
+          min: 17
+          max: 30
+        mapping:
+          - constraint: temperature_unit
+            conditions:
+              - dps_val: f
+                range:
+                  min: 63
+                  max: 86
+      - id: 3
+        name: current_temperature
+        type: integer
+      - id: 4
+        name: mode
+        type: string
+        hidden: true
+      - id: 4
+        name: hvac_action
+        type: string
+        mapping:
+          - dps_val: cold
+            value: cooling
+          - dps_val: hot
+            value: heating
+          - dps_val: dehumidify
+            value: drying
+      - id: 5
+        name: fan_mode
+        type: string
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: low
+            value: low
+          - dps_val: middle
+            value: medium
+          - dps_val: high
+            value: high
+      - id: 19
+        name: temperature_unit
+        type: string
+        mapping:
+          - dps_val: c
+            value: C
+          - dps_val: f
+            value: F
+      - id: 25
+        type: boolean
+        name: preset_mode
+        mapping:
+          - dps_val: true
+            value: sleep
+          - dps_val: false
+            value: comfort
+      - id: 30
+        type: boolean
+        name: swing_mode
+        mapping:
+          - dps_val: true
+            value: vertical
+          - dps_val: false
+            value: "off"
+  - entity: number
+    translation_key: timer
+    class: duration
+    category: config
+    dps:
+      - id: 22
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 24

--- a/custom_components/tuya_local/devices/eberg_qubo_q40ne_heatpump.yaml
+++ b/custom_components/tuya_local/devices/eberg_qubo_q40ne_heatpump.yaml
@@ -81,7 +81,7 @@ entities:
         name: swing_mode
         mapping:
           - dps_val: true
-            value: vertical
+            value: horizontal
           - dps_val: false
             value: "off"
   - entity: number


### PR DESCRIPTION
Adds a separate device configuration for the Eberg Qubo Q40NE portable AC.

The device is similar to the existing Q40HD profile, but DPS 101 incorrectly reports `heat_s` while the unit is cooling. This causes Home Assistant to display `heating`.

For the Q40NE profile, `hvac_action` is mapped from DPS 4:

- `cold` -> `cooling`
- `hot` -> `heating`
- `dehumidify` -> `drying`

- Maps HVAC action from DPS 4 because DPS 101 reports an incorrect state.
- Maps DPS 30 as horizontal swing instead of vertical swing.
- 

`DPS 4 represents the selected mode rather than the real-time compressor state.`

Tested locally on an Eberg Qubo Q40NE with cooling, heating and drying modes.

<img width="588" height="726" alt="obraz" src="https://github.com/user-attachments/assets/4b8eccc6-d990-4c61-80fa-13fc83bdc417" />
<img width="584" height="654" alt="obraz" src="https://github.com/user-attachments/assets/542a269d-1d57-443f-a69f-ffee6915b9f0" />
<img width="585" height="659" alt="obraz" src="https://github.com/user-attachments/assets/ab75753d-977b-4b21-89a4-1bff2e11807a" />

