### PR TITLE
Add Rhino King H7 central HVAC controller

### DIFF
--- a/custom_components/tuya_local/devices/h7_central_controller.yaml
+++ b/custom_components/tuya_local/devices/h7_central_controller.yaml
@@ -230,8 +230,6 @@ entities:
         optional: true
         name: sensor
         unit: "°C"
-        mapping:
-          - scale: 10
   - entity: sensor
     name: 外机回水温度
     class: temperature
@@ -241,8 +239,6 @@ entities:
         optional: true
         name: sensor
         unit: "°C"
-        mapping:
-          - scale: 10
 
   - entity: sensor
     name: H7当前运行模式状态

--- a/custom_components/tuya_local/devices/h7_central_controller.yaml
+++ b/custom_components/tuya_local/devices/h7_central_controller.yaml
@@ -1,10 +1,8 @@
-  # ======基本完美了除了列表加的温度没有%标==== =======================================
-  # 存档路径/homeassistant/custom_components/tuya_local/devices/1xnwh7.yaml
-  #每个H7可能不同先去涂鸦IO网站点云开发-API调试-设备控制-查询物模型查ID实际值
-  # =========================================================================
-name: H7 Central Controller Full
+name: Central HVAC controller
 products:
   - id: ddbcuqy4usocv9lv
+    manufacturer: Rhino King
+    model: H7
 entities:
   # =========================================================================
   # --- 1. 主要控制区（日常核心控制，不带 category 直接显示在最顶部） ---
@@ -49,13 +47,13 @@ entities:
             value: "出风"
           - dps_val: "cold"
             value: "制冷"
-          - dps_val: "hea"              
+          - dps_val: "hea"
             value: "制热"
-          - dps_val: "floorhea"         
+          - dps_val: "floorhea"
             value: "地暖"
           - dps_val: "heat_floorheat"
             value: "制热+地暖"
-          - dps_val: "cold_floorcold"   
+          - dps_val: "cold_floorcold"
             value: "制冷+地冷"
 
       # --- 温度控制 ---
@@ -86,7 +84,7 @@ entities:
           min: 0
           max: 100
         mapping:
-          - scale: 1                        
+          - scale: 1
 
   # =========================================================================
   # --- 2. 轨道二：抽成独立的传感器实体，供顶部卡片与变色程序码直接调用 ---
@@ -140,8 +138,6 @@ entities:
         range:
           min: 0
           max: 6
-
-
 
   # ---关旁通D阀触发数 ---
   - entity: number
@@ -602,7 +598,7 @@ entities:
         range:
           min: 25
           max: 55
-          
+
   - entity: number
     name: 水箱控制温差
     icon: mdi:thermometer
@@ -616,7 +612,7 @@ entities:
         range:
           min: 1
           max: 5
-          
+
   - entity: number
     name: 地暖辐射最低供水温度
     icon: mdi:snowflake-thermometer
@@ -660,7 +656,7 @@ entities:
           max: 4
 
   - entity: number
-    name: 制热初切换切阀月数 # API接口未体现
+    name: 制热初切换切阀月数  # API接口未体现
     icon: mdi:calendar-month
     category: config
     dps:

