### PR TITLE
Add support for ETA 2625 Sole Smart heater

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -34,6 +34,7 @@
 - ElectriQ MY130 oil radiator
 - Emke Orbrad PTR towel radiator
 - Essentials Smart Home electric bathroom heater
+- ETA 2625 Sole Smart panel heater
 - eTowel Mini04 plus towel rail thermostat
 - Eurom Alutherm 1000,1500,2000,2500 heaters
 - Eurom Hot-Shot 2000 heaters

--- a/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
+++ b/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
@@ -1,0 +1,208 @@
+name: ETA 2625 Sole Smart
+
+products:
+  - id: gshakqhah24xdssy
+    manufacturer: ETA
+    model: 2625 Sole Smart
+    model_id: ETA-YBX04-EW
+
+# Datapoints confirmed from the device data model via the Tuya API:
+#   1   switch          bool
+#   2   temp_set        5-35 C
+#   4   mode            CF (normal) / AF (antifreeze) / ST (weekly program)
+#   7   child_lock      bool
+#   11  work_state      standby / working
+#   19  countdown_set   cancel / 1h .. 24h
+#   20  countdown_left  0-1440 min
+#   21  fault           bitmap: Err1 (probe open), Err2 (probe short)
+#   26  week_program9   raw, weekly temperature program
+#   101 fan_mode        H1 / H2 / H3 heating levels
+#   103 night_mode      bool
+#
+# The device has no ambient temperature sensor, so the climate
+# entity reports a target temperature only.
+
+entities:
+  - entity: climate
+    dps:
+      - id: 1
+        type: boolean
+        name: hvac_mode
+        mapping:
+          - dps_val: true
+            value: heat
+          - dps_val: false
+            value: "off"
+
+      - id: 2
+        type: integer
+        name: temperature
+        unit: C
+        range:
+          min: 5
+          max: 35
+
+      # CF is the normal thermostat mode, AF keeps the room just
+      # above freezing, ST follows the weekly program on dp 26.
+      - id: 4
+        type: string
+        name: preset_mode
+        mapping:
+          - dps_val: CF
+            value: comfort
+          - dps_val: AF
+            value: away
+          - dps_val: ST
+            value: program
+
+      # Heating power level. Exposed as fan mode because that is
+      # the closest match in the climate platform.
+      - id: 101
+        type: string
+        name: fan_mode
+        optional: true
+        mapping:
+          - dps_val: H1
+            value: low
+          - dps_val: H2
+            value: medium
+          - dps_val: H3
+            value: high
+
+      - id: 11
+        type: string
+        name: hvac_action
+        mapping:
+          - dps_val: standby
+            value: idle
+          - dps_val: working
+            value: heating
+
+      - id: 21
+        type: bitfield
+        name: error
+        hidden: true
+
+  - entity: switch
+    name: Night mode
+    icon: "mdi:weather-night"
+    category: config
+    dps:
+      - id: 103
+        type: boolean
+        name: switch
+        optional: true
+
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 7
+        type: boolean
+        name: lock
+
+  - entity: select
+    translation_key: timer
+    category: config
+    dps:
+      - id: 19
+        type: string
+        name: option
+        mapping:
+          - dps_val: cancel
+            value: cancel
+          - dps_val: 1h
+            value: 1h
+          - dps_val: 2h
+            value: 2h
+          - dps_val: 3h
+            value: 3h
+          - dps_val: 4h
+            value: 4h
+          - dps_val: 5h
+            value: 5h
+          - dps_val: 6h
+            value: 6h
+          - dps_val: 7h
+            value: 7h
+          - dps_val: 8h
+            value: 8h
+          - dps_val: 9h
+            value: 9h
+          - dps_val: 10h
+            value: 10h
+          - dps_val: 11h
+            value: 11h
+          - dps_val: 12h
+            value: 12h
+          - dps_val: 13h
+            value: 13h
+          - dps_val: 14h
+            value: 14h
+          - dps_val: 15h
+            value: 15h
+          - dps_val: 16h
+            value: 16h
+          - dps_val: 17h
+            value: 17h
+          - dps_val: 18h
+            value: 18h
+          - dps_val: 19h
+            value: 19h
+          - dps_val: 20h
+            value: 20h
+          - dps_val: 21h
+            value: 21h
+          - dps_val: 22h
+            value: 22h
+          - dps_val: 23h
+            value: 23h
+          - dps_val: 24h
+            value: 24h
+
+  - entity: sensor
+    translation_key: time_remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 20
+        type: integer
+        name: sensor
+        unit: min
+
+  # Weekly temperature program, opaque raw data.
+  - entity: text
+    name: Weekly program
+    icon: "mdi:calendar-clock"
+    category: config
+    hidden: true
+    dps:
+      - id: 26
+        type: base64
+        name: value
+        optional: true
+
+  - entity: binary_sensor
+    class: problem
+    category: diagnostic
+    dps:
+      - id: 21
+        type: bitfield
+        name: sensor
+        mapping:
+          - dps_val: 0
+            value: false
+          - value: true
+      - id: 21
+        type: bitfield
+        name: fault_code
+      - id: 21
+        type: bitfield
+        name: description
+        mapping:
+          - dps_val: 0
+            value: ok
+          - dps_val: 1
+            value: temperature_probe_open
+          - dps_val: 2
+            value: temperature_probe_short

