### PR TITLE
3x Arlec lights supported (CHR370HA, CHR352HA, ALP018HA)

### DIFF
--- a/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
@@ -14,7 +14,6 @@ entities:
     dps:
       - id: 20
         type: boolean
-        optional: true
         name: switch
       - id: 21
         type: string
@@ -115,23 +114,6 @@ entities:
         range:
           min: 1
           max: 1000
-  - entity: select
-    translation_key: mode
-    category: config
-    dps:
-      - id: 21
-        type: string
-        name: option
-        optional: true
-        mapping:
-          - dps_val: "white"
-            value: "White"
-          - dps_val: "colour"
-            value: "Color"
-          - dps_val: "scene"
-            value: "Scene"
-          - dps_val: "music"
-            value: "Music"
   - entity: select
     translation_key: scene
     category: config

--- a/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
@@ -6,11 +6,15 @@ products:
   - id: rqrkvuxebofiaifp
     manufacturer: Fancy LED
     model: Fancy Lightstrip  3
+  - id: m6abhkeubvtdfjgw
+    manufacturer: Arlec
+    model: Smart Sound Sync Mood Lamp - ALP018HA
 entities:
   - entity: light
     dps:
       - id: 20
         type: boolean
+        optional: true
         name: switch
       - id: 21
         type: string
@@ -72,9 +76,11 @@ entities:
       - id: 46
         name: length_cm
         type: integer
+        optional: true
       - id: 47
         name: pixels
         type: integer
+        optional: true
       - id: 51
         name: dreamlight_scene
         type: string
@@ -110,7 +116,7 @@ entities:
           min: 1
           max: 1000
   - entity: select
-    name: Color mode
+    name: Mode
     icon: "mdi:palette"
     category: config
     dps:
@@ -119,7 +125,9 @@ entities:
         name: option
         optional: true
         mapping:
-          - dps_val: "color"
+          - dps_val: "white"
+            value: "White"
+          - dps_val: "colour"
             value: "Color"
           - dps_val: "scene"
             value: "Scene"
@@ -222,3 +230,61 @@ entities:
             value: "Summer wind"
           - dps_val: "AToCXV3gAABNALReARxkAOhJAMZf"
             value: "Planet journey"
+  - entity: select
+    name: Sound sync mode
+    icon: "mdi:music"
+    category: config
+    dps:
+      - id: 52
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "AQEAA2QZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 25%"
+          - dps_val: "AQEAA2QyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 50%"
+          - dps_val: "AQEAA2RLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 75%"
+          - dps_val: "AQEAA2RkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 100%"
+          - dps_val: "AQEAAmQZAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 25%"
+          - dps_val: "AQEAAmQyAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 50%"
+          - dps_val: "AQEAAmRLAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 75%"
+          - dps_val: "AQEAAmRkAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 100%"
+          - dps_val: "AQEAEmQZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 25%"
+          - dps_val: "AQEAEmQyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 50%"
+          - dps_val: "AQEAEmRLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 75%"
+          - dps_val: "AQEAEmRkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 100%"
+          - dps_val: "AQEBAmQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 25%"
+          - dps_val: "AQEBAmQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 50%"
+          - dps_val: "AQEBAmRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 75%"
+          - dps_val: "AQEBAmRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 100%"
+          - dps_val: "AQECAGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 25%"
+          - dps_val: "AQECAGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 50%"
+          - dps_val: "AQECAGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 75%"
+          - dps_val: "AQECAGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 100%"
+          - dps_val: "AQEDEGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 25%"
+          - dps_val: "AQEDEGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 50%"
+          - dps_val: "AQEDEGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 75%"
+          - dps_val: "AQEDEGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 100%"

--- a/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
@@ -116,8 +116,7 @@ entities:
           min: 1
           max: 1000
   - entity: select
-    name: Mode
-    icon: "mdi:palette"
+    translation_key: mode
     category: config
     dps:
       - id: 21

--- a/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
@@ -104,6 +104,23 @@ entities:
         range:
           min: 1
           max: 1000
+  - entity: select
+    name: Color mode
+    deprecated: light.color_mode  # 2026-08-10
+    icon: "mdi:palette"
+    category: config
+    dps:
+      - id: 21
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "color"
+            value: "Color"
+          - dps_val: "scene"
+            value: "Scene"
+          - dps_val: "music"
+            value: "Music"
   - entity: text
     translation_key: scene
     category: config

--- a/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_led_strip.yaml
@@ -75,19 +75,9 @@ entities:
       - id: 46
         name: length_cm
         type: integer
-        optional: true
       - id: 47
         name: pixels
         type: integer