--- a/custom_components/tuya_local/devices/h7_central_controller.yaml
+++ b/custom_components/tuya_local/devices/h7_central_controller.yaml
@@ -1,0 +1,787 @@
+  # ======基本完美了除了列表加的温度没有%标==== =======================================
+  # 存档路径/homeassistant/custom_components/tuya_local/devices/1xnwh7.yaml
+  #每个H7可能不同先去涂鸦IO网站点云开发-API调试-设备控制-查询物模型查ID实际值
+  # =========================================================================
+name: H7 Central Controller Full
+products:
+  - id: ddbcuqy4usocv9lv
+entities:
+  # =========================================================================
+  # --- 1. 主要控制区（日常核心控制，不带 category 直接显示在最顶部） ---
+  # =========================================================================
+  - entity: climate
+    dps:
+      # --- 主开关：关机直接对应 off；开机时依据 DP2 回报 HA 标准 HVAC 模式 ---
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: "wind"
+                value: fan_only
+              - dps_val: "cold"
+                value: cool
+              - dps_val: "hea"
+                value: heat
+              - dps_val: "floorhea"
+                value: heat
+              - dps_val: "heat_floorheat"
+                value: heat
+              - dps_val: "cold_floorcold"
+                value: cool
+
+      # --- 核心模式原始 DP：供 hvac_mode 條件映射使用 ---
+      - id: 2
+        type: string
+        name: mode
+        hidden: true
+
+      # --- 核心模式：H7 专有的 6 种运行模式，放在 climate preset 里 ---
+      - id: 2
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: "wind"
+            value: "出风"
+          - dps_val: "cold"
+            value: "制冷"
+          - dps_val: "hea"              
+            value: "制热"
+          - dps_val: "floorhea"         
+            value: "地暖"
+          - dps_val: "heat_floorheat"
+            value: "制热+地暖"
+          - dps_val: "cold_floorcold"   
+            value: "制冷+地冷"
+
+      # --- 温度控制 ---
+      - id: 16
+        type: integer
+        name: temperature
+        range:
+          min: 150
+          max: 400
+        mapping:
+          - scale: 10
+            step: 1                     # 0.1℃ 步進
+
+      - id: 24
+        type: integer
+        name: current_temperature
+        range:
+          min: -200
+          max: 500
+        mapping:
+          - scale: 10
+
+      # --- 轨道一：塞进空调内，让温控器面板正中央显示湿度 ---
+      - id: 34
+        type: integer
+        name: current_humidity
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - scale: 1                        
+
+  # =========================================================================
+  # --- 2. 轨道二：抽成独立的传感器实体，供顶部卡片与变色程序码直接调用 ---
+  # =========================================================================
+  - entity: sensor
+    name: "H7 Indoor Humidity"          # 给它一个专有名字，避免后台生成实体时打架
+    class: humidity
+    dps:
+      - id: 34
+        type: integer
+        name: sensor
+        unit: "%"
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - scale: 1
+
+  - entity: select
+    name: H7运行模式
+    icon: mdi:hvac
+    dps:
+      - id: 2
+        type: string
+        name: option
+        mapping:
+          - dps_val: "wind"
+            value: "出风"
+          - dps_val: "cold"
+            value: "制冷"
+          - dps_val: "hea"
+            value: "制热"
+          - dps_val: "floorhea"
+            value: "地暖"
+          - dps_val: "heat_floorheat"
+            value: "制热+地暖"
+          - dps_val: "cold_floorcold"
+            value: "制冷+地冷"
+
+  # =========================================================================
+  # --- 3. 辅助旁通数量 ---
+  # =========================================================================
+  - entity: number
+    name: 辅助旁通数量
+    icon: mdi:source-branch
+    dps:
+      - id: 109
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0
+          max: 6
+
+
+
+  # ---关旁通D阀触发数 ---
+  - entity: number
+    name: 关旁通D阀触发数
+    icon: mdi:clock-start
+    dps:
+      - id: 111
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0
+          max: 10
+
+  - entity: switch
+    name: 内外机联动控制开关
+    icon: mdi:link-variant
+    dps:
+      - id: 142
+        type: boolean
+        optional: true
+        name: switch
+
+  # =========================================================================
+  # --- 2. 传感器日常监控区 ---
+  # =========================================================================
+  - entity: sensor
+    name: H7系统计算露点
+    class: temperature
+    dps:
+      - id: 102
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: 辐射混水供水温度
+    class: temperature
+    dps:
+      - id: 115
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: 辐射混水回水温度
+    class: temperature
+    dps:
+      - id: 116
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: PM2.5
+    class: pm25
+    dps:
+      - id: 121
+        type: integer
+        optional: true
+        name: sensor
+        unit: "µg/m³"
+        mapping:
+          - step: 1
+
+  - entity: sensor
+    name: H7外机运行状态
+    icon: mdi:heat-pump
+    dps:
+      - id: 125
+        type: string
+        optional: true
+        name: sensor
+
+  - entity: sensor
+    name: 外机供水温度
+    class: temperature
+    dps:
+      - id: 126
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    name: 外机回水温度
+    class: temperature
+    dps:
+      - id: 127
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - scale: 10
+
+  - entity: sensor
+    name: H7当前运行模式状态
+    icon: mdi:list-status
+    dps:
+      - id: 128
+        type: string
+        optional: true
+        name: sensor
+
+  - entity: sensor
+    name: CO2
+    class: carbon_dioxide
+    dps:
+      - id: 130
+        type: integer         #   type: value 数值形态
+        optional: true        #   API 可選屬性
+        name: sensor
+        unit: "ppm"           #   体现 unit: "ppm"
+        mapping:
+          - step: 1           #  体现 step: 1
+
+  - entity: sensor
+    name: H7水泵当前状态
+    class: enum
+    icon: mdi:pump
+    dps:
+      - id: 131
+        type: string
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: all_off
+            value: "全关"
+          - dps_val: fancoilpump_on
+            value: "风盘水泵开"
+          - dps_val: floorheatingpump_on
+            value: "地暖水泵开"
+          - dps_val: all_on
+            value: "全开"
+
+  - entity: sensor
+    name: 水箱温度
+    class: temperature
+    dps:
+      - id: 135
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - step: 1
+
+  - entity: sensor
+    name: 外机环境实际温度
+    class: temperature
+    dps:
+      - id: 146
+        type: integer
+        optional: true
+        name: sensor
+        unit: "°C"
+        mapping:
+          - scale: 1
+
+  # =========================================================================
+  # --- 3. 诊断区（H7系统故障代码） ---
+  # =========================================================================
+  - entity: sensor
+    class: enum   # 依据标准规范，必须将 device_class 改写为顶层的 class: enum
+    name: H7系统故障代码
+    category: diagnostic
+    icon: mdi:alert-circle-outline
+    dps:
+      - id: 122
+        type: string
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: "0"
+            value: "正常"
+          - dps_val: "none"
+            value: "正常"
+          - dps_val: "stop_rotate"
+            value: "阀门停止 (stop_rotate)"
+          - dps_val: "pos_rotate"
+            value: "阀门正转 (pos_rotate)"
+          - dps_val: "neg_rotate"
+            value: "阀门反转 (neg_rotate)"
+          - dps_val: "dewpont_prot"
+            value: "露点保护 (dewpont_prot)"
+
+  - entity: sensor
+    class: enum
+    name: 内机冷热阀  # 🌟 内机冷热阀 (ID: 138) - 只读枚举型传感器
+    category: diagnostic
+    icon: mdi:valve-letter
+    dps:
+      - id: 138
+        type: string
+        optional: true
+        name: sensor
+        mapping:
+          - dps_val: "all_off"
+            value: "全关 (all_off)"
+          - dps_val: "cold_on"
+            value: "开启制冷 (cold_on)"
+          - dps_val: "heat_on"
+            value: "开启制热 (heat_on)"
+          - dps_val: "all_on"
+            value: "全开 (all_on)"
+
+  # =========================================================================
+  # --- 4. 配置面板区（所有的控制下拉选择菜单全部在此） ---
+  # =========================================================================
+  - entity: select
+    name: 外机型号
+    category: config
+    icon: mdi:factory
+    dps:
+      - id: 101
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: HITACHI
+            value: "日立"
+          - dps_val: YORK_012_018
+            value: "约克"
+          - dps_val: MACQUAY
+            value: "麦克维尔"
+          - dps_val: TRANE
+            value: "特灵"
+
+  - entity: select
+    name: 外机接口方式
+    category: config
+    icon: mdi:cable-data
+    dps:
+      - id: 103
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "RS485"
+            value: "总线485"
+          - dps_val: "RELAY"
+            value: "干接点"
+          - dps_val: "TANK_TEMP"
+            value: "干接点+水箱温度"
+
+  - entity: select
+    name: 外机变水温  # 🌟  (ID: 105) - 可读写列举型，生成 select 实体
+    icon: mdi:sine-wave
+    category: config
+    dps:
+      - id: 105
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "manual"
+            value: "手动"
+          - dps_val: "auto"
+            value: "自动"
+
+  - entity: number
+    name: 丛控地址   # 🌟  (ID: 108)
+    icon: mdi:ip-network
+    category: config
+    dps:
+      - id: 108
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0               # min: 0
+          max: 32              # 体现 max: 32
+
+  - entity: number
+    name: 新风数量
+    icon: mdi:fan-alert
+    category: config
+    dps:
+      - id: 110
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0               # 100% 体现 min: 0
+          max: 10              # 100% 体现 max: 10
+
+  - entity: select
+    name: 混水阀类型    # 🌟 (ID: 117) - 可读写列举型，生成 select 实体
+    icon: mdi:valve
+    category: config
+    dps:
+      - id: 117
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "220V"
+            value: "220V"
+          - dps_val: "24V"
+            value: "24V"
+          - dps_val: "12V"
+            value: "12V"
+
+  - entity: select
+    name: 外机水温控制方式
+    category: config
+    icon: mdi:router-wireless-settings
+    dps:
+      - id: 123
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: water_return_control
+            value: "回水控制"
+          - dps_val: water_out_control
+            value: "出水控制"
+
+  - entity: select
+    name: 主从模式设置
+    category: config
+    icon: mdi:account-network
+    dps:
+      - id: 133
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: master
+            value: "主控"
+          - dps_val: slave
+            value: "从控"
+
+  - entity: select
+    name: 干接点模式配置
+    category: config
+    icon: mdi:toggle-switch
+    dps:
+      - id: 136
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: cold_open
+            value: "制冷闭合"
+          - dps_val: cold_close
+            value: "制热闭合"
+
+  - entity: select
+    name: 干接点开关配置
+    category: config
+    icon: mdi:toggle-switch-outline
+    dps:
+      - id: 137
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: relay_onoff_open
+            value: "开机闭合"
+          - dps_val: relay_onoff_close
+            value: "关机闭合"
+
+  - entity: select
+    name: 季节模式切换
+    category: config
+    icon: mdi:calendar-sync
+    dps:
+      - id: 139
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: hand
+            value: "手动"
+          - dps_val: manual
+            value: "手动"
+          - dps_val: Manual
+            value: "手动"
+          - dps_val: auto
+            value: "自动"
+          - dps_val: Auto
+            value: "自动"
+
+  - entity: number
+    name: 外机安装数量
+    icon: mdi:numeric-1-box-multiple
+    category: config
+    dps:
+      - id: 104
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0
+          max: 6
+
+  - entity: number
+    name: 系统的内机总数
+    icon: mdi:format-list-numbered
+    category: config
+    dps:
+      - id: 107
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0
+          max: 32
+
+  - entity: number
+    name: 本地总线地址
+    icon: mdi:bus
+    category: config
+    dps:
+      - id: 118
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0
+          max: 32
+
+  - entity: number
+    name: 从机控制面板数量
+    icon: mdi:dots-hexagon
+    category: config
+    dps:
+      - id: 134
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: 0
+          max: 10
+
+  - entity: number
+    name: 外机采暖热水温度设置
+    icon: mdi:thermometer-hot
+    category: config
+    dps:
+      - id: 119
+        type: integer
+        optional: true
+        name: value
+        unit: "°C"
+        range:
+          min: 25
+          max: 55
+          
+  - entity: number
+    name: 水箱控制温差
+    icon: mdi:thermometer
+    category: config
+    dps:
+      - id: 120
+        type: integer
+        optional: true
+        name: value
+        unit: "°C"
+        range:
+          min: 1
+          max: 5
+          
+  - entity: number
+    name: 地暖辐射最低供水温度
+    icon: mdi:snowflake-thermometer
+    category: config
+    dps:
+      - id: 124
+        type: integer
+        optional: true
+        name: value
+        unit: "°C"
+        range:
+          min: 25
+          max: 45
+
+  - entity: number
+    name: 外机供冷目标温度设置
+    icon: mdi:thermometer-water
+    category: config
+    dps:
+      - id: 129
+        type: integer
+        optional: true
+        name: value
+        unit: "°C"
+        range:
+          min: 5
+          max: 20
+
+  - entity: number
+    name: 制冷初切换切阀月数  # API接口未体现
+    icon: mdi:calendar-month
+    category: config
+    dps:
+      - id: 140
+        type: integer
+        optional: true
+        name: value
+        unit: "m"
+        range:
+          min: 1
+          max: 4
+
+  - entity: number
+    name: 制热初切换切阀月数 # API接口未体现
+    icon: mdi:calendar-month
+    category: config
+    dps:
+      - id: 141
+        type: integer
+        optional: true
+        name: value
+        unit: "m"
+        range:
+          min: 10
+          max: 12
+
+  - entity: number
+    name: 直通常开延时
+    icon: mdi:clock-start
+    category: config
+    dps:
+      - id: 110
+        type: integer
+        optional: true
+        name: value
+        unit: "s"
+        mapping:
+          - step: 5
+        range:
+          min: 0
+          max: 250
+
+  - entity: number
+    name: 直通常关延时
+    icon: mdi:clock-end
+    category: config
+    dps:
+      - id: 112
+        type: integer
+        optional: true
+        name: value
+        unit: "s"
+        mapping:
+          - step: 5
+        range:
+          min: 0
+          max: 250
+
+  - entity: number
+    name: 混水泵开启延时
+    icon: mdi:clock-start
+    category: config
+    dps:
+      - id: 110
+        type: integer
+        optional: true
+        name: value
+        unit: "s"
+        mapping:
+          - step: 5
+        range:
+          min: 0
+          max: 250
+
+  - entity: number
+    name: 混水泵关闭延时
+    icon: mdi:clock-end
+    category: config
+    dps:
+      - id: 113
+        type: integer
+        optional: true
+        name: value
+        unit: "s"
+        mapping:
+          - step: 5
+        range:
+          min: 0
+          max: 250
+
+  - entity: switch
+    name: 辐射混水控制开关
+    icon: mdi:water-sync
+    category: config
+    dps:
+      - id: 114
+        type: boolean
+        optional: true
+        name: switch
+
+  - entity: select
+    name: 外机状态运行指示
+    category: config
+    icon: mdi:power-cycle
+    dps:
+      - id: 106
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: "ON"
+            value: "运行中"
+          - dps_val: "OFF"
+            value: "已停止"
+
+  - entity: number
+    name: 壁挂炉温度设置
+    icon: mdi:speedometer
+    category: config
+    dps:
+      - id: 143
+        type: integer
+        optional: true
+        name: value        #  体现 type: value 的标准声明
+        unit: "%"          #   体现 unit: "%"
+        range:
+          min: -15         #   体现 min: -15
+          max: 20          #  体现 max: 20
+
+  - entity: switch
+    name: 壁挂炉辅助系统开关
+    icon: mdi:fire
+    category: config
+    dps:
+      - id: 132
+        type: boolean
+        optional: true
+        name: switch

