### PR TITLE
fix(turbro_poolheatpump): handle devices without preset DP

### DIFF
--- a/custom_components/tuya_local/devices/turbro_75000btu_poolheatpump.yaml
+++ b/custom_components/tuya_local/devices/turbro_75000btu_poolheatpump.yaml
@@ -3,6 +3,10 @@ products:
   - id: cbnlx1l9nyal6vk4
     manufacturer: Turbro
     model: "75000 btu"
+  - id: cbnlx1l9nyal6vk4
+    manufacturer: Aquaviva
+    model: Model 12 ON/OFF
+    model_id: AVM-ON12RW
 entities:
   - entity: climate
     translation_key: pool_heatpump

--- a/custom_components/tuya_local/devices/turbro_75000btu_poolheatpump.yaml
+++ b/custom_components/tuya_local/devices/turbro_75000btu_poolheatpump.yaml
@@ -107,6 +107,8 @@ entities:
               # Unfortunately we cannot tell what Auto is doing
               - dps_val: Auto
                 value_redirect: work_mode_action
+              - dps_val: null
+                value_redirect: work_mode_action
           - dps_val: Defrosting
             value: defrosting
           - dps_val: Standby
@@ -143,6 +145,8 @@ entities:
               - dps_val: [Cooling_Powerful, Cooling_Smart, Cooling_Silent]
                 value_redirect: set_cold_temp
               - dps_val: Auto
+                value_redirect: set_auto_temp
+              - dps_val: null
                 value_redirect: set_auto_temp
       - id: 101
         type: integer


### PR DESCRIPTION
This fixes target temperature scaling and HVAC action reporting for compatible AquaViva Model 12 ON/OFF heat pumps that do not report DP 2 locally.

The device diagnostics show that DP 2 is absent, DP 5 contains the operating mode, DP 6 is `c`, and DP 101 contains `290`. The internal `set_heating_temp` value was correctly decoded as `29.0`, but the main climate target was exposed as `290 °C` because its redirect depended on DP 2.

This change uses the existing DP 5 mappings as a fallback when DP 2 is unavailable. Devices that report DP 2, including the existing TURBRO variants, continue to use the original mappings. The same fallback lets a presetless device report `cooling` from its work mode instead of falling back to `heating`.

The AquaViva Model 12 ON/OFF (`AVM-ON12RW`) is also listed as a confirmed product for the shared product ID. This allows users to select the correct manufacturer and model during setup while keeping the existing TURBRO entry.

Tested on a physical AquaViva Model 12 ON/OFF:

- Target temperatures are displayed correctly as 28, 29, and 30 °C.
- The target changes in 1 °C steps.
- Changes made in Home Assistant are reflected in Smart Life.
- The config flow exposes both TURBRO and AquaViva product labels for the shared product ID.
- Simulated Heat, Cool, and Auto DP states read and write the correctly scaled values.
- Existing TURBRO DP paths remain unchanged in regression checks.

Validation:

- `ruff check .`
- `ruff check --select I .`
- `ruff format --check .`
- `yamllint custom_components/tuya_local/devices`
- `pytest tests/test_device_config.py` — 32 passed

Before fix
<img width="1238" height="1182" alt="image" src="https://github.com/user-attachments/assets/bfbfb12b-41f9-4c81-b322-725e8fae36e3" />

After fix
<img width="597" height="611" alt="image" src="https://github.com/user-attachments/assets/912546d9-1cbd-40df-8f54-d9e8fab8c94a" />
<img width="597" height="611" alt="image" src="https://github.com/user-attachments/assets/544997dc-8613-49d9-902a-232cf507b262" />
<img width="597" height="611" alt="image" src="https://github.com/user-attachments/assets/212194e6-bcbf-4ce0-882d-555a259fcb8b" />