-        optional: true
-      - id: 51
-        name: dreamlight_scene
-        type: string
-        optional: true
-      - id: 52
-        name: dreamlight_music_data
-        type: string
-        optional: true
       - id: 61
         name: paint_colour_data
         type: string
@@ -114,6 +104,15 @@ entities:
         range:
           min: 1
           max: 1000
+  - entity: text
+    translation_key: scene
+    category: config
+    hidden: true
+    dps:
+      - id: 51
+        type: base64
+        optional: true
+        name: value
   - entity: select
     translation_key: scene
     category: config
@@ -211,61 +210,13 @@ entities:
             value: "Summer wind"
           - dps_val: "AToCXV3gAABNALReARxkAOhJAMZf"
             value: "Planet journey"
-  - entity: select
-    name: Sound sync mode
+  - entity: text
+    name: Sound sync
     icon: "mdi:music"
     category: config
+    hidden: true
     dps:
       - id: 52
-        type: string
-        name: option
+        type: base64
+        name: value
         optional: true
-        mapping:
-          - dps_val: "AQEAA2QZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 25%"
-          - dps_val: "AQEAA2QyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 50%"
-          - dps_val: "AQEAA2RLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 75%"
-          - dps_val: "AQEAA2RkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 100%"
-          - dps_val: "AQEAAmQZAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 25%"
-          - dps_val: "AQEAAmQyAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 50%"
-          - dps_val: "AQEAAmRLAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 75%"
-          - dps_val: "AQEAAmRkAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 100%"
-          - dps_val: "AQEAEmQZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 25%"
-          - dps_val: "AQEAEmQyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 50%"
-          - dps_val: "AQEAEmRLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 75%"
-          - dps_val: "AQEAEmRkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 100%"
-          - dps_val: "AQEBAmQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 25%"
-          - dps_val: "AQEBAmQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 50%"
-          - dps_val: "AQEBAmRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 75%"
-          - dps_val: "AQEBAmRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 100%"
-          - dps_val: "AQECAGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 25%"
-          - dps_val: "AQECAGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 50%"
-          - dps_val: "AQECAGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 75%"
-          - dps_val: "AQECAGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 100%"
-          - dps_val: "AQEDEGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 25%"
-          - dps_val: "AQEDEGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 50%"
-          - dps_val: "AQEDEGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 75%"
-          - dps_val: "AQEDEGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 100%"

--- a/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
@@ -4,7 +4,6 @@ products:
     manufacturer: Outsmart
     model: RGBIC LED
   - id: kmgfxv1zmklfpxxn
-    manufacturer: Outsmart
     model: JSK-P22
   - id: wuy0oikiieoirzs7
     manufacturer: Arlec
@@ -17,6 +16,7 @@ entities:
     dps:
       - id: 20
         type: boolean
+        optional: true
         name: switch
       - id: 21
         type: string
@@ -186,64 +186,6 @@ entities:
             value: "Summer wind"
           - dps_val: "AToCXV3gAABNALReARxkAOhJAMZf"
             value: "Planet journey"
-  - entity: select
-    name: Sound sync mode
-    icon: "mdi:music"
-    category: config
-    dps:
-      - id: 52
-        type: string
-        name: option
-        optional: true
-        mapping:
-          - dps_val: "AQEAA2QZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 25%"
-          - dps_val: "AQEAA2QyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 50%"
-          - dps_val: "AQEAA2RLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 75%"
-          - dps_val: "AQEAA2RkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Flash 100%"
-          - dps_val: "AQEAAmQZAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 25%"
-          - dps_val: "AQEAAmQyAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 50%"
-          - dps_val: "AQEAAmRLAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 75%"
-          - dps_val: "AQEAAmRkAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
-            value: "Fade 100%"
-          - dps_val: "AQEAEmQZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 25%"
-          - dps_val: "AQEAEmQyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 50%"
-          - dps_val: "AQEAEmRLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 75%"
-          - dps_val: "AQEAEmRkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Jump 100%"
-          - dps_val: "AQEBAmQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 25%"
-          - dps_val: "AQEBAmQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 50%"
-          - dps_val: "AQEBAmRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 75%"
-          - dps_val: "AQEBAmRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Scroll 100%"
-          - dps_val: "AQECAGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 25%"
-          - dps_val: "AQECAGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 50%"
-          - dps_val: "AQECAGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 75%"
-          - dps_val: "AQECAGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
-            value: "Energy 100%"
-          - dps_val: "AQEDEGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 25%"
-          - dps_val: "AQEDEGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 50%"
-          - dps_val: "AQEDEGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 75%"
-          - dps_val: "AQEDEGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
-            value: "Spectrum 100%"
   - entity: text
     name: Music
     category: config

