### PR TITLE
Add Anwo Brezza ceiling fan

### DIFF
--- a/custom_components/tuya_local/devices/anwo_brezza_fan.yaml
+++ b/custom_components/tuya_local/devices/anwo_brezza_fan.yaml
@@ -1,0 +1,44 @@
+name: Ceiling fan
+products:
+  - id: t2wk7ze0aiafakw2
+    manufacturer: Anwo
+    model: Brezza
+entities:
+  - entity: fan
+    translation_only_key: fan_with_presets
+    dps:
+      - id: 60
+        type: boolean
+        name: switch
+      - id: 61
+        type: string
+        name: preset_mode
+        optional: true
+        mapping:
+          - dps_val: fresh
+            value: fresh
+          - dps_val: nature
+            value: nature
+      - id: 62
+        type: integer
+        name: speed
+        range:
+          min: 1
+          max: 6
+      - id: 63
+        type: string
+        name: direction
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 64
+        type: integer
+        name: option
+        mapping:
+          - dps_val: 0
+            value: cancel
+          - dps_val: 60
+            value: "1h"
+          - dps_val: 240
+            value: "4h"


### PR DESCRIPTION
Anwo Brezza ceiling fan ("Ventilador de Techo ANWO" in the Tuya cloud): 6 speeds, reversible, no light. Product id `t2wk7ze0aiafakw2`.

Config dps: 60 switch, 61 preset_mode (fresh/nature, optional), 62 speed 1-6, 63 direction, 64 timer.

LOCAL DPS from the device:

```json
{"20": false, "21": "white", "22": 1000, "23": 500, "25": "000e0d0000000000000000c80000", "26": 0,
 "60": false, "61": "nature", "62": 1, "63": "reverse", "64": 60}
```

The board reports light dps (20-23, 25 scene, 26 light timer) but no light is fitted on this product, so I left them out, following the `windcalm_fan` / `windcalm_fan_with_light` split. I have two of these fans, both report the same product id and neither has a light. Happy to include the light instead if you would rather have one config cover a with-light variant.

The timer on dp 64 is a select rather than the usual number: the device only accepts 60 and 240, the two values its remote can send. Other values are ignored (tested 1 and 30) and the value does not count down, so it is an enum in minutes rather than a remaining-time counter.

`duplicates` reports two matches:

- `eglo_ceiling_fan` - 100%. Its light dps are all optional so it matches this fan too, but its speed dp is a fixed mapping of 5 steps (1-5 -> 20/40/60/80/100, plus -1 for sleep), while the Brezza has 6 speeds as a plain 1-6 range, so that mapping would misreport every speed. Its timer is also a free 0-540 number.
- `windcalm_fan` - 80%. Identical dp layout and the same 1-6 speed range, but no preset modes on dp 61, a free 0-540 timer number, and a sound switch on dp 66 that this fan does not have.

`ovlaim_809_ceiling_fanlight` is a 100% match for the raw dps, but it exposes the unused light and models dp 64 as a free 0-1439 minute time.

pytest tests/test_device_config.py, untranslated_entities, untranslated_select and yamllint all pass locally.

AI assistance was used to locate the closest existing config and write the yaml; I reviewed the result and it is running on both my fans.