### PR TITLE
Add support for SPT Dark Knight heat pump water heater

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -257,7 +257,6 @@
 - Shuangri SR223 solar water heating controller
 - Sime EcoMaxi VB200 heat pump water heater
 - SolarEast (Adlar Castra) Aurora II heat pump
-- SPT Dark Knight WH315A-RE heat pump water heater
 - Tauclima DGN-250 heat pump water heater
 - Thermann R290 heat pump water heater
 - Thermex IF series V pro and Lima 80V hot water systems

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -257,6 +257,7 @@
 - Shuangri SR223 solar water heating controller
 - Sime EcoMaxi VB200 heat pump water heater
 - SolarEast (Adlar Castra) Aurora II heat pump
+- SPT Dark Knight WH315A-RE heat pump water heater
 - Tauclima DGN-250 heat pump water heater
 - Thermann R290 heat pump water heater
 - Thermex IF series V pro and Lima 80V hot water systems

--- a/custom_components/tuya_local/devices/spt_darkknight_waterheater.yaml
+++ b/custom_components/tuya_local/devices/spt_darkknight_waterheater.yaml
@@ -1,4 +1,4 @@
-name: Heat pump water heater
+name: Water heater
 products:
   - id: gbna0cgw5i7lhjup
     manufacturer: SPT

--- a/custom_components/tuya_local/devices/spt_darkknight_waterheater.yaml
+++ b/custom_components/tuya_local/devices/spt_darkknight_waterheater.yaml
@@ -1,0 +1,58 @@
+name: Heat pump water heater
+products:
+  - id: gbna0cgw5i7lhjup
+    manufacturer: SPT
+    model: Dark Knight WH315A-RE
+entities:
+  - entity: water_heater
+    dps:
+      - id: 1
+        type: boolean
+        name: operation_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: WATER
+                value: heat_pump
+              - dps_val: COOL
+                value: high_demand
+              - dps_val: eh
+                value: electric
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        # 38-75 confirmed as the controller's setpoint range on the unit's
+        # own panel. The manual's 35-70 figure is the outlet water temp
+        # spec, not the setpoint clamp.
+        range:
+          min: 38
+          max: 75
+      - id: 3
+        type: integer
+        name: current_temperature
+        unit: C
+      # DP4 enum confirmed by observation on a WH315A-RE:
+      #   WATER = heat pump only, COOL = hybrid (heat pump + element),
+      #   eh = element only
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 9
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 9
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
Adds support for the SPT Dark Knight, an Australian R290 heat pump water
heater. Config is in daily use on my own WH315A-RE.

Product id: gbna0cgw5i7lhjup, protocol 3.4
DPs: 1 bool (power), 2 int (setpoint), 3 int (tank temp), 4 str (mode),
9 bitfield (fault)

DP4 values confirmed by switching modes on the unit's own control panel and
reading diagnostics after each change:
  WATER = heat pump only    -> heat_pump
  COOL  = heat pump + element -> high_demand
  eh    = element only      -> electric

DP2 range 38-75C, confirmed on the unit's control panel. The manual's
35-70C figure is the outlet water temp spec, not the setpoint range.

DP9 read 0 throughout, so I have mapped only the problem flag and fault_code.
The manual documents P01-P08, E01-E04, E08 and PA, but I could not verify the
bit positions without triggering a real fault. I did not copy the bit map from
ems_waterheater, as that table covers six P-codes where this unit has eight.

The 265L variants (WH265A-RE/-CE) and the commercial -C models are likely the
same controller but I cannot confirm - happy to add product ids if other
owners report them.

yamllint passes.