--- a/custom_components/tuya_local/devices/h7_central_controller.yaml
+++ b/custom_components/tuya_local/devices/h7_central_controller.yaml
@@ -4,12 +4,8 @@ products:
     manufacturer: Rhino King
     model: H7
 entities:
-  # =========================================================================
-  # --- 1. 主要控制区（日常核心控制，不带 category 直接显示在最顶部） ---
-  # =========================================================================
   - entity: climate
     dps:
-      # --- 主开关：关机直接对应 off；开机时依据 DP2 回报 HA 标准 HVAC 模式 ---
       - id: 1
         type: boolean
         name: hvac_mode
@@ -17,7 +13,7 @@ entities:
           - dps_val: false
             value: "off"
           - dps_val: true
-            constraint: mode
+            constraint: preset_mode
             conditions:
               - dps_val: "wind"
                 value: fan_only
@@ -27,36 +23,31 @@ entities:
                 value: heat
               - dps_val: "floorhea"
                 value: heat
+                hidden: true
               - dps_val: "heat_floorheat"
                 value: heat
+                hidden: true
               - dps_val: "cold_floorcold"
                 value: cool
+                hidden: true
 
-      # --- 核心模式原始 DP：供 hvac_mode 條件映射使用 ---
-      - id: 2
-        type: string
-        name: mode
-        hidden: true
-
-      # --- 核心模式：H7 专有的 6 种运行模式，放在 climate preset 里 ---
       - id: 2
         type: string
         name: preset_mode
         mapping:
           - dps_val: "wind"
