### PR TITLE
Update entity.py for deprecated CONCENTRATION_MICROGRAMS_PER_CUBIC_METER in HA 2026.8

### DIFF
--- a/custom_components/tuya_local/entity.py
+++ b/custom_components/tuya_local/entity.py
@@ -6,8 +6,8 @@ import json
 import logging
 
 from homeassistant.const import (
-    UnitOfDensity,
     UnitOfArea,
+    UnitOfDensity,
     UnitOfTemperature,
 )
 from homeassistant.helpers.entity import EntityCategory

--- a/custom_components/tuya_local/entity.py
+++ b/custom_components/tuya_local/entity.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
     UnitOfArea,
     UnitOfTemperature,
 )
@@ -143,7 +143,7 @@ class TuyaLocalEntity:
 UNIT_ASCII_MAP = {
     "C": UnitOfTemperature.CELSIUS.value,
     "F": UnitOfTemperature.FAHRENHEIT.value,
-    "ugm3": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "ugm3": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
     "m2": UnitOfArea.SQUARE_METERS,
 }
 

--- a/custom_components/tuya_local/entity.py
+++ b/custom_components/tuya_local/entity.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from homeassistant.const import (
-    UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+    UnitOfDensity,
     UnitOfArea,
     UnitOfTemperature,
 )


### PR DESCRIPTION
Fix for the following error in HA 2026.8(beta):

The deprecated constant CONCENTRATION_MICROGRAMS_PER_CUBIC_METER was used from tuya_local. It will be removed in HA Core 2027.8. Use UnitOfDensity.MICROGRAMS_PER_CUBIC_METER instead, please report it to the author of the 'tuya_local' custom integration
