### PR TITLE
Add support for The Unclog AC condensate line cleaner (ir6qiyn5s0pbnbz7)

### DIFF
--- a/custom_components/tuya_local/devices/the_unclog.yaml
+++ b/custom_components/tuya_local/devices/the_unclog.yaml
@@ -1,0 +1,54 @@
+name: The Unclog
+products:
+  - id: ir6qiyn5s0pbnbz7
+    name: The Unclog
+entities:
+  - entity: switch
+    icon: "mdi:water-pump"
+    dps:
+      - id: 1
+        type: boolean
+        name: switch
+  - entity: select
+    name: Frequency
+    icon: "mdi:calendar-refresh"
+    category: config
+    dps:
+      - id: 101
+        type: string
+        name: option
+        mapping:
+          - dps_val: "3_days"
+            value: "Every 3 Days"
+          - dps_val: "Weekly"
+            value: "Weekly"
+          - dps_val: "Monthly"
+            value: "Monthly"
+          - dps_val: "3_Months"
+            value: "Every 3 Months"
+          - dps_val: "6_Months"
+            value: "Every 6 Months"
+  - entity: select
+    name: Duration
+    icon: "mdi:timer-cog"
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: option
+        mapping:
+          - dps_val: "15"
+            value: "15 s"
+          - dps_val: "30"
+            value: "30 s"
+          - dps_val: "45"
+            value: "45 s"
+          - dps_val: "60"
+            value: "60 s"
+  - entity: binary_sensor
+    name: Status
+    category: diagnostic
+    dps:
+      - id: 102
+        type: boolean
+        name: sensor

--- a/tests/const.py
+++ b/tests/const.py
@@ -14,3 +14,4 @@ GPPH_HEATER_PAYLOAD = {
 }
 EUROM_600_HEATER_PAYLOAD = {"1": True, "2": 15, "5": 18, "6": 0}
 KOGAN_HEATER_PAYLOAD = {"2": 30, "3": 25, "4": "Low", "6": True, "7": True, "8": 0}
+THE_UNCLOG_PAYLOAD = {"1": False, "101": "3_days", "102": True, "103": "15"}