-            value: "出风"
+            value: Fan only
           - dps_val: "cold"
-            value: "制冷"
+            value: Cooling
           - dps_val: "hea"
-            value: "制热"
+            value: Heating
           - dps_val: "floorhea"
-            value: "地暖"
+            value: Floor heating
           - dps_val: "heat_floorheat"
-            value: "制热+地暖"
+            value: Heating + floor heating
           - dps_val: "cold_floorcold"
-            value: "制冷+地冷"
+            value: Cooling + floor cooling
 
-      # --- 温度控制 ---
       - id: 16
         type: integer
         name: temperature
@@ -65,7 +56,7 @@ entities:
           max: 400
         mapping:
           - scale: 10
-            step: 1                     # 0.1℃ 步進
+            step: 1
 
       - id: 24
         type: integer
@@ -76,7 +67,6 @@ entities:
         mapping:
           - scale: 10
 
-      # --- 轨道一：塞进空调内，让温控器面板正中央显示湿度 ---
       - id: 34
         type: integer
         name: current_humidity
@@ -86,50 +76,9 @@ entities:
         mapping:
           - scale: 1
 
-  # =========================================================================
-  # --- 2. 轨道二：抽成独立的传感器实体，供顶部卡片与变色程序码直接调用 ---
-  # =========================================================================
-  - entity: sensor
-    name: "H7 Indoor Humidity"          # 给它一个专有名字，避免后台生成实体时打架
-    class: humidity
-    dps:
-      - id: 34
-        type: integer
-        name: sensor
-        unit: "%"
-        range:
-          min: 0
-          max: 100
-        mapping:
-          - scale: 1
-
-  - entity: select
-    name: H7运行模式
-    icon: mdi:hvac
-    dps:
-      - id: 2
-        type: string
-        name: option
-        mapping:
-          - dps_val: "wind"
-            value: "出风"
-          - dps_val: "cold"
-            value: "制冷"
-          - dps_val: "hea"
-            value: "制热"
-          - dps_val: "floorhea"
-            value: "地暖"
-          - dps_val: "heat_floorheat"
-            value: "制热+地暖"
-          - dps_val: "cold_floorcold"
-            value: "制冷+地冷"
-
-  # =========================================================================
-  # --- 3. 辅助旁通数量 ---
-  # =========================================================================
   - entity: number
-    name: 辅助旁通数量
-    icon: mdi:source-branch
+    name: Auxiliary bypass count
+    icon: "mdi:source-branch"
     dps:
       - id: 109
         type: integer
@@ -139,10 +88,9 @@ entities:
           min: 0
           max: 6
 
-  # ---关旁通D阀触发数 ---
   - entity: number
-    name: 关旁通D阀触发数
-    icon: mdi:clock-start
+    name: Bypass D valve closing trigger count
+    icon: "mdi:clock-start"
     dps:
       - id: 111
         type: integer
@@ -153,19 +101,16 @@ entities:
           max: 10
 
   - entity: switch
-    name: 内外机联动控制开关
-    icon: mdi:link-variant
+    name: Indoor-outdoor unit linkage
+    icon: "mdi:link-variant"
     dps:
       - id: 142
         type: boolean
         optional: true
         name: switch
 
-  # =========================================================================
-  # --- 2. 传感器日常监控区 ---
-  # =========================================================================
   - entity: sensor
-    name: H7系统计算露点
+    name: Calculated dew point
     class: temperature
     dps:
       - id: 102
@@ -177,7 +122,7 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: 辐射混水供水温度
+    name: Radiant mixing supply temperature
     class: temperature
     dps:
       - id: 115
@@ -189,7 +134,7 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: 辐射混水回水温度
+    name: Radiant mixing return temperature
     class: temperature
     dps:
       - id: 116
