### PR TITLE
Add LoraTap SC500W-V2 product ID

### DIFF
--- a/custom_components/tuya_local/devices/loratap_curtain_switch.yaml
+++ b/custom_components/tuya_local/devices/loratap_curtain_switch.yaml
@@ -3,6 +3,9 @@ products:
   - id: tuh2eatk4hsq336s
     manufacturer: Loratap
     model: SC500W-V1
+  - id: n3xgr5pdmpinictg
+    manufacturer: LoraTap
+    model: SC500W-V2
   - id: hwbhrbadjynv7w70
     manufacturer: Zemismart
     model: ZM16L


### PR DESCRIPTION
## Summary

Add the LoraTap SC500W-V2 product ID to the existing simple curtain switch profile.

## Device data

- Manufacturer: LoraTap
- Model: SC500W-V2
- Product ID: `n3xgr5pdmpinictg`
- Tuya data model: DP 1 (`status`), enum values `0`, `1`, `2`, `3`

## Verification

- Verified with three physical SC500W-V2 units
- The existing cover profile matched and loaded successfully in Home Assistant
- Idempotent `stop_cover` commands succeeded before and after a Home Assistant Core restart
- No open or close command was used during validation
- `pytest tests/test_device_config.py`: 32 passed
- Ruff, format check, and yamllint passed

## Duplicate check

The duplicate checker reports several generic 100% structural matches (`positivo_remote_control`, `hircr_remote_control`, `hornbill_y4_smart_lock`, `loonas_curtain`, `primebras_athenas_lock`, `s11_rfir_remote`, and `catit_pixi_smart_feeder`). This change intentionally extends the existing LoraTap curtain profile that matches the product model and verified behavior.