--- a/tests/devices/test_the_unclog.py
+++ b/tests/devices/test_the_unclog.py
@@ -1,0 +1,95 @@
+"""Tests for The Unclog using the current config and entity test helpers."""
+
+import pytest
+
+from custom_components.tuya_local.binary_sensor import TuyaLocalBinarySensor
+from custom_components.tuya_local.helpers.device_config import get_config
+from custom_components.tuya_local.select import TuyaLocalSelect
+from custom_components.tuya_local.switch import TuyaLocalSwitch
+from tests.const import THE_UNCLOG_PAYLOAD
+from tests.helpers import assert_device_properties_set, mock_device
+
+
+def test_config_and_sample(mocker):
+    """The live payload matches and initializes all four expected entities."""
+    config = get_config("the_unclog")
+    assert config.matches(THE_UNCLOG_PAYLOAD, [])
+    assert config.matches(THE_UNCLOG_PAYLOAD, ["ir6qiyn5s0pbnbz7"])
+    assert config.matches_product("ir6qiyn5s0pbnbz7")
+    entities = list(config.all_entities())
+    assert [
+        (entity.entity, entity.name, entity.entity_category) for entity in entities
+    ] == [
+        ("switch", None, None),
+        ("select", "Frequency", "config"),
+        ("select", "Duration", "config"),
+        ("binary_sensor", "Status", "diagnostic"),
+    ]
+    assert [
+        [(dp.id, dp.name, dp.type) for dp in entity.dps()] for entity in entities
+    ] == [
+        [("1", "switch", bool)],
+        [("101", "option", str)],
+        [("103", "option", str)],
+        [("102", "sensor", bool)],
+    ]
+    device = mock_device(THE_UNCLOG_PAYLOAD, mocker)
+    assert TuyaLocalSwitch(device, entities[0]).is_on is False
+    assert TuyaLocalSelect(device, entities[1]).current_option == "Every 3 Days"
+    assert TuyaLocalSelect(device, entities[2]).current_option == "15 s"
+    assert TuyaLocalBinarySensor(device, entities[3]).is_on is True
+
+
+@pytest.mark.parametrize(
+    ("name", "dp_id", "mapping"),
+    [
+        (
+            "Frequency",
+            "101",
+            {
+                "3_days": "Every 3 Days",
+                "Weekly": "Weekly",
+                "Monthly": "Monthly",
+                "3_Months": "Every 3 Months",
+                "6_Months": "Every 6 Months",
+            },
+        ),
+        ("Duration", "103", {"15": "15 s", "30": "30 s", "45": "45 s", "60": "60 s"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_select_options(mocker, name, dp_id, mapping):
+    """Every displayed option reads and writes the corresponding raw enum."""
+    config = get_config("the_unclog")
+    entity_config = next(e for e in config.all_entities() if e.name == name)
+    payload = THE_UNCLOG_PAYLOAD.copy()
+    device = mock_device(payload, mocker)
+    entity = TuyaLocalSelect(device, entity_config)
+    assert entity.options == list(mapping.values())
+    for raw, label in mapping.items():
+        payload[dp_id] = raw
+        assert entity.current_option == label
+        async with assert_device_properties_set(device, {dp_id: raw}):
+            await entity.async_select_option(label)
+
+
+@pytest.mark.asyncio
+async def test_cleaning_switch_and_status(mocker):
+    """DP 1 controls cleaning and follows self-reset; DP 102 reports status."""
+    entities = list(get_config("the_unclog").all_entities())
+    payload = THE_UNCLOG_PAYLOAD.copy()
+    device = mock_device(payload, mocker)
+    switch = TuyaLocalSwitch(device, entities[0])
+    status = TuyaLocalBinarySensor(device, entities[3])
+    async with assert_device_properties_set(device, {"1": True}):
+        await switch.async_turn_on()
+    payload["1"] = True
+    assert switch.is_on is True
+    payload["1"] = False
+    assert switch.is_on is False
+    async with assert_device_properties_set(device, {"1": False}):
+        await switch.async_turn_off()
+    payload["102"] = False
+    assert status.is_on is False
+    payload["102"] = True
+    assert status.is_on is True


### PR DESCRIPTION
Adds a device configuration for "The Unclog" — a Tuya-based AC condensate drain-line
cleaner (product_id ir6qiyn5s0pbnbz7, category cz, protocol 3.5).

The official Tuya cloud integration only surfaces the on/off switch (switch_1) because
the other datapoints have no standard instruction mapping. This config exposes the full
datapoint set via tuya-local:

- switch  (DP 1  / switch_1)  — run a cleaning cycle
- select  (DP 101 / scheduler) — auto-run frequency: Every 3 Days / Weekly / Monthly /
  Every 3 Months / Every 6 Months
- select  (DP 103 / duration)  — cycle length: 15 / 30 / 45 / 60 s
- binary_sensor (DP 102 / temp) — status flag (exact meaning unconfirmed; exposed as a
  diagnostic sensor)

Datapoints and mappings were captured live from a physical device over the local
protocol. Sample payload used for the test: {"1": false, "101": "3_days", "102": true,
"103": "15"}.

Notes for review:
- Duration is labeled in seconds based on an observed 60-second cycle and a maximum option of 60. 
- DP 102's meaning is "Status" is deliberately a diagnostic binary sensor. 
- DP 1 is momentary and does not self-reset. Toggle on or off triggers a cycle. 

Validation:
- `uv run pytest -q`: 432 passed, with two AsyncMock coroutine warnings in the existing humidifier tests.
- Ruff lint, import order, formatting, YAML lint, and `untranslated_entities` passed.
- `uv run duplicates the_unclog.yaml` reported no matches above 50%.
- Tests use the current `get_config`, `mock_device`, and `assert_device_properties_set` helpers; the former device-test base class and mixins are no longer on main.
- DEVICES.md is left to the maintainer, as requested by the PR template.

Prepared with AI assistance from the supplied physical-device diagnostics; the profile has been validated in tests and tested on the hardware successfully.