@@ -201,7 +146,6 @@ entities:
           - scale: 10
 
   - entity: sensor
-    name: PM2.5
     class: pm25
     dps:
       - id: 121
@@ -209,12 +153,10 @@ entities:
         optional: true
         name: sensor
         unit: "µg/m³"
-        mapping:
-          - step: 1
 
   - entity: sensor
-    name: H7外机运行状态
-    icon: mdi:heat-pump
+    translation_key: status
+    icon: "mdi:heat-pump"
     dps:
       - id: 125
         type: string
@@ -222,7 +164,7 @@ entities:
         name: sensor
 
   - entity: sensor
-    name: 外机供水温度
+    name: Outdoor unit supply water temperature
     class: temperature
     dps:
       - id: 126
@@ -231,7 +173,7 @@ entities:
         name: sensor
         unit: "°C"
   - entity: sensor
-    name: 外机回水温度
+    name: Outdoor unit return water temperature
     class: temperature
     dps:
       - id: 127
@@ -241,8 +183,8 @@ entities:
         unit: "°C"
 
   - entity: sensor
-    name: H7当前运行模式状态
-    icon: mdi:list-status
+    name: Operating mode status
+    icon: "mdi:list-status"
     dps:
       - id: 128
         type: string
@@ -250,21 +192,18 @@ entities:
         name: sensor
 
   - entity: sensor
-    name: CO2
     class: carbon_dioxide
     dps:
       - id: 130
-        type: integer         #   type: value 数值形态
-        optional: true        #   API 可選屬性
+        type: integer
+        optional: true
         name: sensor
-        unit: "ppm"           #   体现 unit: "ppm"
-        mapping:
-          - step: 1           #  体现 step: 1
+        unit: "ppm"
 
   - entity: sensor
-    name: H7水泵当前状态
+    name: Pump status
     class: enum
-    icon: mdi:pump
+    icon: "mdi:pump"
     dps:
       - id: 131
         type: string
@@ -272,16 +211,16 @@ entities:
         name: sensor
         mapping:
           - dps_val: all_off
-            value: "全关"
+            value: All off
           - dps_val: fancoilpump_on
-            value: "风盘水泵开"
+            value: Fan coil pump on
           - dps_val: floorheatingpump_on
-            value: "地暖水泵开"
+            value: Floor heating pump on
           - dps_val: all_on
-            value: "全开"
+            value: All on
 
   - entity: sensor
-    name: 水箱温度
+    name: Tank temperature
     class: temperature
     dps:
       - id: 135
@@ -289,11 +228,9 @@ entities:
         optional: true
         name: sensor
         unit: "°C"
-        mapping:
-          - step: 1
 
   - entity: sensor
-    name: 外机环境实际温度
+    name: Outdoor ambient temperature
     class: temperature
     dps:
       - id: 146
@@ -304,14 +241,11 @@ entities:
         mapping:
           - scale: 1
 
-  # =========================================================================
-  # --- 3. 诊断区（H7系统故障代码） ---
-  # =========================================================================
   - entity: sensor
-    class: enum   # 依据标准规范，必须将 device_class 改写为顶层的 class: enum
-    name: H7系统故障代码
+    class: enum
+    name: System fault code
     category: diagnostic
-    icon: mdi:alert-circle-outline
+    icon: "mdi:alert-circle-outline"
     dps:
       - id: 122
         type: string
@@ -319,23 +253,23 @@ entities:
         name: sensor
         mapping:
           - dps_val: "0"
-            value: "正常"
+            value: Normal
           - dps_val: "none"
-            value: "正常"
+            value: Normal
           - dps_val: "stop_rotate"
-            value: "阀门停止 (stop_rotate)"
+            value: Valve stopped
           - dps_val: "pos_rotate"
-            value: "阀门正转 (pos_rotate)"
+            value: Valve rotating forward
           - dps_val: "neg_rotate"
-            value: "阀门反转 (neg_rotate)"
+            value: Valve rotating reverse
           - dps_val: "dewpont_prot"
-            value: "露点保护 (dewpont_prot)"
+            value: Dew point protection
 
   - entity: sensor
     class: enum
-    name: 内机冷热阀  # 🌟 内机冷热阀 (ID: 138) - 只读枚举型传感器
+    name: Indoor cooling and heating valve
     category: diagnostic
-    icon: mdi:valve-letter
+    icon: "mdi:valve-letter"
     dps:
       - id: 138
         type: string
@@ -343,21 +277,18 @@ entities:
         name: sensor
         mapping:
           - dps_val: "all_off"
-            value: "全关 (all_off)"
+            value: All off
           - dps_val: "cold_on"
-            value: "开启制冷 (cold_on)"
+            value: Cooling on
           - dps_val: "heat_on"
-            value: "开启制热 (heat_on)"
+            value: Heating on
           - dps_val: "all_on"
-            value: "全开 (all_on)"
+            value: All on
 
-  # =========================================================================
-  # --- 4. 配置面板区（所有的控制下拉选择菜单全部在此） ---
-  # =========================================================================
   - entity: select
-    name: 外机型号
+    name: Outdoor unit model
     category: config
-    icon: mdi:factory
+    icon: "mdi:factory"
     dps:
       - id: 101
         type: string
@@ -365,18 +296,18 @@ entities:
         name: option
         mapping:
           - dps_val: HITACHI
-            value: "日立"
+            value: Hitachi
           - dps_val: YORK_012_018
-            value: "约克"
+            value: York
           - dps_val: MACQUAY
-            value: "麦克维尔"
+            value: McQuay
           - dps_val: TRANE
-            value: "特灵"
+            value: Trane
 
   - entity: select
-    name: 外机接口方式
+    name: Outdoor unit interface
     category: config
-    icon: mdi:cable-data
+    icon: "mdi:cable-data"
     dps:
       - id: 103
         type: string
@@ -384,15 +315,16 @@ entities:
         name: option
         mapping:
           - dps_val: "RS485"
-            value: "总线485"
+            value: RS485 bus
           - dps_val: "RELAY"
-            value: "干接点"
+            value: Dry contact
           - dps_val: "TANK_TEMP"
