### PR TITLE
Update airwoods_av_htpf_fresh_air_heat_pump.yaml

### DIFF
--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -319,6 +319,7 @@ entities:
     dps:
       - id: 129
         type: integer
+        optional: true
         name: sensor
         unit: C
         class: measurement

--- a/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
+++ b/custom_components/tuya_local/devices/airwoods_av_htpf_fresh_air_heat_pump.yaml
@@ -1,7 +1,8 @@
 name: Fresh air heat pump
-
-#     manufacturer: Airwoods
-#     model: AV-HTPF35 / AV-HTPF60 / AV-HTPF90
+products:
+  - id: fgahx8jfarzd3mty
+    manufacturer: Airwoods
+    model: AV-HTPF35 / AV-HTPF60 / AV-HTPF90
 
 entities:
   - entity: climate


### PR DESCRIPTION
### Device

Airwoods Fresh Air Heat Pump

The existing device configuration:

`airwoods_av_htpf_fresh_air_heat_pump.yaml`

matches my device almost completely.

Product ID:

`fgahx8jfarzd3mty`

Tuya protocol version:

`3.4`

### Problem

During device setup, tuya-local did not offer the existing **Fresh air heat pump** configuration.

Instead, it suggested unrelated device types such as:

`hama_radiator_controller`

with only an 11% match.

The debug log showed the reason:

```text
Loaded device config airwoods_av_htpf_fresh_air_heat_pump.yaml
Not match for Fresh air heat pump, missing required DPs: [{'129': 'int'}]