### PR TITLE
fix: Reload config entry after option changes

### DIFF
--- a/custom_components/tuya_local/__init__.py
+++ b/custom_components/tuya_local/__init__.py
@@ -1079,5 +1079,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("Updating entry for device: %s", get_device_id(entry.data))
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    hass.config_entries.async_schedule_reload(entry.entry_id)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,6 +13,7 @@ from custom_components.tuya_local import (
     async_migrate_entry,
     async_setup_entry,
     async_unload_entry,
+    async_update_entry,
     config_flow,
     get_device_unique_id,
 )
@@ -163,6 +164,33 @@ async def test_async_unload_entry_ignores_missing_device_data(hass):
     )
 
     assert await async_unload_entry(hass, entry)
+
+
+@pytest.mark.asyncio
+async def test_async_update_entry_reloads_config_entry(hass, mocker):
+    """Entry updates should delegate lifecycle management to Home Assistant."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DEVICE_ID: "deviceid"},
+    )
+    schedule_reload = mocker.patch.object(
+        hass.config_entries,
+        "async_schedule_reload",
+    )
+    unload_entry = mocker.patch(
+        "custom_components.tuya_local.async_unload_entry",
+        new=AsyncMock(),
+    )
+    setup_entry = mocker.patch(
+        "custom_components.tuya_local.async_setup_entry",
+        new=AsyncMock(),
+    )
+
+    await async_update_entry(hass, entry)
+
+    schedule_reload.assert_called_once_with(entry.entry_id)
+    unload_entry.assert_not_awaited()
+    setup_entry.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Changing a configured device's IP through the integration options now reloads the config entry via `hass.config_entries.async_reload(entry.entry_id)` instead of calling the integration's unload and setup functions directly.

## Why this matters

The options update listener called `async_unload_entry` / `async_setup_entry` itself while Home Assistant still tracked the entry as loaded, so the reload logged that the config entry had already been set up and left the entry in an invalid state. Letting Home Assistant own the unload, state transition, and setup sequence keeps its config-entry bookkeeping correct. The same listener handles LAN rediscovery host updates, so that path is fixed too.

## Changes

- `custom_components/tuya_local/__init__.py`: the options update listener delegates to `async_reload`.
- `tests/test_config_flow.py`: regression test asserting the listener requests exactly one reload for the affected entry and no longer drives unload/setup directly.

Fixes #5740

AI was used for assistance.