-            value: "干接点+水箱温度"
+            value: Dry contact + tank temperature
 
   - entity: select
-    name: 外机变水温  # 🌟  (ID: 105) - 可读写列举型，生成 select 实体
-    icon: mdi:sine-wave
+    name: Outdoor water temperature control
+    translation_key: mode
+    icon: "mdi:sine-wave"
     category: config
     dps:
       - id: 105
@@ -401,13 +333,13 @@ entities:
         name: option
         mapping:
           - dps_val: "manual"
-            value: "手动"
+            value: manual
           - dps_val: "auto"
-            value: "自动"
+            value: auto
 
   - entity: number
-    name: 丛控地址   # 🌟  (ID: 108)
-    icon: mdi:ip-network
+    name: Group control address
+    icon: "mdi:ip-network"
     category: config
     dps:
       - id: 108
@@ -416,11 +348,11 @@ entities:
         name: value
         range:
           min: 0               # min: 0
-          max: 32              # 体现 max: 32
+          max: 32
 
   - entity: number
-    name: 新风数量
-    icon: mdi:fan-alert
+    name: Fresh air unit count
+    icon: "mdi:fan-alert"
     category: config
     dps:
       - id: 110
@@ -428,12 +360,12 @@ entities:
         optional: true
         name: value
         range:
-          min: 0               # 100% 体现 min: 0
-          max: 10              # 100% 体现 max: 10
+          min: 0
+          max: 10
 
   - entity: select
-    name: 混水阀类型    # 🌟 (ID: 117) - 可读写列举型，生成 select 实体
-    icon: mdi:valve
+    name: Mixing valve type
+    icon: "mdi:valve"
     category: config
     dps:
       - id: 117
@@ -449,9 +381,9 @@ entities:
             value: "12V"
 
   - entity: select
-    name: 外机水温控制方式
+    name: Outdoor water temperature control method
     category: config
-    icon: mdi:router-wireless-settings
+    icon: "mdi:router-wireless-settings"
     dps:
       - id: 123
         type: string
@@ -459,14 +391,14 @@ entities:
         name: option
         mapping:
           - dps_val: water_return_control
-            value: "回水控制"
+            value: Return water control
           - dps_val: water_out_control
-            value: "出水控制"
+            value: Supply water control
 
   - entity: select
-    name: 主从模式设置
+    name: Master-slave mode
     category: config
-    icon: mdi:account-network
+    icon: "mdi:account-network"
     dps:
       - id: 133
         type: string
@@ -474,14 +406,14 @@ entities:
         name: option
         mapping:
           - dps_val: master
-            value: "主控"
+            value: Master
           - dps_val: slave
-            value: "从控"
+            value: Slave
 
   - entity: select
-    name: 干接点模式配置
+    name: Dry contact mode
     category: config
-    icon: mdi:toggle-switch
+    icon: "mdi:toggle-switch"
     dps:
       - id: 136
         type: string
@@ -489,14 +421,14 @@ entities:
         name: option
         mapping:
           - dps_val: cold_open
-            value: "制冷闭合"
+            value: Close on cooling
           - dps_val: cold_close
-            value: "制热闭合"
+            value: Close on heating
 
   - entity: select
-    name: 干接点开关配置
+    name: Dry contact switching
     category: config
-    icon: mdi:toggle-switch-outline
+    icon: "mdi:toggle-switch-outline"
     dps:
       - id: 137
         type: string
@@ -504,14 +436,15 @@ entities:
         name: option
         mapping:
           - dps_val: relay_onoff_open
-            value: "开机闭合"
+            value: Close when on
           - dps_val: relay_onoff_close
-            value: "关机闭合"
+            value: Close when off
 
   - entity: select
-    name: 季节模式切换
+    name: Seasonal mode
+    translation_key: mode
     category: config
-    icon: mdi:calendar-sync
+    icon: "mdi:calendar-sync"
     dps:
       - id: 139
         type: string
@@ -519,19 +452,13 @@ entities:
         name: option
         mapping:
           - dps_val: hand
-            value: "手动"
-          - dps_val: manual
-            value: "手动"
-          - dps_val: Manual
-            value: "手动"
+            value: manual
           - dps_val: auto
-            value: "自动"
-          - dps_val: Auto
-            value: "自动"
+            value: auto
 
   - entity: number
-    name: 外机安装数量
-    icon: mdi:numeric-1-box-multiple
+    name: Outdoor unit count
+    icon: "mdi:numeric-1-box-multiple"
     category: config
     dps:
       - id: 104
@@ -543,8 +470,8 @@ entities:
           max: 6
 
   - entity: number
-    name: 系统的内机总数
-    icon: mdi:format-list-numbered
+    name: Indoor unit count
+    icon: "mdi:format-list-numbered"
     category: config
     dps:
       - id: 107
@@ -556,8 +483,8 @@ entities:
           max: 32
 
   - entity: number
-    name: 本地总线地址
-    icon: mdi:bus
+    name: Local bus address
+    icon: "mdi:bus"
     category: config
     dps:
       - id: 118
@@ -569,8 +496,8 @@ entities:
           max: 32
 
   - entity: number
-    name: 从机控制面板数量
-    icon: mdi:dots-hexagon
+    name: Slave control panel count
+    icon: "mdi:dots-hexagon"
     category: config
     dps:
       - id: 134
@@ -582,8 +509,8 @@ entities:
           max: 10
 
   - entity: number
-    name: 外机采暖热水温度设置
-    icon: mdi:thermometer-hot
+    name: Outdoor unit heating water temperature
+    icon: "mdi:thermometer-hot"
     category: config
     dps:
       - id: 119
@@ -596,8 +523,8 @@ entities:
           max: 55
 
   - entity: number
-    name: 水箱控制温差
-    icon: mdi:thermometer
+    name: Tank temperature differential
+    icon: "mdi:thermometer"
     category: config
     dps:
       - id: 120
@@ -610,8 +537,8 @@ entities:
           max: 5
 
   - entity: number
