### PR TITLE
Trevi InnovAqua: re-add Fahrenheit setpoint and water temperature entities

### DIFF
--- a/custom_components/tuya_local/devices/trevi_innovaqua_heatpump.yaml
+++ b/custom_components/tuya_local/devices/trevi_innovaqua_heatpump.yaml
@@ -7,6 +7,10 @@ products:
 # The Celsius setpoint (dp2) and inlet water temp (dp3) drive the climate.
 # The device also exposes an integer Fahrenheit setpoint (dp25) and inlet
 # water temperature (dp26).
+# dp25/dp26 are additionally exposed as separate number/sensor entities: HA
+# converts climate values to the system unit, so on a Celsius install the
+# native Fahrenheit reading (as shown by the device and its app) is otherwise
+# lost to rounding.
 entities:
   - entity: climate
     translation_key: pool_heatpump
@@ -70,6 +74,27 @@ entities:
           - dps_val: f
             value: F
           - value: C
+  - entity: sensor
+    name: Water temperature
+    category: diagnostic
+    dps:
+      - id: 26
+        name: sensor
+        type: integer
+        unit: F
+        class: measurement
+  - entity: number
+    name: Set temperature
+    category: config
+    icon: "mdi:thermometer"
+    dps:
+      - id: 25
+        name: value
+        type: integer
+        unit: F
+        range:
+          min: 46
+          max: 104
   - entity: select
     translation_key: temperature_unit
     category: config


### PR DESCRIPTION
Follow-up to #5764. The device natively exposes an integer Fahrenheit setpoint (dp25) and inlet water temperature (dp26).

Context: in North America, pool water temperature is universally expressed in **whole degrees Fahrenheit** — never in Celsius with decimals. That is what the heat pump's own display and its Tuya app show, and what pool owners expect to read and set.

The refactored climate reads dp25/dp26 via `value_redirect`, but Home Assistant converts climate values to the system temperature unit. On a Celsius HA install (common in Canada, where the rest of the home is metric but the pool is still Fahrenheit), the native Fahrenheit reading is lost to rounding — e.g. 70 °F → 21 °C → 69.8 °F — so the value shown in HA never matches the device.

This adds dp25/dp26 back as separate `number`/`sensor` entities (config/diagnostic, no `device_class` so HA does not re-convert), alongside the existing climate, which is unchanged. Purely additive (+25 lines).

Tested on my unit with 2026.9.0: climate and both entities work together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
