### PR TITLE
Add product ids for Tesla and Niceboy devices

### DIFF
--- a/custom_components/tuya_local/devices/dual_power_monitor_smartplugv2.yaml
+++ b/custom_components/tuya_local/devices/dual_power_monitor_smartplugv2.yaml
@@ -20,6 +20,9 @@ products:
     manufacturer: SmartKnight ML Accessories Ltd
     model: Knightsbridge 13A Smart Swtched Socket (2-gang)
     model_id: SN9KW/CU9KW/OP9KW
+  - id: vswhszzzqzqdoz1w
+    manufacturer: Tesla
+    model: Smart Plug 2USB
 entities:
   - entity: switch
     translation_key: outlet_x

--- a/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
@@ -61,6 +61,10 @@ products:
   - id: key8u54q9dtru5jw
     manufacturer: Havells
     model: TW+RGB
+  - id: riigwjxro6gzpifh
+    manufacturer: Niceboy
+    model: ION SmartBulb RGB E27
+    model_id: E157
 entities:
   - entity: light
     dps:

--- a/custom_components/tuya_local/devices/single_switch_with_backlight.yaml
+++ b/custom_components/tuya_local/devices/single_switch_with_backlight.yaml
@@ -1,6 +1,9 @@
 name: Single switch with backlight
 products:
   - id: gbdzignerqxddcuj
+  - id: sr1zcserapldtkll
+    manufacturer: Tesla
+    model: Smart Switch
 entities:
   - entity: switch
     dps:

--- a/custom_components/tuya_local/devices/single_switch_with_backlight.yaml
+++ b/custom_components/tuya_local/devices/single_switch_with_backlight.yaml
@@ -3,7 +3,6 @@ products:
   - id: gbdzignerqxddcuj
   - id: sr1zcserapldtkll
     manufacturer: Tesla
-    model: Smart Switch
 entities:
   - entity: switch
     dps:


### PR DESCRIPTION
Adding product ids for three devices I own. All three match their
existing configs completely - no config changes needed, only direct
product id matching instead of datapoint guessing.

- Tesla Smart Switch (sr1zcserapldtkll) -> single_switch_with_backlight
  dp 1 switch, 7 timer, 14 initial state, 15 light mode, 16 backlight

- Tesla Smart Plug 2USB (vswhszzzqzqdoz1w) -> dual_power_monitor_smartplugv2
  100% datapoint match, all 11 entities work

- Niceboy ION SmartBulb RGB E27 (riigwjxro6gzpifh) -> rgbcw_lightbulb
  2700-6500K matches the config range

Unrelated note: product id keytg5kq8gvkv9dh appears twice in
rgbcw_lightbulb.yaml - once as Lijun and once as LSC Smart Connect
GU10. One of them is probably wrong.