--- a/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
@@ -4,7 +4,14 @@ products:
     manufacturer: Outsmart
     model: RGBIC LED
   - id: kmgfxv1zmklfpxxn
+    manufacturer: Outsmart
     model: JSK-P22
+  - id: wuy0oikiieoirzs7
+    manufacturer: Arlec
+    model: Smart 5m Neon Flex - CHR370HA
+  - id: ceu9kibxiqqcpigb
+    manufacturer: Arlec
+    model: Smart Desk Light - CHR352HA
 entities:
   - entity: light
     dps:
@@ -83,6 +90,22 @@ entities:
           - dps_val: null
             value: false
           - value: true
+  - entity: select
+    name: Mode
+    icon: "mdi:palette"
+    category: config
+    dps:
+      - id: 21
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "colour"
+            value: "Color"
+          - dps_val: "scene"
+            value: "Scene"
+          - dps_val: "music"
+            value: "Music"
   - entity: select
     translation_key: scene
     category: config
@@ -180,6 +203,64 @@ entities:
             value: "Summer wind"
           - dps_val: "AToCXV3gAABNALReARxkAOhJAMZf"
             value: "Planet journey"
+  - entity: select
+    name: Sound sync mode
+    icon: "mdi:music"
+    category: config
+    dps:
+      - id: 52
+        type: string
+        name: option
+        optional: true
+        mapping:
+          - dps_val: "AQEAA2QZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 25%"
+          - dps_val: "AQEAA2QyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 50%"
+          - dps_val: "AQEAA2RLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 75%"
+          - dps_val: "AQEAA2RkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Flash 100%"
+          - dps_val: "AQEAAmQZAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 25%"
+          - dps_val: "AQEAAmQyAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 50%"
+          - dps_val: "AQEAAmRLAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 75%"
+          - dps_val: "AQEAAmRkAAAAZAAAUAB4UADwUAA8UAC0UAEsUAAAAA=="
+            value: "Fade 100%"
+          - dps_val: "AQEAEmQZAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 25%"
+          - dps_val: "AQEAEmQyAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 50%"
+          - dps_val: "AQEAEmRLAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 75%"
+          - dps_val: "AQEAEmRkAAAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Jump 100%"
+          - dps_val: "AQEBAmQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 25%"
+          - dps_val: "AQEBAmQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 50%"
+          - dps_val: "AQEBAmRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 75%"
+          - dps_val: "AQEBAmRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Scroll 100%"
+          - dps_val: "AQECAGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 25%"
+          - dps_val: "AQECAGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 50%"
+          - dps_val: "AQECAGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 75%"
+          - dps_val: "AQECAGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZA=="
+            value: "Energy 100%"
+          - dps_val: "AQEDEGQZAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 25%"
+          - dps_val: "AQEDEGQyAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 50%"
+          - dps_val: "AQEDEGRLAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 75%"
+          - dps_val: "AQEDEGRkAQAAZAAAZAB4ZADwZAA8ZAC0ZAEsZAAAAA=="
+            value: "Spectrum 100%"
   - entity: text
     name: Music
     category: config

--- a/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
@@ -17,7 +17,6 @@ entities:
     dps:
       - id: 20
         type: boolean
-        optional: true
         name: switch
       - id: 21
         type: string
@@ -90,21 +89,6 @@ entities:
           - dps_val: null
             value: false
           - value: true
-  - entity: select
-    translation_key: mode
-    category: config
-    dps:
-      - id: 21
-        type: string
-        name: option
-        optional: true
-        mapping:
-          - dps_val: "colour"
-            value: "Color"
-          - dps_val: "scene"
-            value: "Scene"
-          - dps_val: "music"
-            value: "Music"
   - entity: select
     translation_key: scene
     category: config

--- a/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
+++ b/custom_components/tuya_local/devices/dreamlight_rgb_strip.yaml
@@ -91,8 +91,7 @@ entities:
             value: false
           - value: true
   - entity: select
-    name: Mode
-    icon: "mdi:palette"
+    translation_key: mode
     category: config
     dps:
       - id: 21


### PR DESCRIPTION
Added support for 3 Arlec branded lights:

Smart 5m Neon Flex - CHR370HA
Smart Desk Light - CHR352HA
Smart Sound Sync Mood Lamp - ALP018HA

Unified colour mode and added sound sync mode configurations across 2 devices; dreamlight_led_strip.yaml and dreamlight_rgb_strip.yaml.