### PR TITLE
fix(lumary-c2): coordinate light with master power

### DIFF
--- a/custom_components/tuya_local/devices/lumary_c2_ceilingfanlight.yaml
+++ b/custom_components/tuya_local/devices/lumary_c2_ceilingfanlight.yaml
@@ -15,7 +15,7 @@ entities:
           - dps_val: false
             value: false
           - dps_val: true
-            constraint: main
+            constraint: master_power
             conditions:
               - dps_val: false
                 value: false
@@ -23,7 +23,7 @@ entities:
                 value: true
       - id: 119
         type: boolean
-        name: main
+        name: master_power
         hidden: true
       - id: 21
         name: color_mode

--- a/custom_components/tuya_local/devices/lumary_c2_ceilingfanlight.yaml
+++ b/custom_components/tuya_local/devices/lumary_c2_ceilingfanlight.yaml
@@ -11,6 +11,20 @@ entities:
       - id: 20
         type: boolean
         name: switch
+        mapping:
+          - dps_val: false
+            value: false
+          - dps_val: true
+            constraint: main
+            conditions:
+              - dps_val: false
+                value: false
+              - dps_val: true
+                value: true
+      - id: 119
+        type: boolean
+        name: main
+        hidden: true
       - id: 21
         name: color_mode
         type: string

--- a/custom_components/tuya_local/devices/lumary_c2_ceilingfanlight.yaml
+++ b/custom_components/tuya_local/devices/lumary_c2_ceilingfanlight.yaml
@@ -11,20 +11,9 @@ entities:
       - id: 20
         type: boolean
         name: switch
-        mapping:
-          - dps_val: false
-            value: false
-          - dps_val: true
-            constraint: master_power
-            conditions:
-              - dps_val: false
-                value: false
-              - dps_val: true
-                value: true
       - id: 119
         type: boolean
-        name: master_power
-        hidden: true
+        name: available
       - id: 21
         name: color_mode
         type: string
@@ -144,6 +133,9 @@ entities:
   - entity: fan
     translation_only_key: fan_with_presets
     dps:
+      - id: 119
+        type: boolean
+        name: available
       - id: 101
         type: boolean
         name: switch
@@ -192,6 +184,9 @@ entities:
   - entity: light
     translation_key: nightlight
     dps:
+      - id: 119
+        type: boolean
+        name: available
       - id: 143
         type: boolean
         name: switch
@@ -199,6 +194,9 @@ entities:
     name: White
     category: config
     dps:
+      - id: 119
+        type: boolean
+        name: available
       - id: 107
         type: boolean
         name: switch
@@ -222,6 +220,9 @@ entities:
     name: Color
     category: config
     dps:
+      - id: 119
+        type: boolean
+        name: available
       - id: 108
         type: boolean
         name: switch


### PR DESCRIPTION
On the Lumary C2, DPS 119 is the device-wide master switch and DPS 20 is the main light switch. When the master is off, the device can retain DPS 20 as `true`, so Tuya Local can report the light on even though it is physically off. Sending only DPS 20 as `true` also cannot restore power.

This updates the existing profile from #5634 so:

- `119=false` masks a stale `20=true` light state;
- turning the light on sets both `119=true` and `20=true`;
- turning the light off sets only `20=false`.

The change uses the integration's existing conditional mapping support and does not change Python code.

Tested on all six installed L-CFL19C2 fixtures. One fixture was used as the physical canary, followed by a two-day household soak.

Validation:

- 428 full tests passed;
- 32 device-config tests passed;
- Ruff, import order, formatting, yamllint, the direct DPS semantic probe, duplicate-profile check, and diff hygiene passed.
