### PR TITLE
Add LoraTap QCSC500W-V2N2 product ID

### DIFF
--- a/custom_components/tuya_local/devices/loratap_curtain_switch_QCSC400ZB-V2.yaml
+++ b/custom_components/tuya_local/devices/loratap_curtain_switch_QCSC400ZB-V2.yaml
@@ -26,13 +26,6 @@ entities:
       - id: 8
         name: control_back_mode
         type: string
-        mapping:
-          - dps_val: forward
-            value: forward
-          - dps_val: backward
-            value: backward
-          - dps_val: back
-            value: backward
       - id: 10
         name: tr_timecontrol
         type: integer

--- a/custom_components/tuya_local/devices/loratap_curtain_switch_QCSC400ZB-V2.yaml
+++ b/custom_components/tuya_local/devices/loratap_curtain_switch_QCSC400ZB-V2.yaml
@@ -3,6 +3,9 @@ products:
   - id: qa8s8vca
     manufacturer: LoraTap
     model: QCSC400ZB-V2
+  - id: nnfrmb3val45av1n
+    manufacturer: LoraTap
+    model: QCSC500W-V2N2
   - id: cqcew2xvoqjdaixe
     manufacturer: LoraTap
     model: SC400W
@@ -27,6 +30,8 @@ entities:
           - dps_val: forward
             value: forward
           - dps_val: backward
+            value: backward
+          - dps_val: back
             value: backward
       - id: 10
         name: tr_timecontrol


### PR DESCRIPTION
## Summary

Add the LoraTap QCSC500W-V2N2 product ID to the existing curtain switch profile and accept the `back` value reported by its motor direction DP.

## Device data

- Manufacturer: LoraTap
- Model: QCSC500W-V2N2
- Product ID: `nnfrmb3val45av1n`
- DP 1 (`control`): `open`, `stop`, `close`
- DP 8 (`control_back`): `forward`, `back`
- DP 10 (`tr_timecon`): 1–120 seconds

The existing profile used `backward` for DP 8. Mapping the device value `back` to the same Home Assistant value preserves compatibility with the existing variant.

## Verification

- Verified with two physical QCSC500W-V2N2 units
- Both cover entities loaded successfully in Home Assistant
- Idempotent `stop_cover` commands succeeded before and after a Home Assistant Core restart
- No open or close command was used during validation
- `pytest tests/test_device_config.py`: 32 passed
- Ruff, format check, and yamllint passed

## Duplicate check

The duplicate checker reports two generic 100% structural matches (`positivo_remote_control` and `hircr_remote_control`) plus three 67% matches. This change intentionally extends the existing LoraTap curtain profile whose DPs and verified behavior match this product.