### PR TITLE
Add brinna spfw 63

### DIFF
--- a/custom_components/tuya_local/devices/brinna_spfw63_breaker.yaml
+++ b/custom_components/tuya_local/devices/brinna_spfw63_breaker.yaml
@@ -1,0 +1,221 @@
+name: Circuit breaker energy meter
+products:
+  - id: ai1wxf8tow62uieb
+    manufacturer: Brinna
+    model: SPFW-63
+entities:
+  - entity: switch
+    icon: "mdi:fuse"
+    dps:
+      - id: 16
+        name: switch
+        type: boolean
+      - id: 19
+        name: breaker_id
+        type: string
+        optional: true
+      - id: 6
+        name: phase_a
+        type: base64
+        optional: true
+        force: true
+  - entity: sensor
+    class: voltage
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: V
+        class: measurement
+        mask: "FFFF0000000000000000"
+        mapping:
+          - scale: 10
+  - entity: sensor
+    class: current
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        class: measurement
+        mask: "0000FFFFFF0000000000"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: power
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: W
+        class: measurement
+        mask: "0000000000FFFFFF0000"
+  - entity: sensor
+    translation_key: leakage_current
+    class: current
+    category: diagnostic
+    dps:
+      - id: 6
+        type: base64
+        name: sensor
+        optional: true
+        unit: A
+        class: measurement
+        mask: "0000000000000000FFFF"
+        mapping:
+          - scale: 1000
+  - entity: sensor
+    class: energy
+    dps:
+      - id: 1
+        type: integer
+        name: sensor
+        unit: kWh
+        class: total_increasing
+        mapping:
+          - scale: 100
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 9
+        type: bitfield
+        name: sensor
+        optional: true
+        mapping:
+          - dps_val: 0
+            value: false
+          - dps_val: null
+            value: false
+          - value: true
+      - id: 9
+        type: bitfield
+        name: fault_code
+        optional: true
+  - entity: switch
+    name: Prepayment
+    icon: "mdi:cash-multiple"
+    category: config
+    dps:
+      - id: 11
+        type: boolean
+        name: switch
+        optional: true
+  - entity: sensor
+    name: Balance energy
+    class: energy_storage
+    category: diagnostic
+    dps:
+      - id: 13
+        type: integer
+        name: sensor
+        optional: true
+        unit: kWh
+        class: measurement
+        mapping:
+          - scale: 100
+  - entity: number
+    name: Charge energy
+    class: energy_storage
+    icon: "mdi:cash"
+    category: config
+    dps:
+      - id: 14
+        type: integer
+        name: value
+        optional: true
+        unit: kWh
+        range:
+          min: 0
+          max: 999999
+        mapping:
+          - scale: 100
+  - entity: button
+    name: Clear energy
+    class: restart
+    category: config
+    dps:
+      - id: 12
+        type: boolean
+        name: button
+        optional: true
+  - entity: number
+    name: Overvoltage protection
+    class: voltage
+    icon: "mdi:flash-alert"
+    category: config
+    dps:
+      - id: 101
+        type: integer
+        name: value
+        optional: true
+        unit: V
+        range:
+          min: 130
+          max: 300
+  - entity: number
+    name: Undervoltage protection
+    class: voltage
+    icon: "mdi:flash-alert-outline"
+    category: config
+    dps:
+      - id: 102
+        type: integer
+        name: value
+        optional: true
+        unit: V
+        range:
+          min: 80
+          max: 210
+  - entity: number
+    name: Overcurrent protection
+    class: current
+    icon: "mdi:current-ac"
+    category: config
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        optional: true
+        unit: A
+        range:
+          min: 1
+          max: 63
+  - entity: number
+    name: Leakage current threshold
+    class: current
+    icon: "mdi:shield-flash-outline"
+    category: config
+    dps:
+      - id: 104
+        type: integer
+        name: value
+        optional: true
+        unit: mA
+        range:
+          min: 5
+          max: 99
+  - entity: switch
+    name: Mute
+    icon: "mdi:volume-off"
+    category: config
+    dps:
+      - id: 105
+        type: boolean
+        name: switch
+        optional: true
+  - entity: switch
+    name: Trip on leakage
+    icon: "mdi:shield-flash"
+    category: config
+    dps:
+      - id: 106
+        type: boolean
+        name: switch
+        optional: true


### PR DESCRIPTION
Closes #6012

Adds support for the Brinna SPFW-63, a single-phase 63A DIN-rail breaker with energy monitoring (product id ai1wxf8tow62uieb, category dlq)
