### PR TITLE
Add support for Madimack GT Freedom i80 pool cleaner

### DIFF
--- a/custom_components/tuya_local/devices/madimack_gtfreedomi80_poolcleaner.yaml
+++ b/custom_components/tuya_local/devices/madimack_gtfreedomi80_poolcleaner.yaml
@@ -2,12 +2,13 @@ name: Pool cleaning robot
 
 products:
   - id: 7up9kxk6vx0e7pcm
-    manufacturer: Madimack
+  - manufacturer: Madimack
     model: GT Freedom i80
 
 entities:
   - entity: number
     name: Cleaning duration
+    class: duration
     category: config
     dps:
       - id: 103
@@ -27,15 +28,24 @@ entities:
         name: switch
 
   - entity: sensor
-    name: Battery level
+    class: battery
     category: diagnostic
     dps:
       - id: 107
-        type: string
+        type: integer
         name: sensor
+        unit: "%"
+        mapping:
+          - dps_val: 0
+            value: 33
+          - dps_val: 1
+            value: 67
+          - dps_val: 2
+            value: 100
 
   - entity: number
     name: Repeat interval
+    class: duration
     category: config
     dps:
       - id: 108

--- a/custom_components/tuya_local/devices/madimack_gtfreedomi80_poolcleaner.yaml
+++ b/custom_components/tuya_local/devices/madimack_gtfreedomi80_poolcleaner.yaml
@@ -1,0 +1,47 @@
+name: Pool cleaning robot
+
+products:
+  - id: 7up9kxk6vx0e7pcm
+    manufacturer: Madimack
+    model: GT Freedom i80
+
+entities:
+  - entity: number
+    name: Cleaning duration
+    category: config
+    dps:
+      - id: 103
+        type: integer
+        name: value
+        unit: min
+        range:
+          min: 30
+          max: 480
+
+  - entity: switch
+    name: Wall cleaning
+    category: config
+    dps:
+      - id: 104
+        type: boolean
+        name: switch
+
+  - entity: sensor
+    name: Battery level
+    category: diagnostic
+    dps:
+      - id: 107
+        type: string
+        name: sensor
+
+  - entity: number
+    name: Repeat interval
+    category: config
+    dps:
+      - id: 108
+        type: integer
+        name: value
+        unit: h
+        range:
+          min: 0
+          max: 168

--- a/custom_components/tuya_local/devices/madimack_gtfreedomi80_poolcleaner.yaml
+++ b/custom_components/tuya_local/devices/madimack_gtfreedomi80_poolcleaner.yaml
@@ -2,7 +2,7 @@ name: Pool cleaning robot
 
 products:
   - id: 7up9kxk6vx0e7pcm
-  - manufacturer: Madimack
+    manufacturer: Madimack
     model: GT Freedom i80
 
 entities:
@@ -32,15 +32,15 @@ entities:
     category: diagnostic
     dps:
       - id: 107
-        type: integer
+        type: string
         name: sensor
         unit: "%"
         mapping:
-          - dps_val: 0
+          - dps_val: "0"
             value: 33
-          - dps_val: 1
+          - dps_val: "1"
             value: 67
-          - dps_val: 2
+          - dps_val: "2"
             value: 100
 
   - entity: number


### PR DESCRIPTION
Adds Tuya Local support for the Madimack GT Freedom i80 robotic pool cleaner.

Product ID: 7up9kxk6vx0e7pcm

The configuration has been tested locally with Tuya Local on the physical device.