-    name: 地暖辐射最低供水温度
-    icon: mdi:snowflake-thermometer
+    name: Minimum floor heating supply temperature
+    icon: "mdi:snowflake-thermometer"
     category: config
     dps:
       - id: 124
@@ -624,8 +551,8 @@ entities:
           max: 45
 
   - entity: number
-    name: 外机供冷目标温度设置
-    icon: mdi:thermometer-water
+    name: Outdoor unit cooling target temperature
+    icon: "mdi:thermometer-water"
     category: config
     dps:
       - id: 129
@@ -638,36 +565,34 @@ entities:
           max: 20
 
   - entity: number
-    name: 制冷初切换切阀月数  # API接口未体现
-    icon: mdi:calendar-month
+    name: Cooling valve changeover start month
+    icon: "mdi:calendar-month"
     category: config
     dps:
       - id: 140
         type: integer
         optional: true
         name: value
-        unit: "m"
         range:
           min: 1
           max: 4
 
   - entity: number
-    name: 制热初切换切阀月数  # API接口未体现
-    icon: mdi:calendar-month
+    name: Heating valve changeover start month
+    icon: "mdi:calendar-month"
     category: config
     dps:
       - id: 141
         type: integer
         optional: true
         name: value
-        unit: "m"
         range:
           min: 10
           max: 12
 
   - entity: number
-    name: 直通常开延时
-    icon: mdi:clock-start
+    name: Normally open bypass delay
+    icon: "mdi:clock-start"
     category: config
     dps:
       - id: 110
@@ -682,8 +607,8 @@ entities:
           max: 250
 
   - entity: number
-    name: 直通常关延时
-    icon: mdi:clock-end
+    name: Normally closed bypass delay
+    icon: "mdi:clock-end"
     category: config
     dps:
       - id: 112
@@ -698,8 +623,8 @@ entities:
           max: 250
 
   - entity: number
-    name: 混水泵开启延时
-    icon: mdi:clock-start
+    name: Mixing pump start delay
+    icon: "mdi:clock-start"
     category: config
     dps:
       - id: 110
@@ -714,8 +639,8 @@ entities:
           max: 250
 
   - entity: number
-    name: 混水泵关闭延时
-    icon: mdi:clock-end
+    name: Mixing pump stop delay
+    icon: "mdi:clock-end"
     category: config
     dps:
       - id: 113
@@ -730,8 +655,8 @@ entities:
           max: 250
 
   - entity: switch
-    name: 辐射混水控制开关
-    icon: mdi:water-sync
+    name: Radiant mixing control
+    icon: "mdi:water-sync"
     category: config
     dps:
       - id: 114
@@ -740,9 +665,9 @@ entities:
         name: switch
 
   - entity: select
-    name: 外机状态运行指示
+    name: Outdoor unit operating state
     category: config
-    icon: mdi:power-cycle
+    icon: "mdi:power-cycle"
     dps:
       - id: 106
         type: string
@@ -750,27 +675,27 @@ entities:
         name: option
         mapping:
           - dps_val: "ON"
-            value: "运行中"
+            value: Running
           - dps_val: "OFF"
-            value: "已停止"
+            value: Stopped
 
   - entity: number
-    name: 壁挂炉温度设置
-    icon: mdi:speedometer
+    name: Boiler temperature setting
+    icon: "mdi:speedometer"
     category: config
     dps:
       - id: 143
         type: integer
         optional: true
-        name: value        #  体现 type: value 的标准声明
-        unit: "%"          #   体现 unit: "%"
+        name: value
+        unit: "%"
         range:
-          min: -15         #   体现 min: -15
-          max: 20          #  体现 max: 20
+          min: -15
+          max: 20
 
   - entity: switch
-    name: 壁挂炉辅助系统开关
-    icon: mdi:fire
+    name: Boiler auxiliary system
+    icon: "mdi:fire"
     category: config
     dps:
       - id: 132

--- a/custom_components/tuya_local/devices/rhinoking_h7central_hvaccontroller.yaml
+++ b/custom_components/tuya_local/devices/rhinoking_h7central_hvaccontroller.yaml
@@ -31,7 +31,6 @@ entities:
               - dps_val: "cold_floorcold"
                 value: cool
                 hidden: true
-
       - id: 2
         type: string
         name: preset_mode
@@ -48,7 +47,6 @@ entities:
             value: air_floor_heat
           - dps_val: "cold_floorcold"
             value: air_floor_cool
-
       - id: 16
         type: integer
         name: temperature
@@ -57,26 +55,27 @@ entities:
           max: 400
         mapping:
           - scale: 10
-            step: 1
-
       - id: 24
         type: integer
         name: current_temperature
-        range:
-          min: -200
-          max: 500
         mapping:
           - scale: 10
-
       - id: 34
         type: integer
         name: current_humidity
-        range:
-          min: 0
-          max: 100
+      - id: 138
+        type: string
+        optional: true
+        name: hvac_action
         mapping:
-          - scale: 1
-
+          - dps_val: "all_off"
+            value: idle
+          - dps_val: "cold_on"
+            value: cooling
+          - dps_val: "heat_on"
+            value: heating
+          - dps_val: "all_on"
+            value: null
   - entity: number
     name: Auxiliary bypass count
     icon: "mdi:source-branch"
@@ -249,8 +248,6 @@ entities:
         optional: true
         name: sensor
         unit: "°C"
-        mapping:
-          - scale: 1
 
   - entity: binary_sensor
     class: problem
@@ -285,26 +282,6 @@ entities:
             value: Valve rotating reverse
           - dps_val: "dewpont_prot"
             value: Dew point protection
-
-  - entity: sensor
-    class: enum
-    name: Indoor cooling and heating valve
-    category: diagnostic
-    icon: "mdi:valve-letter"
-    dps:
-      - id: 138
-        type: string
-        optional: true
-        name: sensor
-        mapping:
-          - dps_val: "all_off"
-            value: All off
-          - dps_val: "cold_on"
-            value: Cooling on
-          - dps_val: "heat_on"
-            value: Heating on
-          - dps_val: "all_on"
-            value: All on
 
   - entity: select
     name: Outdoor unit model
