### PR TITLE
Add PJ2101A single phase bidirectional clamp meter

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -731,6 +731,7 @@
 - PC321-TY 3 phase power clamp meter
 - PC473 3-phase energy monitor
 - PJ-1103, PJ-1103A, PJ-1103C power clamp meters
+- PJ2101A single phase bidirectional power clamp meter
 - PowBay JGQW01-63 energy monitoring circuit breaker
 - PZIOT E01 energy meter
 - SG600MD solar inverter (also SG700MD, other SGxx0MD and SGxx0W models) sold under various brands

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -730,8 +730,7 @@
 - PC311-TY 2 phase power clamp meter
 - PC321-TY 3 phase power clamp meter
 - PC473 3-phase energy monitor
-- PJ-1103, PJ-1103A, PJ-1103C power clamp meters
-- PJ2101A single phase bidirectional power clamp meter
+- PJ-1103, PJ-1103A, PJ-1103C, PJ-2101A power clamp meters
 - PowBay JGQW01-63 energy monitoring circuit breaker
 - PZIOT E01 energy meter
 - SG600MD solar inverter (also SG700MD, other SGxx0MD and SGxx0W models) sold under various brands

--- a/custom_components/tuya_local/devices/pj2101a_clampmeter.yaml
+++ b/custom_components/tuya_local/devices/pj2101a_clampmeter.yaml
@@ -1,0 +1,44 @@
+name: Bidirectional clamp meter
+products:
+  - id: ze8faryrxr0glqnn
+    model: PJ2101A
+entities:
+  - entity: sensor
+    class: power
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        unit: W
+        class: measurement
+        mapping:
+          - constraint: direction
+            conditions:
+              - dps_val: REVERSE
+                scale: -1
+      - id: 102
+        type: string
+        optional: true
+        name: direction
+  - entity: sensor
+    translation_key: energy_consumed
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: sensor
+    translation_key: energy_produced
+    class: energy
+    dps:
+      - id: 2
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100


### PR DESCRIPTION
## PJ2101A single phase bidirectional clamp meter

Single phase member of the PJ-1103 family, with one clamp instead of two. It
reports cumulative import and export energy counters, instantaneous power, and
the direction of the flow.

### LOCAL DPS

```
{"updated_at": 1788512235.539172, "1": 707703, "2": 317539, "101": 4433, "102": "FORWARD"}
```

All four dps are present in the discovery log, so none are marked optional
except `102`, which follows the same treatment as in `pj1103c_dualclampmeter`.

### Why a new config

`best_match` on the log above returned 50% at best before this change
(`th16_temp_humidity_sensor`). The near misses were each ruled out:

- `matsee_2wayv2_energymeter` — same dp1/dp2 energy counters at scale 100, but
  its dp101 is voltage and dp102 frequency, both integers. Here dp101 is power
  and dp102 is a string.
- `pj1103_clamp_meter` and `pj1103a_dual_channel_meter` — unrelated dps
  (17-26, 51-52).
- `owon_pc341_energymeter` — unrelated dps.

`duplicates` reports no matches. After the change, `best_match` reports 100%.

### Scales

The power scale differs from the PJ-1103C, which uses `scale: 10`. On this
model dp101 is in watts. Confirmed against the cloud: the Tuya API reported
4.442 kW at the same moment the device returned `4442` over the local protocol,
and again 4603 locally against 4.603 kW. Using scale 10 would under-report by a
factor of ten.

As on the PJ-1103C, dp102 is used as a `constraint` so that exported power is
reported as negative.

The two energy counters are in hundredths of a kWh. This is confirmed by the
Query Things Data Model API, which gives `scale: 2` for `forward_energy_total`
and `reverse_energy_total`:

```json
{"code": "forward_energy_total", "type": "Integer",
 "values": {"unit": "kW·h", "min": 0, "max": 99999999, "scale": 2, "step": 1}}
```

### Naming

`Clamp meter` and `Energy meter` were already taken, so the top level name is
`Bidirectional clamp meter`, which also distinguishes it from the unidirectional
models. The `energy_consumed` and `energy_produced` translation keys are used
rather than the `_x` variants, as there is a single pair of counters. Power is
the only sensor of its class, so it carries no name or translation key.

### Checks

- `uv run yamllint custom_components/tuya_local/devices` — clean
- `uv run ruff check .` and `uv run ruff format --check .` — clean
- `uv run duplicates pj2101a_clampmeter.yaml` — no matches
- `uv run pytest` — 428 passed

Device tested in service on Home Assistant 2026.9.0: power, both energy
counters and the flow direction all read correctly over the local protocol.
