### PR TITLE
Add Goldair GCT315/GCT425 2000W ceramic tower heater

### DIFF
--- a/custom_components/tuya_local/devices/goldair_gct315_heater.yaml
+++ b/custom_components/tuya_local/devices/goldair_gct315_heater.yaml
@@ -1,0 +1,80 @@
+name: Heater
+products:
+  - id: 8eapmvhb79pcxx7x
+    manufacturer: Goldair
+    model: GCT315/GCT425
+    name: 2000W ceramic tower heater
+entities:
+  - entity: climate
+    translation_only_key: heater
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: "heat"
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 15
+          max: 45
+      - id: 3
+        type: integer
+        name: current_temperature
+      - id: 4
+        type: string
+        name: preset_mode
+        # dp 4 selects whether the heat level on dp 5 is chosen by the user or
+        # by the appliance. Auto is therefore not a value of dp 5, and setting
+        # it must write dp 4 alone - sending a level in the same message drops
+        # the appliance straight back to normal.
+        mapping:
+          - dps_val: auto
+            value: auto
+          - dps_val: normal
+            constraint: heat_level
+            conditions:
+              - dps_val: level_0
+                value: fan_only
+              - dps_val: level_1
+                value: low
+              - dps_val: level_2
+                value: high
+      - id: 5
+        type: string
+        name: heat_level
+      - id: 8
+        type: boolean
+        name: swing_mode
+        mapping:
+          - dps_val: false
+            value: "off"
+          - dps_val: true
+            value: horizontal
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: "1h"
+            value: "1h"
+          - dps_val: "2h"
+            value: "2h"
+          - dps_val: "3h"
+            value: "3h"
+          - dps_val: "4h"
+            value: "4h"
+          - dps_val: "5h"
+            value: "5h"
+          - dps_val: "6h"
+            value: "6h"


### PR DESCRIPTION
Closes #6038.

Adds support for the Goldair 2000W ceramic tower heater (GCT315 and GCT425), product `8eapmvhb79pcxx7x`. One new device config, nothing else changed.

Notes:

- dps read from my own heater over the LAN on protocol 3.5: `{"1": false, "2": 15, "3": 20, "4": "auto", "5": "level_0", "8": false, "19": "cancel"}`
- dp 4 chooses whether the heat level in dp 5 is set by the user or by the heater, so Auto sits on dp 4 with dp 5 as its constraint rather than being a value of dp 5. Auto writes dp 4 alone, a named level writes both. Sending a level together with Auto puts the heater back to normal.
- dp 5 reports `level_0` and dp 4 accepts `normal`, neither of which is in the Tuya data model for this product, so the values used here come from the device.
- `duplicates` reports no 100% match.
- yamllint, tests and ruff pass locally.