@@ -368,7 +345,7 @@ entities:
         optional: true
         name: value
         range:
-          min: 0               # min: 0
+          min: 0
           max: 32
 
   - entity: number

--- a/custom_components/tuya_local/devices/rhinoking_h7central_hvaccontroller.yaml
+++ b/custom_components/tuya_local/devices/rhinoking_h7central_hvaccontroller.yaml
@@ -45,9 +45,9 @@ entities:
           - dps_val: "floorhea"
             value: floor_heat
           - dps_val: "heat_floorheat"
-            value: Heating + floor heating
+            value: air_floor_heat
           - dps_val: "cold_floorcold"
-            value: Cooling + floor cooling
+            value: air_floor_cool
 
       - id: 16
         type: integer
@@ -80,6 +80,7 @@ entities:
   - entity: number
     name: Auxiliary bypass count
     icon: "mdi:source-branch"
+    category: config
     dps:
       - id: 109
         type: integer
@@ -92,6 +93,7 @@ entities:
   - entity: number
     name: Bypass D valve closing trigger count
     icon: "mdi:clock-start"
+    category: config
     dps:
       - id: 111
         type: integer
@@ -104,6 +106,7 @@ entities:
   - entity: switch
     name: Indoor-outdoor unit linkage
     icon: "mdi:link-variant"
+    category: config
     dps:
       - id: 142
         type: boolean
@@ -125,6 +128,7 @@ entities:
   - entity: sensor
     name: Radiant mixing supply temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 115
         type: integer
@@ -137,6 +141,7 @@ entities:
   - entity: sensor
     name: Radiant mixing return temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 116
         type: integer
@@ -158,6 +163,7 @@ entities:
   - entity: sensor
     translation_key: status
     icon: "mdi:heat-pump"
+    category: diagnostic
     dps:
       - id: 125
         type: string
@@ -167,6 +173,7 @@ entities:
   - entity: sensor
     name: Outdoor unit supply water temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 126
         type: integer
@@ -176,6 +183,7 @@ entities:
   - entity: sensor
     name: Outdoor unit return water temperature
     class: temperature
+    category: diagnostic
     dps:
       - id: 127
         type: integer
@@ -186,6 +194,7 @@ entities:
   - entity: sensor
     name: Operating mode status
     icon: "mdi:list-status"
+    category: diagnostic
     dps:
       - id: 128
         type: string
@@ -205,6 +214,7 @@ entities:
     name: Pump status
     class: enum
     icon: "mdi:pump"
+    category: diagnostic
     dps:
       - id: 131
         type: string
@@ -242,16 +252,26 @@ entities:
         mapping:
           - scale: 1
 
-  - entity: sensor
-    class: enum
-    name: System fault code
+  - entity: binary_sensor
+    class: problem
     category: diagnostic
-    icon: "mdi:alert-circle-outline"
     dps:
       - id: 122
         type: string
         optional: true
         name: sensor
+        mapping:
+          - dps_val: "0"
+            value: false
+          - dps_val: "none"
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 122
+        type: string
+        optional: true
+        name: description
         mapping:
           - dps_val: "0"
             value: Normal
@@ -511,7 +531,7 @@ entities:
 
   - entity: number
     name: Outdoor unit heating water temperature
-    icon: "mdi:thermometer-hot"
+    class: temperature
     category: config
     dps:
       - id: 119
@@ -525,7 +545,7 @@ entities:
 
   - entity: number
     name: Tank temperature differential
-    icon: "mdi:thermometer"
+    class: temperature_delta
     category: config
     dps:
       - id: 120
@@ -539,7 +559,7 @@ entities:
 
   - entity: number
     name: Minimum floor heating supply temperature
-    icon: "mdi:snowflake-thermometer"
+    class: temperature
     category: config
     dps:
       - id: 124
@@ -553,7 +573,7 @@ entities:
 
   - entity: number
     name: Outdoor unit cooling target temperature
-    icon: "mdi:thermometer-water"
+    class: temperature
     category: config
     dps:
       - id: 129
@@ -594,6 +614,7 @@ entities:
   - entity: number
     name: Normally open bypass delay
     icon: "mdi:clock-start"
+    class: duration
     category: config
     dps:
       - id: 110
@@ -610,6 +631,7 @@ entities:
   - entity: number
     name: Normally closed bypass delay
     icon: "mdi:clock-end"
+    class: duration
     category: config
     dps:
       - id: 112
@@ -626,6 +648,7 @@ entities:
   - entity: number
     name: Mixing pump start delay
     icon: "mdi:clock-start"
+    class: duration
     category: config
     dps:
       - id: 110
@@ -642,6 +665,7 @@ entities:
   - entity: number
     name: Mixing pump stop delay
     icon: "mdi:clock-end"
+    class: duration
     category: config
     dps:
       - id: 113

--- a/custom_components/tuya_local/devices/rhinoking_h7central_hvaccontroller.yaml
+++ b/custom_components/tuya_local/devices/rhinoking_h7central_hvaccontroller.yaml
@@ -5,6 +5,7 @@ products:
     model: H7
 entities:
   - entity: climate
+    translation_key: combo_floor
     dps:
       - id: 1
         type: boolean
@@ -36,13 +37,13 @@ entities:
         name: preset_mode
         mapping:
           - dps_val: "wind"
-            value: Fan only
+            value: fan_only
           - dps_val: "cold"
-            value: Cooling
+            value: cool
           - dps_val: "hea"
-            value: Heating
+            value: heat
           - dps_val: "floorhea"
-            value: Floor heating
+            value: floor_heat
           - dps_val: "heat_floorheat"
             value: Heating + floor heating
           - dps_val: "cold_floorcold"


### PR DESCRIPTION
Adds device configuration for the Rhino King H7 central HVAC controller (product ID `ddbcuqy4usocv9lv`).

The configuration is in use on the contributor’s Home Assistant instance and covers climate control, monitoring, and controller configuration datapoints. Upstream device-config parsing and untranslated-entity checks pass locally.

AI assistance was used to align the submitted YAML with the current schema and run the project tests; the device mapping itself was supplied and tested by the contributor.