### PR TITLE
add Medion LIFE P901 climater

### DIFF
--- a/custom_components/tuya_local/devices/medion_life_p901.yaml
+++ b/custom_components/tuya_local/devices/medion_life_p901.yaml
@@ -1,0 +1,73 @@
+name: Portable air conditioner
+products:
+  - id: 3ofbq4q9ewc8yc4e
+    manufacturer: Medion
+    model: LIFE P901
+entities:
+  - entity: climate
+    icon: "mdi:air-conditioner"
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            constraint: mode
+            conditions:
+              - dps_val: Cool
+                value: cool
+              - dps_val: Dyr
+                value: dry
+              - dps_val: Fan
+                value: fan_only
+      - id: 2
+        type: integer
+        name: temperature
+        range:
+          min: 16
+          max: 32
+        unit: C
+      - id: 3
+        type: integer
+        name: current_temperature
+      - id: 4
+        type: string
+        name: mode
+        hidden: true
+      - id: 5
+        type: string
+        name: fan_mode
+        mapping:
+          - dps_val: Low
+            value: low
+          - dps_val: High
+            value: high
+  - entity: lock
+    icon: "mdi:lock"
+    translation_key: child_lock
+    dps:
+      - id: 14
+        type: boolean
+        name: lock
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 22
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 22
+        type: bitfield
+        name: fault_code
+  - entity: switch
+    translation_key: sleep
+    dps:
+      - id: 101
+        type: boolean
+        name: switch


### PR DESCRIPTION
Adds the Medion Life P901.
I was using this for a few weeks already (like 6 or so).
It's pretty much a slightly weaker P1002 without swing mode and a different ID.