### PR TITLE
Add Pro Breeze PB-D-18W-WF 12L dehumidifier

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -954,3 +954,4 @@ Further device support has been made with the assistance of users. Please consid
 - [denismilanovic](https://github.com/denismilanovic) for contributing support for Breville BAD358 dehumidifier.
 - [klobuczek](https://github.com/klobuczek) for contributing support for FRE1L4 water chiller.
 - [gergely-sallai](https://github.com/gergely-sallai) for contributing support for Holtop CDA-500t ERV.
+- [surfnterd](https://github.com/surfnterd) for contributing support for Pro Breeze PB-D-18W-WF 12L dehumidifier.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -588,6 +588,7 @@
 - Point PODH20 dehumidifier
 - Pro Breeze 30L dehumidifier
 - Pro Breeze D-23 dehumidifier
+- Pro Breeze PB-D-18W-WF 12L dehumidifier
 - Qlima D720, D812, D820A dehumidifiers
 - Rohnson R-9530 dehumidifier
 - Sefaul Q8 dehumidifier

--- a/custom_components/tuya_local/devices/probreeze_pbd18wwf_dehumidifier.yaml
+++ b/custom_components/tuya_local/devices/probreeze_pbd18wwf_dehumidifier.yaml
@@ -1,0 +1,159 @@
+name: Dehumidifier
+products:
+  - id: 006lnrrrsa2sayck
+    manufacturer: Pro Breeze
+    model: PB-D-18W-WF
+entities:
+  - entity: humidifier
+    class: dehumidifier
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 2
+        type: string
+        name: mode
+        mapping:
+          - dps_val: "0"
+            value: auto
+          - dps_val: "1"
+            value: continuous
+      - id: 3
+        type: integer
+        name: current_humidity
+      - id: 4
+        type: integer
+        name: humidity
+        range:
+          min: 30
+          max: 80
+        mapping:
+          - step: 5
+  - entity: fan
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+      - id: 6
+        type: string
+        name: speed
+        mapping:
+          - dps_val: "0"
+            value: 100
+          - dps_val: "1"
+            value: 50
+  - entity: switch
+    translation_key: sleep
+    category: config
+    dps:
+      - id: 5
+        type: boolean
+        name: switch
+  - entity: switch
+    translation_key: ionizer
+    category: config
+    dps:
+      - id: 101
+        type: boolean
+        name: switch
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 12
+        type: string
+        name: option
+        mapping:
+          - dps_val: "0"
+            value: cancel
+          - dps_val: "1"
+            value: "1h"
+          - dps_val: "2"
+            value: "2h"
+          - dps_val: "3"
+            value: "3h"
+          - dps_val: "4"
+            value: "4h"
+          - dps_val: "5"
+            value: "5h"
+          - dps_val: "6"
+            value: "6h"
+          - dps_val: "7"
+            value: "7h"
+          - dps_val: "8"
+            value: "8h"
+          - dps_val: "9"
+            value: "9h"
+          - dps_val: "10"
+            value: "10h"
+          - dps_val: "11"
+            value: "11h"
+          - dps_val: "12"
+            value: "12h"
+          - dps_val: "13"
+            value: "13h"
+          - dps_val: "14"
+            value: "14h"
+          - dps_val: "15"
+            value: "15h"
+          - dps_val: "16"
+            value: "16h"
+          - dps_val: "17"
+            value: "17h"
+          - dps_val: "18"
+            value: "18h"
+          - dps_val: "19"
+            value: "19h"
+          - dps_val: "20"
+            value: "20h"
+          - dps_val: "21"
+            value: "21h"
+          - dps_val: "22"
+            value: "22h"
+          - dps_val: "23"
+            value: "23h"
+          - dps_val: "24"
+            value: "24h"
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        unit: min
+  - entity: binary_sensor
+    translation_key: tank_full
+    category: diagnostic
+    dps:
+      - id: 11
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 8
+            value: true
+          - value: false
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 11
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: 8
+            value: false
+          - value: true
+      - id: 11
+        type: bitfield
+        name: fault_code


### PR DESCRIPTION
## Pro Breeze PB-D-18W-WF 12L smart dehumidifier (product id `006lnrrrsa2sayck`)

New device config for the Pro Breeze "OmniDry 12L Quiet Low Energy Dehumidifier with Smart App Control" (UK model PB-D-18W-WF, sold on Amazon as "Pro Breeze 12L Dehumidifier ... Smart App"). Not the 20L PB-D-23W-W already covered by `probreeze_pbd23w_dehumidifier.yaml` - the 12L uses a different, simpler DP layout that currently matches `shinco_30d_dehumidifier` at 100%, but with two DPs meaning something else on this unit (dp 5 = sleep mode, dp 101 = ionizer), and mode "1" being the manual's "Continuous" mode rather than boost.

Local DPS as logged by the config flow (protocol auto-detected 3.4/3.5 family, cloud product category `cs`):

```
{"1": true, "2": "1", "3": 53, "4": 50, "5": false, "6": "0", "7": false, "11": 0, "12": "0", "13": 0, "101": false}
```

| dp | meaning | values | how verified |
|---|---|---|---|
| 1 | power | bool | HA turn_on/off, unit responds |
| 2 | mode | "0" auto, "1" continuous | pressed the mode button, dp followed; manual names the modes Auto / Continuous / Sleep |
| 3 | current humidity | int % | tracks the display |
| 4 | target humidity | 30-80 step 5 | manual: 30-80 in 5% steps |
| 5 | sleep mode | bool | held mode button 2 s (manual's sleep gesture): dp5 -> true and dp6 forced to "1" (low fan), as documented |
| 6 | fan speed | "0" high, "1" low | set 100% from HA -> display showed High |
| 7 | child lock | bool | |
| 11 | fault bitfield | 0 = ok | tank-full bit assumed to be 8 as in sibling dehumidifier configs; not yet observed (tank not filled yet) |
| 12 | timer | "0".."24" hours | manual: 1-24 h timer |
| 13 | minutes remaining | int | |
| 101 | ionizer | bool | cloud API exposes this DP as `anion` |

Not present on this unit: dp 8 (oscillate), dp 102 (water pump), so those entities from the shinco config are dropped.

Tested on HA 2026.8.3 with tuya_local 2026.5.4 (yes, an old tuya_local - the config uses nothing newer). Entities produced: humidifier (auto/continuous), fan (50/100), sleep switch, ionizer switch, child lock, timer select, time remaining sensor, tank-full and problem binary sensors. Everything except the tank-full bit was exercised against the physical unit.

Manual: https://cdn.shopify.com/s/files/1/0668/4075/6504/files/PB-D-18W-WF_Instruction_Manual__UK__FINAL_MAY_24_v2.pdf