--- a/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
+++ b/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
@@ -80,9 +80,12 @@ entities:
             value: heating
 
 
+  # The device only accepts turning this on over the local
+  # protocol - turning it off is ignored and works only from
+  # the vendor app or the panel. It controls the display
+  # backlight rather than any heating behaviour.
   - entity: switch
-    name: Night mode
-    icon: "mdi:weather-night"
+    translation_key: night_mode
     category: config
     dps:
       - id: 103
@@ -169,8 +172,7 @@ entities:
 
   # Weekly temperature program, opaque raw data.
   - entity: text
-    name: Weekly program
-    icon: "mdi:calendar-clock"
+    translation_key: schedule
     category: config
     hidden: true
     dps:

--- a/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
+++ b/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
@@ -84,7 +84,7 @@ entities:
         hidden: true
 
   - entity: switch
-    name: Night mode
+    translation_key: night_mode
     icon: "mdi:weather-night"
     category: config
     dps:

--- a/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
+++ b/custom_components/tuya_local/devices/eta_2625_sole_smart.yaml
@@ -1,4 +1,4 @@
-name: ETA 2625 Sole Smart
+name: Panel heater
 
 products:
   - id: gshakqhah24xdssy
@@ -24,6 +24,7 @@ products:
 
 entities:
   - entity: climate
+    translation_key: heater
     dps:
       - id: 1
         type: boolean
@@ -78,13 +79,9 @@ entities:
           - dps_val: working
             value: heating
 
-      - id: 21
-        type: bitfield
-        name: error
-        hidden: true
 
   - entity: switch
-    translation_key: night_mode
+    name: Night mode
     icon: "mdi:weather-night"
     category: config
     dps:


### PR DESCRIPTION
## Device

ETA 2625 Sole Smart (model ETA-YBX04-EW), a Czech brand panel heater.
Product ID: gshakqhah24xdssy

## Config

Datapoints taken from the device data model via the Tuya API:

  1    switch          bool
  2    temp_set        5-35 C
  4    mode            CF normal / AF antifreeze / ST weekly program
  7    child_lock      bool
  11   work_state      standby / working
  19   countdown_set   cancel / 1h .. 24h
  20   countdown_left  0-1440 min
  21   fault           bitmap: Err1 probe open, Err2 probe short
  26   week_program9   raw weekly temperature program
  101  fan_mode        H1 / H2 / H3 heating levels
  103  night_mode      bool

The device has no ambient temperature sensor, so the climate entity
exposes a target temperature only.

dp 101 is named fan_mode in the data model but the Chinese label
reads "heating mode" - it selects the heating power level. Exposed
as fan mode as the closest match in the climate platform.

## Note

Until now this device matched taurus_agadir_heater, which only
covers part of it: it misses the ST weekly program mode, night mode
and the weekly program datapoint, and it creates a display light
entity for a datapoint this device does not have.

## Testing

Tested on my own device.