### PR TITLE
fix(nedis_pilldispenser): correct dp 102 masks, add alarm status sensors

### DIFF
--- a/custom_components/tuya_local/devices/nedis_pilldispenser.yaml
+++ b/custom_components/tuya_local/devices/nedis_pilldispenser.yaml
@@ -24,7 +24,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          0000000000000000000000000000000000000000000000000000000000000001
+          010000000000000000000000000000000000000000000000000000000000
         name: sensor
   - entity: binary_sensor
     class: battery
@@ -38,15 +38,15 @@ entities:
           - dps_val: null
             constraint: battery_state
             conditions:
-              - dps_val: 2
+              - dps_val: low
                 value: true
-              - dps_val: [0, 1, 3]
+              - dps_val: [normal, full, charging]
                 value: false
       - id: 102
         type: base64
         optional: true
         mask: >-
-          0000000000000000000000000000000000000000000000000000000000000700
+          000700000000000000000000000000000000000000000000000000000000
         name: battery_state
         mapping:
           - dps_val: 0
@@ -67,7 +67,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          0000000000000000000000000000000000000000000000000000000000000700
+          000700000000000000000000000000000000000000000000000000000000
         name: sensor
         mapping:
           - dps_val: 3
@@ -81,7 +81,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          0000000000000000000000000000000000000000000000000000000000FF0000
+          0000FF000000000000000000000000000000000000000000000000000000
         name: sensor
         unit: "%"
         class: measurement
@@ -94,7 +94,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          0000000000000000000000000000000000000000000000000000000001000000
+          000000010000000000000000000000000000000000000000000000000000
         name: sensor
   - entity: sensor
     name: Total compartments
@@ -105,7 +105,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          000000000000000000000000000000000000000000000000000000FF00000000
+          00000000FF00000000000000000000000000000000000000000000000000
         name: sensor
   - entity: sensor
     name: Loaded compartments
@@ -116,7 +116,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          0000000000000000000000000000000000000000000000000000FF0000000000
+          0000000000FF000000000000000000000000000000000000000000000000
         name: sensor
         class: measurement
   - entity: sensor
@@ -128,7 +128,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          00000000000000000000000000000000000000000000000000FF000000000000
+          000000000000FF0000000000000000000000000000000000000000000000
         name: sensor
         class: measurement
   - entity: sensor
@@ -140,7 +140,7 @@ entities:
         type: base64
         optional: true
         mask: >-
-          000000000000000000000000000000000000000000000000FF00000000000000
+          00000000000000FF00000000000000000000000000000000000000000000
         name: sensor
         class: measurement
   - entity: event
@@ -785,3 +785,246 @@ entities:
           - dps_val: 2
             value: false
           - value: null
+  - entity: sensor
+    name: Alarm 1 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "000000000000000000000000000000000000000000FF0000000000000000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 2 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "00000000000000000000000000000000000000000000FF00000000000000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 3 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "0000000000000000000000000000000000000000000000FF000000000000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 4 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "000000000000000000000000000000000000000000000000FF0000000000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 5 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "00000000000000000000000000000000000000000000000000FF00000000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 6 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "0000000000000000000000000000000000000000000000000000FF000000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 7 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "000000000000000000000000000000000000000000000000000000FF0000"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 8 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "00000000000000000000000000000000000000000000000000000000FF00"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing
+  - entity: sensor
+    name: Alarm 9 status
+    class: enum
+    icon: "mdi:alarm"
+    dps:
+      - id: 102
+        type: base64
+        optional: true
+        mask: "0000000000000000000000000000000000000000000000000000000000FF"
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: none
+          - dps_val: 1
+            value: waiting
+          - dps_val: 2
+            value: overdue
+          - dps_val: 3
+            value: taken_early
+          - dps_val: 4
+            value: taken_on_time
+          - dps_val: 5
+            value: taken_late
+          - dps_val: 6
+            value: missed
+          - dps_val: 7
+            value: taken_after_missing


### PR DESCRIPTION
**I have this device (Nedis WIFIPD10WT) and tested all of this against it.**

The dp 102 masks are the wrong width. The payload is 30 bytes but the masks are 32, so every field was read from the alarm-status bytes at the *end* of the payload instead of the status bytes at the start — everything decoded as 0 or off.

Real dp 102 payload from my device:

`00002b001c0805030000b302000000000000000000070000000000000000`

| field | before | after |
|---|---|---|
| total compartments | 0 | 28 |
| loaded compartments | 0 | 8 |
| current compartment | 0 | 5 |
| remaining compartments | 0 | 3 |
| battery | 0 | 43 % |
| plug / lid | off | correct |

I also added sensors for the per-alarm status bytes (B21–B29). On my device dp 103 and dp 120 never arrive over the LAN, and are not answered when requested explicitly, so these bytes are the only local way to see whether a dose was taken. Confirmed live: alarm 2 went `waiting` → `missed` → `taken_after_missing` across a real dose.

Finally, the battery binary_sensor: its constraint compares integers (`2`, `[0, 1, 3]`) against `battery_state`, but that dp maps its values to strings first, so nothing ever matched and the entity stayed `unknown`. It now compares the mapped names, and reads `off` with `battery_state: full` on my device.

The config was originally created from the cloud data model in #3357 without hardware to test against, which is presumably why the mask alignment was never caught.

<img width="394" height="622" alt="Screenshot 2026-09-05 at 21 26 50" src="https://github.com/user-attachments/assets/1fcc7b11-ecb0-4562-9667-3bf45b52a78d" />
<img width="393" height="535" alt="Screenshot 2026-09-05 at 21 26 37" src="https://github.com/user-attachments/assets/867be5e8-9953-4927-a4c7-9028c57f884e" />
<img width="395" height="574" alt="Screenshot 2026-09-05 at 21 26 26" src="https://github.com/user-attachments/assets/c600b41f-2073-46b6-89f8-09c6afe6131a" />
<img width="399" height="483" alt="Screenshot 2026-09-05 at 21 26 17" src="https://github.com/user-attachments/assets/66c186f7-be0e-42f8-86d8-6f7b4e91c6d0" />
